### PR TITLE
Clang format rule change

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,6 +12,7 @@ AllowShortBlocksOnASingleLine: Empty
 AllowShortEnumsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortLambdasOnASingleLine: All
+# AllowShortCompoundRequirementOnASingleLine: true
 BraceWrapping:
   AfterCaseLabel: false
   AfterClass: false
@@ -34,6 +35,9 @@ BreakInheritanceList: AfterColon
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeComma
 BreakStringLiterals: true
+# BreakTemplateDeclarations: MultiLine
+AlwaysBreakTemplateDeclarations: true
+IndentRequiresClause: false
 ColumnLimit: 100
 CompactNamespaces: false
 PackConstructorInitializers: CurrentLine
@@ -52,7 +56,6 @@ PointerAlignment: Left
 QualifierAlignment: Right
 SortIncludes: CaseSensitive
 SpaceBeforeCaseColon: false
-
 SpaceBeforeParens: Custom
 SpaceBeforeParensOptions:
   AfterControlStatements: true
@@ -60,7 +63,7 @@ SpaceBeforeParensOptions:
   AfterFunctionDeclarationName: false
   AfterFunctionDefinitionName: false
   AfterIfMacros: false
-  AfterOverloadedOperator: true
+  AfterOverloadedOperator: false
   AfterRequiresInClause: true
   AfterRequiresInExpression: false
   BeforeNonEmptyParentheses: false
@@ -78,3 +81,4 @@ IncludeCategories:
     Priority:        3
   - Regex:           '^<.*>'
     Priority:        4
+

--- a/include/utl/compare/utl_compare_traits.h
+++ b/include/utl/compare/utl_compare_traits.h
@@ -12,57 +12,69 @@
 UTL_NAMESPACE_BEGIN
 
 namespace compare_ops {
-template <typename T, typename U = T, typename = void> struct has_eq : false_type {};
+template <typename T, typename U = T, typename = void>
+struct has_eq : false_type {};
 template <typename T, typename U>
 struct has_eq<T, U,
     enable_if_t<is_boolean_testable<decltype(declval<T>() == declval<U>())>::value>> : true_type {};
 
-template <typename T, typename U = T, typename = void> struct has_nothrow_eq : false_type {};
+template <typename T, typename U = T, typename = void>
+struct has_nothrow_eq : false_type {};
 template <typename T, typename U>
 struct has_nothrow_eq<T, U, enable_if_t<has_eq<T, U>::value>> :
     bool_constant<noexcept(declval<T>() == declval<U>())> {};
 
-template <typename T, typename U = T, typename = void> struct has_neq : false_type {};
+template <typename T, typename U = T, typename = void>
+struct has_neq : false_type {};
 template <typename T, typename U>
 struct has_neq<T, U,
     enable_if_t<is_boolean_testable<decltype(declval<T>() != declval<U>())>::value>> : true_type {};
-template <typename T, typename U = T, typename = void> struct has_nothrow_neq : false_type {};
+template <typename T, typename U = T, typename = void>
+struct has_nothrow_neq : false_type {};
 template <typename T, typename U>
 struct has_nothrow_neq<T, U, enable_if_t<has_neq<T, U>::value>> :
     bool_constant<noexcept(declval<T>() != declval<U>())> {};
 
-template <typename T, typename U = T, typename = void> struct has_lt : false_type {};
+template <typename T, typename U = T, typename = void>
+struct has_lt : false_type {};
 template <typename T, typename U>
 struct has_lt<T, U,
     enable_if_t<is_boolean_testable<decltype(declval<T>() < declval<U>())>::value>> : true_type {};
-template <typename T, typename U = T, typename = void> struct has_nothrow_lt : false_type {};
+template <typename T, typename U = T, typename = void>
+struct has_nothrow_lt : false_type {};
 template <typename T, typename U>
 struct has_nothrow_lt<T, U, enable_if_t<has_lt<T, U>::value>> :
     bool_constant<noexcept(declval<T>() < declval<U>())> {};
 
-template <typename T, typename U = T, typename = void> struct has_gt : false_type {};
+template <typename T, typename U = T, typename = void>
+struct has_gt : false_type {};
 template <typename T, typename U>
 struct has_gt<T, U,
     enable_if_t<is_boolean_testable<decltype(declval<T>() > declval<U>())>::value>> : true_type {};
-template <typename T, typename U = T, typename = void> struct has_nothrow_gt : false_type {};
+template <typename T, typename U = T, typename = void>
+struct has_nothrow_gt : false_type {};
 template <typename T, typename U>
 struct has_nothrow_gt<T, U, enable_if_t<has_gt<T, U>::value>> :
     bool_constant<noexcept(declval<T>() > declval<U>())> {};
 
-template <typename T, typename U = T, typename = void> struct has_lteq : false_type {};
+template <typename T, typename U = T, typename = void>
+struct has_lteq : false_type {};
 template <typename T, typename U>
 struct has_lteq<T, U,
     enable_if_t<is_boolean_testable<decltype(declval<T>() <= declval<U>())>::value>> : true_type {};
-template <typename T, typename U = T, typename = void> struct has_nothrow_lteq : false_type {};
+template <typename T, typename U = T, typename = void>
+struct has_nothrow_lteq : false_type {};
 template <typename T, typename U>
 struct has_nothrow_lteq<T, U, enable_if_t<has_lteq<T, U>::value>> :
     bool_constant<noexcept(declval<T>() <= declval<U>())> {};
 
-template <typename T, typename U = T, typename = void> struct has_gteq : false_type {};
+template <typename T, typename U = T, typename = void>
+struct has_gteq : false_type {};
 template <typename T, typename U>
 struct has_gteq<T, U,
     enable_if_t<is_boolean_testable<decltype(declval<T>() >= declval<U>())>::value>> : true_type {};
-template <typename T, typename U = T, typename = void> struct has_nothrow_gteq : false_type {};
+template <typename T, typename U = T, typename = void>
+struct has_nothrow_gteq : false_type {};
 template <typename T, typename U>
 struct has_nothrow_gteq<T, U, enable_if_t<has_gteq<T, U>::value>> :
     bool_constant<noexcept(declval<T>() >= declval<U>())> {};
@@ -82,13 +94,15 @@ template <typename T, typename U>
 struct is_nonequality_comparable<T, U,
     enable_if_t<is_boolean_testable<decltype(declval<T>() != declval<U>())>::value>> : true_type {};
 
-template <typename T, typename U = T, typename = void> struct is_less_comparable : false_type {};
+template <typename T, typename U = T, typename = void>
+struct is_less_comparable : false_type {};
 
 template <typename T, typename U>
 struct is_less_comparable<T, U,
     enable_if_t<is_boolean_testable<decltype(declval<T>() < declval<U>())>::value>> : true_type {};
 
-template <typename T, typename U = T, typename = void> struct is_greater_comparable : false_type {};
+template <typename T, typename U = T, typename = void>
+struct is_greater_comparable : false_type {};
 
 template <typename T, typename U>
 struct is_greater_comparable<T, U,
@@ -111,37 +125,43 @@ struct is_greater_equal_comparable<T, U,
 namespace details {
 namespace compare_traits {
 
-template <typename T, typename U> auto nothrow_equality_test(float) -> false_type;
+template <typename T, typename U>
+auto nothrow_equality_test(float) -> false_type;
 
 template <typename T, typename U>
 auto nothrow_equality_test(int)
     -> bool_constant<noexcept(static_cast<bool>(declval<T>() == declval<U>()))>;
 
-template <typename T, typename U> auto nothrow_nonequality_test(float) -> false_type;
+template <typename T, typename U>
+auto nothrow_nonequality_test(float) -> false_type;
 
 template <typename T, typename U>
 auto nothrow_nonequality_test(int)
     -> bool_constant<noexcept(static_cast<bool>(declval<T>() != declval<U>()))>;
 
-template <typename T, typename U> auto nothrow_less_test(float) -> false_type;
+template <typename T, typename U>
+auto nothrow_less_test(float) -> false_type;
 
 template <typename T, typename U>
 auto nothrow_less_test(int)
     -> bool_constant<noexcept(static_cast<bool>(declval<T>() < declval<U>()))>;
 
-template <typename T, typename U> auto nothrow_greater_test(float) -> false_type;
+template <typename T, typename U>
+auto nothrow_greater_test(float) -> false_type;
 
 template <typename T, typename U>
 auto nothrow_greater_test(int)
     -> bool_constant<noexcept(static_cast<bool>(declval<T>() > declval<U>()))>;
 
-template <typename T, typename U> auto nothrow_less_equal_test(float) -> false_type;
+template <typename T, typename U>
+auto nothrow_less_equal_test(float) -> false_type;
 
 template <typename T, typename U>
 auto nothrow_less_equal_test(int)
     -> bool_constant<noexcept(static_cast<bool>(declval<T>() <= declval<U>()))>;
 
-template <typename T, typename U> auto nothrow_greater_equal_test(float) -> false_type;
+template <typename T, typename U>
+auto nothrow_greater_equal_test(float) -> false_type;
 
 template <typename T, typename U>
 auto nothrow_greater_equal_test(int)
@@ -179,7 +199,8 @@ struct is_nothrow_greater_equal_comparable : R {};
 namespace details {
 namespace compare_traits {
 
-template <typename T, typename U, typename Cat> false_type three_way_comparable_with_test(...);
+template <typename T, typename U, typename Cat>
+false_type three_way_comparable_with_test(...);
 
 template <typename T, typename U, typename Cat>
 auto three_way_comparable_with_test(int)

--- a/include/utl/compare/utl_partial_ordering.h
+++ b/include/utl/compare/utl_partial_ordering.h
@@ -30,7 +30,8 @@ public:
                   : p == T::greater    ? greater
                                        : unordered) {}
 
-    template <same_as<std::partial_ordering> T> constexpr operator T () noexcept {
+    template <same_as<std::partial_ordering> T>
+    constexpr operator T() noexcept {
         return *this == less      ? T::less
             : *this == equivalent ? T::equivalent
             : *this == greater    ? T::greater
@@ -40,60 +41,58 @@ public:
 
     constexpr partial_ordering(partial_ordering const&) noexcept = default;
     constexpr partial_ordering(partial_ordering&&) noexcept = default;
-    constexpr partial_ordering& operator= (partial_ordering const&) noexcept = default;
-    constexpr partial_ordering& operator= (partial_ordering&&) noexcept = default;
+    constexpr partial_ordering& operator=(partial_ordering const&) noexcept = default;
+    constexpr partial_ordering& operator=(partial_ordering&&) noexcept = default;
 
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr bool operator== (partial_ordering l, partial_ordering r) noexcept {
+    friend constexpr bool operator==(partial_ordering l, partial_ordering r) noexcept {
         return l.value == r.value;
     }
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr bool operator== (partial_ordering l, zero_t) noexcept { return l.value == 0; }
+    friend constexpr bool operator==(partial_ordering l, zero_t) noexcept { return l.value == 0; }
 
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr bool operator< (zero_t, partial_ordering r) noexcept {
+    friend constexpr bool operator<(zero_t, partial_ordering r) noexcept {
         return r.value == greater.value;
     }
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr bool operator< (partial_ordering l, zero_t) noexcept {
+    friend constexpr bool operator<(partial_ordering l, zero_t) noexcept {
         return l.value == less.value;
     }
 
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr bool operator> (zero_t, partial_ordering r) noexcept {
+    friend constexpr bool operator>(zero_t, partial_ordering r) noexcept {
         return r.value == less.value;
     }
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr bool operator> (partial_ordering l, zero_t) noexcept {
+    friend constexpr bool operator>(partial_ordering l, zero_t) noexcept {
         return l.value == greater.value;
     }
 
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr bool operator<= (zero_t, partial_ordering r) noexcept {
+    friend constexpr bool operator<=(zero_t, partial_ordering r) noexcept {
         return r.value == greater.value || r.value == equivalent.value;
     }
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr bool operator<= (partial_ordering l, zero_t) noexcept {
+    friend constexpr bool operator<=(partial_ordering l, zero_t) noexcept {
         return l.value == less.value || l.value == equivalent.value;
     }
 
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr bool operator>= (zero_t, partial_ordering r) noexcept {
+    friend constexpr bool operator>=(zero_t, partial_ordering r) noexcept {
         return r.value == less.value || r.value == equivalent.value;
     }
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr bool operator>= (partial_ordering l, zero_t) noexcept {
+    friend constexpr bool operator>=(partial_ordering l, zero_t) noexcept {
         return l.value == greater.value || l.value == equivalent.value;
     }
 
 #ifdef UTL_CXX20
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr partial_ordering operator<=> (partial_ordering l, zero_t) noexcept {
-        return l;
-    }
+    friend constexpr partial_ordering operator<=>(partial_ordering l, zero_t) noexcept { return l; }
 
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr partial_ordering operator<=> (zero_t, partial_ordering r) noexcept {
+    friend constexpr partial_ordering operator<=>(zero_t, partial_ordering r) noexcept {
         switch (r.value) {
         case value_t(order_t::less):
             return greater;

--- a/include/utl/compare/utl_strong_ordering.h
+++ b/include/utl/compare/utl_strong_ordering.h
@@ -20,8 +20,8 @@ public:
     static strong_ordering const equal;
     static strong_ordering const greater;
 
-    constexpr operator partial_ordering () const { return partial_ordering(order_t(value)); }
-    constexpr operator weak_ordering () const { return weak_ordering(order_t(value)); }
+    constexpr operator partial_ordering() const { return partial_ordering(order_t(value)); }
+    constexpr operator weak_ordering() const { return weak_ordering(order_t(value)); }
 #ifdef UTL_CXX20
     template <same_as<std::strong_ordering> T>
     constexpr strong_ordering(T p) noexcept
@@ -30,7 +30,8 @@ public:
                   : p == T::equal      ? equal
                                        : greater) {}
 
-    template <same_as<std::strong_ordering> T> constexpr operator T () noexcept {
+    template <same_as<std::strong_ordering> T>
+    constexpr operator T() noexcept {
         return *this == less      ? T::less
             : *this == equivalent ? T::equivalent
             : *this == equal      ? T::equal
@@ -39,23 +40,23 @@ public:
 #endif
     constexpr strong_ordering(strong_ordering const&) noexcept = default;
     constexpr strong_ordering(strong_ordering&&) noexcept = default;
-    constexpr strong_ordering& operator= (strong_ordering const&) noexcept = default;
-    constexpr strong_ordering& operator= (strong_ordering&&) noexcept = default;
+    constexpr strong_ordering& operator=(strong_ordering const&) noexcept = default;
+    constexpr strong_ordering& operator=(strong_ordering&&) noexcept = default;
 
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr bool operator== (strong_ordering l, strong_ordering r) noexcept {
+    friend constexpr bool operator==(strong_ordering l, strong_ordering r) noexcept {
         return l.value == r.value;
     }
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr bool operator== (strong_ordering l, zero_t) noexcept { return l.value == 0; }
+    friend constexpr bool operator==(strong_ordering l, zero_t) noexcept { return l.value == 0; }
 
-#define UTL_ORDERING_COMPARISONS(SYMBOL)                                         \
-    UTL_ATTRIBUTES(NODISCARD, CONST)                                             \
-    friend constexpr bool operator SYMBOL (zero_t, strong_ordering r) noexcept { \
-        return 0 SYMBOL r.value;                                                 \
-    }                                                                            \
-    friend constexpr bool operator SYMBOL (strong_ordering l, zero_t) noexcept { \
-        return l.value SYMBOL 0;                                                 \
+#define UTL_ORDERING_COMPARISONS(SYMBOL)                                        \
+    UTL_ATTRIBUTES(NODISCARD, CONST)                                            \
+    friend constexpr bool operator SYMBOL(zero_t, strong_ordering r) noexcept { \
+        return 0 SYMBOL r.value;                                                \
+    }                                                                           \
+    friend constexpr bool operator SYMBOL(strong_ordering l, zero_t) noexcept { \
+        return l.value SYMBOL 0;                                                \
     }
 
     UTL_ORDERING_COMPARISONS(<)
@@ -67,10 +68,10 @@ public:
 
 #ifdef UTL_CXX20
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr strong_ordering operator<=> (strong_ordering l, zero_t) noexcept { return l; }
+    friend constexpr strong_ordering operator<=>(strong_ordering l, zero_t) noexcept { return l; }
 
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr strong_ordering operator<=> (zero_t, strong_ordering r) noexcept {
+    friend constexpr strong_ordering operator<=>(zero_t, strong_ordering r) noexcept {
         return strong_ordering(order_t(-r.value));
     }
 #endif

--- a/include/utl/compare/utl_weak_ordering.h
+++ b/include/utl/compare/utl_weak_ordering.h
@@ -20,7 +20,7 @@ public:
     static weak_ordering const equivalent;
     static weak_ordering const greater;
 
-    constexpr operator partial_ordering () const { return partial_ordering(order_t(value)); }
+    constexpr operator partial_ordering() const { return partial_ordering(order_t(value)); }
 
 #ifdef UTL_CXX20
     template <same_as<std::weak_ordering> T>
@@ -29,63 +29,64 @@ public:
                   : p == T::equivalent ? equivalent
                                        : greater) {}
 
-    template <same_as<std::weak_ordering> T> constexpr operator T () noexcept {
+    template <same_as<std::weak_ordering> T>
+    constexpr operator T() noexcept {
         return *this == less ? T::less : *this == equivalent ? T::equivalent : T::greater;
     }
 #endif
     constexpr weak_ordering(weak_ordering const&) noexcept = default;
     constexpr weak_ordering(weak_ordering&&) noexcept = default;
-    constexpr weak_ordering& operator= (weak_ordering const&) noexcept = default;
-    constexpr weak_ordering& operator= (weak_ordering&&) noexcept = default;
+    constexpr weak_ordering& operator=(weak_ordering const&) noexcept = default;
+    constexpr weak_ordering& operator=(weak_ordering&&) noexcept = default;
 
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr bool operator== (weak_ordering l, weak_ordering r) noexcept {
+    friend constexpr bool operator==(weak_ordering l, weak_ordering r) noexcept {
         return l.value == r.value;
     }
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr bool operator== (weak_ordering l, zero_t) noexcept { return l.value == 0; }
+    friend constexpr bool operator==(weak_ordering l, zero_t) noexcept { return l.value == 0; }
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr bool operator< (zero_t, weak_ordering r) noexcept {
+    friend constexpr bool operator<(zero_t, weak_ordering r) noexcept {
         return r.value == greater.value;
     }
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr bool operator< (weak_ordering l, zero_t) noexcept {
+    friend constexpr bool operator<(weak_ordering l, zero_t) noexcept {
         return l.value == less.value;
     }
 
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr bool operator> (zero_t, weak_ordering r) noexcept {
+    friend constexpr bool operator>(zero_t, weak_ordering r) noexcept {
         return r.value == less.value;
     }
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr bool operator> (weak_ordering l, zero_t) noexcept {
+    friend constexpr bool operator>(weak_ordering l, zero_t) noexcept {
         return l.value == greater.value;
     }
 
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr bool operator<= (zero_t, weak_ordering r) noexcept {
+    friend constexpr bool operator<=(zero_t, weak_ordering r) noexcept {
         return r.value == greater.value || r.value == equivalent.value;
     }
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr bool operator<= (weak_ordering l, zero_t) noexcept {
+    friend constexpr bool operator<=(weak_ordering l, zero_t) noexcept {
         return l.value == less.value || l.value == equivalent.value;
     }
 
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr bool operator>= (zero_t, weak_ordering r) noexcept {
+    friend constexpr bool operator>=(zero_t, weak_ordering r) noexcept {
         return r.value == less.value || r.value == equivalent.value;
     }
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr bool operator>= (weak_ordering l, zero_t) noexcept {
+    friend constexpr bool operator>=(weak_ordering l, zero_t) noexcept {
         return l.value == greater.value || l.value == equivalent.value;
     }
 
 #ifdef UTL_CXX20
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr weak_ordering operator<=> (weak_ordering l, zero_t) noexcept { return l; }
+    friend constexpr weak_ordering operator<=>(weak_ordering l, zero_t) noexcept { return l; }
 
     UTL_ATTRIBUTES(NODISCARD, CONST)
-    friend constexpr weak_ordering operator<=> (zero_t, weak_ordering r) noexcept {
+    friend constexpr weak_ordering operator<=>(zero_t, weak_ordering r) noexcept {
         return weak_ordering(order_t(-r.value));
     }
 #endif

--- a/include/utl/concepts/utl_same_as.h
+++ b/include/utl/concepts/utl_same_as.h
@@ -9,7 +9,8 @@
 UTL_NAMESPACE_BEGIN
 namespace concepts {
 namespace details {
-template <typename T> struct proxy_t {};
+template <typename T>
+struct proxy_t {};
 } // namespace details
 } // namespace concepts
 

--- a/include/utl/functional/utl_equal_to.h
+++ b/include/utl/functional/utl_equal_to.h
@@ -8,16 +8,18 @@
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T = void> struct equal_to {
-    constexpr bool operator() (T const& lhs, T const& rhs) const
+template <typename T = void>
+struct equal_to {
+    constexpr bool operator()(T const& lhs, T const& rhs) const
         noexcept(declval<T const&>() == declval<T const&>()) {
         return lhs == rhs;
     }
 };
 
-template <> struct equal_to<void> {
+template <>
+struct equal_to<void> {
     template <typename T, typename U>
-    constexpr auto operator() (T&& lhs, U&& rhs) const noexcept(declval<T>() == declval<U>())
+    constexpr auto operator()(T&& lhs, U&& rhs) const noexcept(declval<T>() == declval<U>())
         -> decltype(declval<T>() == declval<U>()) {
         return forward<T>(lhs) == forward<U>(rhs);
     }

--- a/include/utl/functional/utl_less.h
+++ b/include/utl/functional/utl_less.h
@@ -8,16 +8,18 @@
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T = void> struct less {
-    constexpr bool operator() (T const& lhs, T const& rhs) const
+template <typename T = void>
+struct less {
+    constexpr bool operator()(T const& lhs, T const& rhs) const
         noexcept(declval<T const&>() < declval<T const&>()) {
         return lhs < rhs;
     }
 };
 
-template <> struct less<void> {
+template <>
+struct less<void> {
     template <typename T, typename U>
-    constexpr auto operator() (T&& lhs, U&& rhs) const noexcept(declval<T>() < declval<U>())
+    constexpr auto operator()(T&& lhs, U&& rhs) const noexcept(declval<T>() < declval<U>())
         -> decltype(declval<T>() < declval<U>()) {
         return forward<T>(lhs) < forward<U>(rhs);
     }

--- a/include/utl/memory/utl_addressof.h
+++ b/include/utl/memory/utl_addressof.h
@@ -7,7 +7,8 @@
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> constexpr T* addressof(T&&) = delete;
+template <typename T>
+constexpr T* addressof(T&&) = delete;
 
 #ifdef UTL_BUILTIN_addressof
 
@@ -25,23 +26,27 @@ constexpr enable_if_t<!is_object<remove_reference_t<T>>::value, T*> addressof(
     return &arg;
 }
 
-template <typename T> struct is_addressof_constexpr : true_type {};
+template <typename T>
+struct is_addressof_constexpr : true_type {};
 
 #else // ifdef UTL_BUILTIN_addressof
 
 namespace details {
 namespace addressof {
-template <typename T, typename = void> struct has_adl_overload : false_type {};
+template <typename T, typename = void>
+struct has_adl_overload : false_type {};
 template <typename T>
-struct has_adl_overload<T, void_t<decltype(operator& (declval<add_lvalue_reference_t<T>>()))>> :
+struct has_adl_overload<T, void_t<decltype(operator&(declval<add_lvalue_reference_t<T>>()))>> :
     true_type {};
 
-template <typename T, typename = void> struct has_member_overload : false_type {};
+template <typename T, typename = void>
+struct has_member_overload : false_type {};
 template <typename T>
-struct has_member_overload<T, void_t<decltype(declval<add_lvalue_reference_t<T>>().operator& ())>> :
+struct has_member_overload<T, void_t<decltype(declval<add_lvalue_reference_t<T>>().operator&())>> :
     true_type {};
 
-template <typename T, typename = void> struct natively_invocable : false_type {};
+template <typename T, typename = void>
+struct natively_invocable : false_type {};
 template <typename T>
 struct natively_invocable<T, void_t<decltype(&declval<add_lvalue_reference_t<T>>())>> :
     true_type {};

--- a/include/utl/memory/utl_uses_allocator.h
+++ b/include/utl/memory/utl_uses_allocator.h
@@ -10,7 +10,8 @@
 
 UTL_STD_NAMESPACE_BEGIN
 /* UTL_UNDEFINED_BEHAVIOUR */
-template <typename T, typename Alloc> struct uses_allocator;
+template <typename T, typename Alloc>
+struct uses_allocator;
 
 struct allocator_arg_t;
 UTL_STD_NAMESPACE_END
@@ -27,9 +28,11 @@ template <typename T, typename Alloc,
     typename R = is_convertible<Alloc, typename T::allocator_type>>
 R resolver(float);
 
-template <typename T, typename Alloc> false_type resolver(...);
+template <typename T, typename Alloc>
+false_type resolver(...);
 
-template <typename T, typename Alloc, typename R = decltype(resolver<T, Alloc>(0))> using impl = R;
+template <typename T, typename Alloc, typename R = decltype(resolver<T, Alloc>(0))>
+using impl = R;
 
 } // namespace uses_allocator
 } // namespace details
@@ -41,7 +44,7 @@ struct allocator_arg_t {
     constexpr allocator_arg_t(T) noexcept {}
     template <typename T UTL_REQUIRES_CXX11(is_same<T, ::std::allocator_arg_t>::value)>
     UTL_REQUIRES_CXX20(same_as<T, ::std::allocator_arg_t>)
-    constexpr operator T () const noexcept {
+    constexpr operator T() const noexcept {
         return {};
     }
 };

--- a/include/utl/meta/function_info.h
+++ b/include/utl/meta/function_info.h
@@ -10,11 +10,13 @@
 
 UTL_NAMESPACE_BEGIN
 
-template <typename F> struct function_type;
+template <typename F>
+struct function_type;
 
 namespace details {
 namespace function_info {
-template <typename F, typename = void> struct function_type;
+template <typename F, typename = void>
+struct function_type;
 template <typename F>
 struct function_type<F*, enable_if_t<is_function<F>::value>> : UTL_SCOPE function_type<F> {};
 template <typename F>
@@ -22,175 +24,250 @@ struct function_type<F&, enable_if_t<is_function<F>::value>> : UTL_SCOPE functio
 } // namespace function_info
 } // namespace details
 
-template <typename F> struct function_type : details::function_info::function_type<F> {};
-template <typename F> using function_type_t = typename function_type<F>::type;
+template <typename F>
+struct function_type : details::function_info::function_type<F> {};
+template <typename F>
+using function_type_t = typename function_type<F>::type;
 
-template <typename R, typename... A> struct function_type<R(A...)> {
+template <typename R, typename... A>
+struct function_type<R(A...)> {
     using type = R(A...);
     using return_type = R;
 };
 
-template <typename R, typename... A> struct function_type<R(A...) const> {
+template <typename R, typename... A>
+struct function_type<R(A...) const> {
     using type = R(A...) const;
     using return_type = R;
 };
 
-template <typename R, typename... A> struct function_type<R(A...) const volatile> {
+template <typename R, typename... A>
+struct function_type<R(A...) const volatile> {
     using type = R(A...) const volatile;
     using return_type = R;
 };
 
-template <typename R, typename... A> struct function_type<R(A...) volatile> {
+template <typename R, typename... A>
+struct function_type<R(A...) volatile> {
     using type = R(A...) volatile;
     using return_type = R;
 };
 
-template <typename R, typename... A> struct function_type<R(A...)&> {
+template <typename R, typename... A>
+struct function_type<R(A...)&> {
     using type = R(A...);
     using return_type = R;
 };
 
-template <typename R, typename... A> struct function_type<R(A...) const&> {
+template <typename R, typename... A>
+struct function_type<R(A...) const&> {
     using type = R(A...) const&;
     using return_type = R;
 };
 
-template <typename R, typename... A> struct function_type<R(A...) const volatile&> {
+template <typename R, typename... A>
+struct function_type<R(A...) const volatile&> {
     using type = R(A...) const volatile&;
     using return_type = R;
 };
 
-template <typename R, typename... A> struct function_type<R(A...) volatile&> {
+template <typename R, typename... A>
+struct function_type<R(A...) volatile&> {
     using type = R(A...) volatile&;
     using return_type = R;
 };
 
-template <typename R, typename... A> struct function_type<R(A...) &&> {
+template <typename R, typename... A>
+struct function_type<R(A...) &&> {
     using type = R(A...);
     using return_type = R;
 };
 
-template <typename R, typename... A> struct function_type<R(A...) const&&> {
+template <typename R, typename... A>
+struct function_type<R(A...) const&&> {
     using type = R(A...) const&&;
     using return_type = R;
 };
 
-template <typename R, typename... A> struct function_type<R(A...) const volatile&&> {
+template <typename R, typename... A>
+struct function_type<R(A...) const volatile&&> {
     using type = R(A...) const volatile&&;
     using return_type = R;
 };
 
-template <typename R, typename... A> struct function_type<R(A...) volatile&&> {
+template <typename R, typename... A>
+struct function_type<R(A...) volatile&&> {
     using type = R(A...) volatile&&;
     using return_type = R;
 };
 
 namespace functional {
-template <typename F> struct is_const;
-template <typename R, typename... A> struct is_const<R(A...)> : bool_constant<false> {};
-template <typename R, typename... A> struct is_const<R(A...) const> : bool_constant<true> {};
+template <typename F>
+struct is_const;
+template <typename R, typename... A>
+struct is_const<R(A...)> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_const<R(A...) const> : bool_constant<true> {};
 template <typename R, typename... A>
 struct is_const<R(A...) const volatile> : bool_constant<true> {};
-template <typename R, typename... A> struct is_const<R(A...) volatile> : bool_constant<false> {};
-template <typename R, typename... A> struct is_const<R(A...)&> : bool_constant<false> {};
-template <typename R, typename... A> struct is_const<R(A...) const&> : bool_constant<true> {};
+template <typename R, typename... A>
+struct is_const<R(A...) volatile> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_const<R(A...)&> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_const<R(A...) const&> : bool_constant<true> {};
 template <typename R, typename... A>
 struct is_const<R(A...) const volatile&> : bool_constant<true> {};
-template <typename R, typename... A> struct is_const<R(A...) volatile&> : bool_constant<false> {};
-template <typename R, typename... A> struct is_const<R(A...) &&> : bool_constant<false> {};
-template <typename R, typename... A> struct is_const<R(A...) const&&> : bool_constant<true> {};
+template <typename R, typename... A>
+struct is_const<R(A...) volatile&> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_const<R(A...) &&> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_const<R(A...) const&&> : bool_constant<true> {};
 template <typename R, typename... A>
 struct is_const<R(A...) const volatile&&> : bool_constant<true> {};
-template <typename R, typename... A> struct is_const<R(A...) volatile&&> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_const<R(A...) volatile&&> : bool_constant<false> {};
 
-template <typename F> struct is_volatile;
-template <typename R, typename... A> struct is_volatile<R(A...)> : bool_constant<false> {};
-template <typename R, typename... A> struct is_volatile<R(A...) const> : bool_constant<false> {};
+template <typename F>
+struct is_volatile;
+template <typename R, typename... A>
+struct is_volatile<R(A...)> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_volatile<R(A...) const> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_volatile<R(A...) const volatile> : bool_constant<true> {};
-template <typename R, typename... A> struct is_volatile<R(A...) volatile> : bool_constant<true> {};
-template <typename R, typename... A> struct is_volatile<R(A...)&> : bool_constant<false> {};
-template <typename R, typename... A> struct is_volatile<R(A...) const&> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_volatile<R(A...) volatile> : bool_constant<true> {};
+template <typename R, typename... A>
+struct is_volatile<R(A...)&> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_volatile<R(A...) const&> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_volatile<R(A...) const volatile&> : bool_constant<true> {};
-template <typename R, typename... A> struct is_volatile<R(A...) volatile&> : bool_constant<true> {};
-template <typename R, typename... A> struct is_volatile<R(A...) &&> : bool_constant<false> {};
-template <typename R, typename... A> struct is_volatile<R(A...) const&&> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_volatile<R(A...) volatile&> : bool_constant<true> {};
+template <typename R, typename... A>
+struct is_volatile<R(A...) &&> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_volatile<R(A...) const&&> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_volatile<R(A...) const volatile&&> : bool_constant<true> {};
 template <typename R, typename... A>
 struct is_volatile<R(A...) volatile&&> : bool_constant<true> {};
 
-template <typename F> struct is_cv;
-template <typename R, typename... A> struct is_cv<R(A...)> : bool_constant<false> {};
-template <typename R, typename... A> struct is_cv<R(A...) const> : bool_constant<false> {};
-template <typename R, typename... A> struct is_cv<R(A...) const volatile> : bool_constant<true> {};
-template <typename R, typename... A> struct is_cv<R(A...) volatile> : bool_constant<false> {};
-template <typename R, typename... A> struct is_cv<R(A...)&> : bool_constant<false> {};
-template <typename R, typename... A> struct is_cv<R(A...) const&> : bool_constant<false> {};
-template <typename R, typename... A> struct is_cv<R(A...) const volatile&> : bool_constant<true> {};
-template <typename R, typename... A> struct is_cv<R(A...) volatile&> : bool_constant<false> {};
-template <typename R, typename... A> struct is_cv<R(A...) &&> : bool_constant<false> {};
-template <typename R, typename... A> struct is_cv<R(A...) const&&> : bool_constant<false> {};
+template <typename F>
+struct is_cv;
+template <typename R, typename... A>
+struct is_cv<R(A...)> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_cv<R(A...) const> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_cv<R(A...) const volatile> : bool_constant<true> {};
+template <typename R, typename... A>
+struct is_cv<R(A...) volatile> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_cv<R(A...)&> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_cv<R(A...) const&> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_cv<R(A...) const volatile&> : bool_constant<true> {};
+template <typename R, typename... A>
+struct is_cv<R(A...) volatile&> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_cv<R(A...) &&> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_cv<R(A...) const&&> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_cv<R(A...) const volatile&&> : bool_constant<true> {};
-template <typename R, typename... A> struct is_cv<R(A...) volatile&&> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_cv<R(A...) volatile&&> : bool_constant<false> {};
 
-template <typename F> struct is_lvalue;
-template <typename R, typename... A> struct is_lvalue<R(A...)> : bool_constant<false> {};
-template <typename R, typename... A> struct is_lvalue<R(A...) const> : bool_constant<false> {};
+template <typename F>
+struct is_lvalue;
+template <typename R, typename... A>
+struct is_lvalue<R(A...)> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_lvalue<R(A...) const> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_lvalue<R(A...) const volatile> : bool_constant<false> {};
-template <typename R, typename... A> struct is_lvalue<R(A...) volatile> : bool_constant<false> {};
-template <typename R, typename... A> struct is_lvalue<R(A...)&> : bool_constant<true> {};
-template <typename R, typename... A> struct is_lvalue<R(A...) const&> : bool_constant<true> {};
+template <typename R, typename... A>
+struct is_lvalue<R(A...) volatile> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_lvalue<R(A...)&> : bool_constant<true> {};
+template <typename R, typename... A>
+struct is_lvalue<R(A...) const&> : bool_constant<true> {};
 template <typename R, typename... A>
 struct is_lvalue<R(A...) const volatile&> : bool_constant<true> {};
-template <typename R, typename... A> struct is_lvalue<R(A...) volatile&> : bool_constant<true> {};
-template <typename R, typename... A> struct is_lvalue<R(A...) &&> : bool_constant<false> {};
-template <typename R, typename... A> struct is_lvalue<R(A...) const&&> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_lvalue<R(A...) volatile&> : bool_constant<true> {};
+template <typename R, typename... A>
+struct is_lvalue<R(A...) &&> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_lvalue<R(A...) const&&> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_lvalue<R(A...) const volatile&&> : bool_constant<false> {};
-template <typename R, typename... A> struct is_lvalue<R(A...) volatile&&> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_lvalue<R(A...) volatile&&> : bool_constant<false> {};
 
-template <typename F> struct is_rvalue;
-template <typename R, typename... A> struct is_rvalue<R(A...)> : bool_constant<false> {};
-template <typename R, typename... A> struct is_rvalue<R(A...) const> : bool_constant<false> {};
+template <typename F>
+struct is_rvalue;
+template <typename R, typename... A>
+struct is_rvalue<R(A...)> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_rvalue<R(A...) const> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_rvalue<R(A...) const volatile> : bool_constant<false> {};
-template <typename R, typename... A> struct is_rvalue<R(A...) volatile> : bool_constant<false> {};
-template <typename R, typename... A> struct is_rvalue<R(A...)&> : bool_constant<false> {};
-template <typename R, typename... A> struct is_rvalue<R(A...) const&> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_rvalue<R(A...) volatile> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_rvalue<R(A...)&> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_rvalue<R(A...) const&> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_rvalue<R(A...) const volatile&> : bool_constant<false> {};
-template <typename R, typename... A> struct is_rvalue<R(A...) volatile&> : bool_constant<false> {};
-template <typename R, typename... A> struct is_rvalue<R(A...) &&> : bool_constant<true> {};
-template <typename R, typename... A> struct is_rvalue<R(A...) const&&> : bool_constant<true> {};
+template <typename R, typename... A>
+struct is_rvalue<R(A...) volatile&> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_rvalue<R(A...) &&> : bool_constant<true> {};
+template <typename R, typename... A>
+struct is_rvalue<R(A...) const&&> : bool_constant<true> {};
 template <typename R, typename... A>
 struct is_rvalue<R(A...) const volatile&&> : bool_constant<true> {};
-template <typename R, typename... A> struct is_rvalue<R(A...) volatile&&> : bool_constant<true> {};
+template <typename R, typename... A>
+struct is_rvalue<R(A...) volatile&&> : bool_constant<true> {};
 
-template <typename F> struct is_noexcept;
-template <typename R, typename... A> struct is_noexcept<R(A...)> : bool_constant<false> {};
-template <typename R, typename... A> struct is_noexcept<R(A...) const> : bool_constant<false> {};
+template <typename F>
+struct is_noexcept;
+template <typename R, typename... A>
+struct is_noexcept<R(A...)> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_noexcept<R(A...) const> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_noexcept<R(A...) const volatile> : bool_constant<false> {};
-template <typename R, typename... A> struct is_noexcept<R(A...) volatile> : bool_constant<false> {};
-template <typename R, typename... A> struct is_noexcept<R(A...)&> : bool_constant<false> {};
-template <typename R, typename... A> struct is_noexcept<R(A...) const&> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_noexcept<R(A...) volatile> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_noexcept<R(A...)&> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_noexcept<R(A...) const&> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_noexcept<R(A...) const volatile&> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_noexcept<R(A...) volatile&> : bool_constant<false> {};
-template <typename R, typename... A> struct is_noexcept<R(A...) &&> : bool_constant<false> {};
-template <typename R, typename... A> struct is_noexcept<R(A...) const&&> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_noexcept<R(A...) &&> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_noexcept<R(A...) const&&> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_noexcept<R(A...) const volatile&&> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_noexcept<R(A...) volatile&&> : bool_constant<false> {};
 
-template <typename F> struct argument_list;
-template <typename F> using argument_list_t = typename argument_list<F>::type;
+template <typename F>
+struct argument_list;
+template <typename F>
+using argument_list_t = typename argument_list<F>::type;
 template <typename R, typename... A>
 struct argument_list<R(A...)> : type_identity<type_list<A...>> {};
 template <typename R, typename... A>
@@ -218,81 +295,96 @@ struct argument_list<R(A...) volatile&&> : type_identity<type_list<A...>> {};
 
 #ifdef UTL_CXX17
 
-template <typename R, typename... A> struct function_type<R(A...) noexcept> {
+template <typename R, typename... A>
+struct function_type<R(A...) noexcept> {
     using type = R(A...) noexcept;
     using return_type = R;
 };
 
-template <typename R, typename... A> struct function_type<R(A...) const noexcept> {
+template <typename R, typename... A>
+struct function_type<R(A...) const noexcept> {
     using type = R(A...) const noexcept;
     using return_type = R;
 };
 
-template <typename R, typename... A> struct function_type<R(A...) const volatile noexcept> {
+template <typename R, typename... A>
+struct function_type<R(A...) const volatile noexcept> {
     using type = R(A...) const volatile noexcept;
     using return_type = R;
 };
 
-template <typename R, typename... A> struct function_type<R(A...) volatile noexcept> {
+template <typename R, typename... A>
+struct function_type<R(A...) volatile noexcept> {
     using type = R(A...) volatile noexcept;
     using return_type = R;
 };
 
-template <typename R, typename... A> struct function_type<R(A...) & noexcept> {
+template <typename R, typename... A>
+struct function_type<R(A...) & noexcept> {
     using type = R(A...);
     using return_type = R;
 };
 
-template <typename R, typename... A> struct function_type<R(A...) const & noexcept> {
+template <typename R, typename... A>
+struct function_type<R(A...) const & noexcept> {
     using type = R(A...) const&;
     using return_type = R;
 };
 
-template <typename R, typename... A> struct function_type<R(A...) const volatile & noexcept> {
+template <typename R, typename... A>
+struct function_type<R(A...) const volatile & noexcept> {
     using type = R(A...) const volatile&;
     using return_type = R;
 };
 
-template <typename R, typename... A> struct function_type<R(A...) volatile & noexcept> {
+template <typename R, typename... A>
+struct function_type<R(A...) volatile & noexcept> {
     using type = R(A...) volatile&;
     using return_type = R;
 };
 
-template <typename R, typename... A> struct function_type<R(A...) && noexcept> {
+template <typename R, typename... A>
+struct function_type<R(A...) && noexcept> {
     using type = R(A...);
     using return_type = R;
 };
 
-template <typename R, typename... A> struct function_type<R(A...) const && noexcept> {
+template <typename R, typename... A>
+struct function_type<R(A...) const && noexcept> {
     using type = R(A...) const&&;
     using return_type = R;
 };
 
-template <typename R, typename... A> struct function_type<R(A...) const volatile && noexcept> {
+template <typename R, typename... A>
+struct function_type<R(A...) const volatile && noexcept> {
     using type = R(A...) const volatile&&;
     using return_type = R;
 };
 
-template <typename R, typename... A> struct function_type<R(A...) volatile && noexcept> {
+template <typename R, typename... A>
+struct function_type<R(A...) volatile && noexcept> {
     using type = R(A...) volatile&&;
     using return_type = R;
 };
 
-template <typename R, typename... A> struct is_const<R(A...) noexcept> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_const<R(A...) noexcept> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_const<R(A...) const noexcept> : bool_constant<true> {};
 template <typename R, typename... A>
 struct is_const<R(A...) const volatile noexcept> : bool_constant<true> {};
 template <typename R, typename... A>
 struct is_const<R(A...) volatile noexcept> : bool_constant<false> {};
-template <typename R, typename... A> struct is_const<R(A...) & noexcept> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_const<R(A...) & noexcept> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_const<R(A...) const & noexcept> : bool_constant<true> {};
 template <typename R, typename... A>
 struct is_const<R(A...) const volatile & noexcept> : bool_constant<true> {};
 template <typename R, typename... A>
 struct is_const<R(A...) volatile & noexcept> : bool_constant<false> {};
-template <typename R, typename... A> struct is_const<R(A...) && noexcept> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_const<R(A...) && noexcept> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_const<R(A...) const && noexcept> : bool_constant<true> {};
 template <typename R, typename... A>
@@ -300,7 +392,8 @@ struct is_const<R(A...) const volatile && noexcept> : bool_constant<true> {};
 template <typename R, typename... A>
 struct is_const<R(A...) volatile && noexcept> : bool_constant<false> {};
 
-template <typename R, typename... A> struct is_volatile<R(A...) noexcept> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_volatile<R(A...) noexcept> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_volatile<R(A...) const noexcept> : bool_constant<false> {};
 template <typename R, typename... A>
@@ -324,20 +417,24 @@ struct is_volatile<R(A...) const volatile && noexcept> : bool_constant<true> {};
 template <typename R, typename... A>
 struct is_volatile<R(A...) volatile && noexcept> : bool_constant<true> {};
 
-template <typename R, typename... A> struct is_cv<R(A...) noexcept> : bool_constant<false> {};
-template <typename R, typename... A> struct is_cv<R(A...) const noexcept> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_cv<R(A...) noexcept> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_cv<R(A...) const noexcept> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_cv<R(A...) const volatile noexcept> : bool_constant<true> {};
 template <typename R, typename... A>
 struct is_cv<R(A...) volatile noexcept> : bool_constant<false> {};
-template <typename R, typename... A> struct is_cv<R(A...) & noexcept> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_cv<R(A...) & noexcept> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_cv<R(A...) const & noexcept> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_cv<R(A...) const volatile & noexcept> : bool_constant<true> {};
 template <typename R, typename... A>
 struct is_cv<R(A...) volatile & noexcept> : bool_constant<false> {};
-template <typename R, typename... A> struct is_cv<R(A...) && noexcept> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_cv<R(A...) && noexcept> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_cv<R(A...) const && noexcept> : bool_constant<false> {};
 template <typename R, typename... A>
@@ -345,14 +442,16 @@ struct is_cv<R(A...) const volatile && noexcept> : bool_constant<true> {};
 template <typename R, typename... A>
 struct is_cv<R(A...) volatile && noexcept> : bool_constant<false> {};
 
-template <typename R, typename... A> struct is_lvalue<R(A...) noexcept> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_lvalue<R(A...) noexcept> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_lvalue<R(A...) const noexcept> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_lvalue<R(A...) const volatile noexcept> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_lvalue<R(A...) volatile noexcept> : bool_constant<false> {};
-template <typename R, typename... A> struct is_lvalue<R(A...) & noexcept> : bool_constant<true> {};
+template <typename R, typename... A>
+struct is_lvalue<R(A...) & noexcept> : bool_constant<true> {};
 template <typename R, typename... A>
 struct is_lvalue<R(A...) const & noexcept> : bool_constant<true> {};
 template <typename R, typename... A>
@@ -368,21 +467,24 @@ struct is_lvalue<R(A...) const volatile && noexcept> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_lvalue<R(A...) volatile && noexcept> : bool_constant<false> {};
 
-template <typename R, typename... A> struct is_rvalue<R(A...) noexcept> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_rvalue<R(A...) noexcept> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_rvalue<R(A...) const noexcept> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_rvalue<R(A...) const volatile noexcept> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_rvalue<R(A...) volatile noexcept> : bool_constant<false> {};
-template <typename R, typename... A> struct is_rvalue<R(A...) & noexcept> : bool_constant<false> {};
+template <typename R, typename... A>
+struct is_rvalue<R(A...) & noexcept> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_rvalue<R(A...) const & noexcept> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_rvalue<R(A...) const volatile & noexcept> : bool_constant<false> {};
 template <typename R, typename... A>
 struct is_rvalue<R(A...) volatile & noexcept> : bool_constant<false> {};
-template <typename R, typename... A> struct is_rvalue<R(A...) && noexcept> : bool_constant<true> {};
+template <typename R, typename... A>
+struct is_rvalue<R(A...) && noexcept> : bool_constant<true> {};
 template <typename R, typename... A>
 struct is_rvalue<R(A...) const && noexcept> : bool_constant<true> {};
 template <typename R, typename... A>
@@ -390,7 +492,8 @@ struct is_rvalue<R(A...) const volatile && noexcept> : bool_constant<true> {};
 template <typename R, typename... A>
 struct is_rvalue<R(A...) volatile && noexcept> : bool_constant<true> {};
 
-template <typename R, typename... A> struct is_noexcept<R(A...) noexcept> : bool_constant<true> {};
+template <typename R, typename... A>
+struct is_noexcept<R(A...) noexcept> : bool_constant<true> {};
 template <typename R, typename... A>
 struct is_noexcept<R(A...) const noexcept> : bool_constant<true> {};
 template <typename R, typename... A>
@@ -443,7 +546,8 @@ struct argument_list<R(A...) volatile && noexcept> : type_identity<type_list<A..
 
 } // namespace functional
 
-template <typename F> struct function_traits : function_type<F> {
+template <typename F>
+struct function_traits : function_type<F> {
     using function_type::return_type;
     using function_type::type;
     using argument_list = functional::argument_list_t<F>;
@@ -466,7 +570,8 @@ struct template_element<I, function_type<F>> : template_element<I, function_trai
 
 template <typename F>
 struct template_size<function_traits<F>> : template_size<functional::argument_list_t<F>> {};
-template <typename F> struct template_size<function_type<F>> : template_size<function_traits<F>> {};
+template <typename F>
+struct template_size<function_type<F>> : template_size<function_traits<F>> {};
 
 template <typename T, typename F>
 struct template_count<T, function_traits<F>> : template_count<T, functional::argument_list_t<F>> {};

--- a/include/utl/meta/member_info.h
+++ b/include/utl/meta/member_info.h
@@ -6,15 +6,18 @@
 
 UTL_NAMESPACE_BEGIN
 
-template <typename M> struct member_traits;
+template <typename M>
+struct member_traits;
 
-template <typename Type, typename Class> struct member_traits<Type Class::*> {
+template <typename Type, typename Class>
+struct member_traits<Type Class::*> {
     using type = Type;
     using value_type = Type Class::*;
     using owner_type = Class;
 };
 
-template <typename M, M Pointer> struct member_info;
+template <typename M, M Pointer>
+struct member_info;
 
 template <typename Type, typename Class, Type Class::*V>
 struct member_info<Type Class::*, V> : member_traits<Type Class::*> {
@@ -25,8 +28,8 @@ struct member_info<Type Class::*, V> : member_traits<Type Class::*> {
 
     template <typename T, typename... Args,
         typename = enable_if_t<is_base_of<Class, decay_t<T>>::value && is_function<type>::value>>
-    constexpr decltype((declval<copy_cvref_t<T, Class>>()().*value)(declval<Args>()...))
-    operator() (T&& instance, Args&&... args) const {
+    constexpr decltype((declval<copy_cvref_t<T, Class>>()().*value)(declval<Args>()...)) operator()(
+        T&& instance, Args&&... args) const {
         return (static_cast<copy_cvref_t<T&&, Class>>(forward<T>(instance))->*value)(
             forward<Args>(args)...);
     }
@@ -34,12 +37,13 @@ struct member_info<Type Class::*, V> : member_traits<Type Class::*> {
     template <typename T,
         typename = enable_if_t<is_convertible<T&&, copy_cvref_t<T&&, Class>>::value &&
             !is_function<type>::value>>
-    constexpr copy_cvref_t<T&&, type> operator() (T&& instance) const {
+    constexpr copy_cvref_t<T&&, type> operator()(T&& instance) const {
         return static_cast<copy_cvref_t<T&&, Class>>(forward<T>(instance)).*value;
     }
 };
 
-template <typename M, M Pointer> using member_info_t = typename member_info<M, Pointer>::type;
+template <typename M, M Pointer>
+using member_info_t = typename member_info<M, Pointer>::type;
 
 #ifndef UTL_CXX17
 
@@ -48,8 +52,10 @@ template <typename M, M Pointer> using member_info_t = typename member_info<M, P
 
 #else // ifndef UTL_CXX17
 
-template <auto V> using member_info_of = member_info<decltype(V), V>;
-template <auto V> using member_info_of_t = typename member_info<decltype(V), V>::type;
+template <auto V>
+using member_info_of = member_info<decltype(V), V>;
+template <auto V>
+using member_info_of_t = typename member_info<decltype(V), V>::type;
 
 #  define UTL_MEMBER_INFO(CLASS, MEMBER) UTL_SCOPE member_info_of<&CLASS::MEMBER>
 

--- a/include/utl/tuple/utl_tuple_cat.h
+++ b/include/utl/tuple/utl_tuple_cat.h
@@ -15,11 +15,13 @@ UTL_NAMESPACE_BEGIN
 namespace details {
 namespace tuple {
 
-template <typename, typename> struct is_all_reference_impl;
+template <typename, typename>
+struct is_all_reference_impl;
 template <typename T, size_t... Is>
 struct is_all_reference_impl<T, index_sequence<Is...>> :
     conjunction<is_reference<tuple_element_t<Is, T>>...> {};
-template <typename T> using is_all_reference = is_all_reference_impl<T, tuple_index_sequence<T>>;
+template <typename T>
+using is_all_reference = is_all_reference_impl<T, tuple_index_sequence<T>>;
 
 // unpacks into references
 template <typename Tuple, size_t... Ns>
@@ -37,7 +39,8 @@ constexpr auto tuple_forward(Tuple&& tuple) noexcept(
     return tuple_forward(forward<Tuple>(tuple), tuple_index_sequence<Tuple>{});
 }
 
-template <typename T> constexpr auto tuple_cat_impl(T&& tuple) noexcept -> T&& {
+template <typename T>
+constexpr auto tuple_cat_impl(T&& tuple) noexcept -> T&& {
     static_assert(is_all_reference<T>::value, "Elements must all be references");
     return forward<T>(tuple);
 }

--- a/include/utl/tuple/utl_tuple_compare_traits.h
+++ b/include/utl/tuple/utl_tuple_compare_traits.h
@@ -17,7 +17,8 @@ UTL_NAMESPACE_BEGIN
 namespace compare_ops {
 namespace details {
 
-template <typename T> using const_ref_t = remove_reference_t<T> const&;
+template <typename T>
+using const_ref_t = remove_reference_t<T> const&;
 template <typename T>
 using sequence_t = conditional_t<TT_SCOPE is_tuple_like<T>::value, tuple_index_sequence<T>, void>;
 
@@ -82,12 +83,18 @@ struct all_have_gteq_impl<T, U, index_sequence<Is...>,
     > : true_type {};
 } // namespace details
 
-template <typename T, typename U = T> struct all_have_eq : details::all_have_eq_impl<T, U> {};
-template <typename T, typename U = T> struct all_have_neq : details::all_have_neq_impl<T, U> {};
-template <typename T, typename U = T> struct all_have_lt : details::all_have_lt_impl<T, U> {};
-template <typename T, typename U = T> struct all_have_gt : details::all_have_gt_impl<T, U> {};
-template <typename T, typename U = T> struct all_have_lteq : details::all_have_lteq_impl<T, U> {};
-template <typename T, typename U = T> struct all_have_gteq : details::all_have_gteq_impl<T, U> {};
+template <typename T, typename U = T>
+struct all_have_eq : details::all_have_eq_impl<T, U> {};
+template <typename T, typename U = T>
+struct all_have_neq : details::all_have_neq_impl<T, U> {};
+template <typename T, typename U = T>
+struct all_have_lt : details::all_have_lt_impl<T, U> {};
+template <typename T, typename U = T>
+struct all_have_gt : details::all_have_gt_impl<T, U> {};
+template <typename T, typename U = T>
+struct all_have_lteq : details::all_have_lteq_impl<T, U> {};
+template <typename T, typename U = T>
+struct all_have_gteq : details::all_have_gteq_impl<T, U> {};
 
 namespace details {
 template <typename T, typename U, typename Seq = sequence_t<T>, typename = void>

--- a/include/utl/tuple/utl_tuple_cpp17.h
+++ b/include/utl/tuple/utl_tuple_cpp17.h
@@ -36,7 +36,8 @@ UTL_NAMESPACE_BEGIN
 
 namespace details {
 namespace tuple {
-template <typename, typename, typename = void> struct common_type_impl {};
+template <typename, typename, typename = void>
+struct common_type_impl {};
 
 template <typename... Ts, typename... Us>
 struct common_type_impl<UTL_SCOPE tuple<Ts...>, UTL_SCOPE tuple<Us...>,
@@ -77,7 +78,8 @@ UTL_NAMESPACE_BEGIN
 
 namespace details {
 namespace tuple {
-template <typename...> struct invalid_swap_t {
+template <typename...>
+struct invalid_swap_t {
     inline UTL_CONSTEXPR_CXX14 void swap(invalid_swap_t& other) const noexcept {}
     inline UTL_CONSTEXPR_CXX14 void swap(invalid_swap_t const& other) const noexcept {}
 
@@ -85,21 +87,25 @@ private:
     ~invalid_swap_t() = default;
 };
 
-template <typename...> struct storage;
-template <size_t I, typename T, typename = void> struct offset_impl;
+template <typename...>
+struct storage;
+template <size_t I, typename T, typename = void>
+struct offset_impl;
 struct invalid_t {
 private:
     ~invalid_t() = default;
 };
 
-template <> struct storage<> {
+template <>
+struct storage<> {
     constexpr storage() noexcept = default;
-    constexpr storage&       operator= (storage const&) noexcept = default;
-    constexpr storage&       operator= (storage&&) noexcept = default;
+    constexpr storage&       operator=(storage const&) noexcept = default;
+    constexpr storage&       operator=(storage&&) noexcept = default;
     UTL_CONSTEXPR_CXX14 void swap(storage<>& other) noexcept {}
 };
 
-template <typename T> struct storage<T> : variadic_traits<T> {
+template <typename T>
+struct storage<T> : variadic_traits<T> {
 public:
     using traits = variadic_traits<T>;
     using head_type = T;
@@ -108,16 +114,16 @@ public:
 
     constexpr storage() noexcept(traits::is_nothrow_default_constructible) = default;
     constexpr storage(storage const&) noexcept(traits::is_nothrow_copy_constructible) = default;
-    UTL_CONSTEXPR_CXX14 storage& operator= (storage const&) noexcept(
+    UTL_CONSTEXPR_CXX14 storage& operator=(storage const&) noexcept(
         traits::is_nothrow_copy_assignable) = default;
 
 #ifdef UTL_ENFORCE_NONMOVABILIITY
     constexpr storage(move_construct_t&&) noexcept(traits::is_nothrow_move_constructible) = delete;
-    UTL_CONSTEXPR_CXX14 storage& operator= (move_assign_t&&) noexcept(
+    UTL_CONSTEXPR_CXX14 storage& operator=(move_assign_t&&) noexcept(
         traits::is_nothrow_move_assignable) = delete;
 #else
     constexpr storage(storage&&) noexcept(traits::is_nothrow_move_constructible) = default;
-    UTL_CONSTEXPR_CXX14 storage& operator= (storage&&) noexcept(
+    UTL_CONSTEXPR_CXX14 storage& operator=(storage&&) noexcept(
         traits::is_nothrow_move_assignable) = default;
 #endif
 
@@ -237,7 +243,8 @@ public:
     UTL_ATTRIBUTE(NO_UNIQUE_ADDRESS) head_type head;
 };
 
-template <typename T, typename... Tail> struct storage<T, Tail...> : variadic_traits<T, Tail...> {
+template <typename T, typename... Tail>
+struct storage<T, Tail...> : variadic_traits<T, Tail...> {
     using traits = variadic_traits<T, Tail...>;
     using head_type = T;
     using tail_type = storage<Tail...>;
@@ -246,16 +253,16 @@ template <typename T, typename... Tail> struct storage<T, Tail...> : variadic_tr
 
     constexpr storage() noexcept(traits::is_nothrow_default_constructible) = default;
     constexpr storage(storage const&) noexcept(traits::is_nothrow_copy_constructible) = default;
-    UTL_CONSTEXPR_CXX14 storage& operator= (storage const&) noexcept(
+    UTL_CONSTEXPR_CXX14 storage& operator=(storage const&) noexcept(
         traits::is_nothrow_copy_assignable) = default;
 
 #ifdef UTL_ENFORCE_NONMOVABILIITY
     constexpr storage(move_construct_t&&) noexcept(traits::is_nothrow_move_constructible) = delete;
-    UTL_CONSTEXPR_CXX14 storage& operator= (move_assign_t&&) noexcept(
+    UTL_CONSTEXPR_CXX14 storage& operator=(move_assign_t&&) noexcept(
         traits::is_nothrow_move_assignable) = delete;
 #else
     constexpr storage(storage&&) noexcept(traits::is_nothrow_move_constructible) = default;
-    UTL_CONSTEXPR_CXX14 storage& operator= (storage&&) noexcept(
+    UTL_CONSTEXPR_CXX14 storage& operator=(storage&&) noexcept(
         traits::is_nothrow_move_assignable) = default;
 #endif
 
@@ -427,7 +434,8 @@ template <typename T, typename... Tail> struct storage<T, Tail...> : variadic_tr
     UTL_ATTRIBUTE(NO_UNIQUE_ADDRESS) tail_type tail;
 };
 
-template <typename... Ts> struct offset_impl<0, storage<Ts...>> {
+template <typename... Ts>
+struct offset_impl<0, storage<Ts...>> {
     using type = storage<Ts...>;
     static_assert(is_standard_layout<type>::value, "Must be standard layout");
     static constexpr size_t value = offsetof(type, head);
@@ -445,7 +453,8 @@ struct offset_impl<I, storage<T0, Ts...>, enable_if_t<(I > 0)>> {
 } // namespace tuple
 } // namespace details
 
-template <> class tuple<> : private details::tuple::storage<> {
+template <>
+class tuple<> : private details::tuple::storage<> {
 public:
     using storage::storage;
     using storage::operator=;
@@ -453,9 +462,11 @@ public:
     friend inline UTL_CONSTEXPR_CXX14 void swap(tuple const&, tuple const&) noexcept {}
 };
 
-template <typename... Types> class tuple : private details::tuple::storage<Types...> {
+template <typename... Types>
+class tuple : private details::tuple::storage<Types...> {
 private:
-    template <size_t I, typename T> friend struct tuple_element_offset;
+    template <size_t I, typename T>
+    friend struct tuple_element_offset;
 
     using base_type = details::tuple::storage<Types...>;
     using traits = typename base_type::traits;
@@ -467,7 +478,8 @@ private:
         conditional_t<traits::is_move_assignable, details::tuple::invalid_t, tuple>;
     using move_construct_t =
         conditional_t<traits::is_move_constructible, details::tuple::invalid_t, tuple>;
-    template <typename T> using not_this = negation<is_same<T, tuple>>;
+    template <typename T>
+    using not_this = negation<is_same<T, tuple>>;
     using base_type::get;
 
     template <typename TupleLike, size_t... Is>
@@ -505,24 +517,24 @@ private:
 
 public:
     constexpr tuple(tuple const&) noexcept(traits::is_nothrow_copy_constructible) = default;
-    UTL_CONSTEXPR_CXX14 tuple& operator= (tuple const& other) noexcept(
+    UTL_CONSTEXPR_CXX14 tuple& operator=(tuple const& other) noexcept(
         traits::is_nothrow_copy_assignable) = default;
     constexpr tuple(tuple&&) noexcept(traits::is_nothrow_move_constructible) = default;
-    UTL_CONSTEXPR_CXX14 tuple& operator= (tuple&&) noexcept(
+    UTL_CONSTEXPR_CXX14 tuple& operator=(tuple&&) noexcept(
         traits::is_nothrow_move_assignable) = default;
 
     UTL_CONSTEXPR_CXX20 ~tuple() = default;
 
     template <bool NotEmpty = (sizeof...(Types) >= 1),
         typename = enable_if_t<NotEmpty && traits::is_const_copy_assignable>>
-    constexpr tuple const& operator= (tuple const& other) const
+    constexpr tuple const& operator=(tuple const& other) const
         noexcept(traits::is_nothrow_const_copy_assignable) {
         return assign(other, index_sequence_for<Types...>{});
     }
 
     template <bool NotEmpty = (sizeof...(Types) >= 1),
         typename = enable_if_t<NotEmpty && traits::is_const_move_assignable>>
-    constexpr tuple const& operator= (tuple&& other) const
+    constexpr tuple const& operator=(tuple&& other) const
         noexcept(traits::is_nothrow_const_move_assignable) {
         return assign(move(other), index_sequence_for<Types...>{});
     }
@@ -1230,7 +1242,7 @@ public:
     template <typename... UTypes,
         typename = enable_if_t<
             conjunction<typename traits::template is_assignable<UTypes const&...>>::value>>
-    UTL_CONSTEXPR_CXX14 tuple& operator= (tuple<UTypes...> const& other) noexcept(
+    UTL_CONSTEXPR_CXX14 tuple& operator=(tuple<UTypes...> const& other) noexcept(
         traits::template is_nothrow_assignable<UTypes const&...>::value) {
         return assign(other, index_sequence_for<Types...>{});
     }
@@ -1238,7 +1250,7 @@ public:
     template <typename... UTypes,
         typename = enable_if_t<
             conjunction<typename traits::template is_const_assignable<UTypes const&...>>::value>>
-    constexpr tuple const& operator= (tuple<UTypes...> const& other) const
+    constexpr tuple const& operator=(tuple<UTypes...> const& other) const
         noexcept(traits::template is_nothrow_const_assignable<UTypes const&...>::value) {
         return assign(other, index_sequence_for<Types...>{});
     }
@@ -1247,7 +1259,7 @@ public:
     template <typename... UTypes,
         enable_if_t<conjunction<typename traits::template is_assignable<UTypes&&...>>::value, int> =
             0>
-    UTL_CONSTEXPR_CXX14 tuple& operator= (tuple<UTypes...>&& other) noexcept(
+    UTL_CONSTEXPR_CXX14 tuple& operator=(tuple<UTypes...>&& other) noexcept(
         traits::template is_nothrow_assignable<UTypes&&...>::value) {
         return assign(move(other), index_sequence_for<Types...>{});
     }
@@ -1256,12 +1268,12 @@ public:
         enable_if_t<
             disjunction<negation<typename traits::template is_assignable<UTypes&&...>>>::value,
             int> = 1>
-    UTL_CONSTEXPR_CXX14 tuple& operator= (tuple<UTypes...>&& other) = delete;
+    UTL_CONSTEXPR_CXX14 tuple& operator=(tuple<UTypes...>&& other) = delete;
 
     template <typename... UTypes,
         enable_if_t<conjunction<typename traits::template is_const_assignable<UTypes&&...>>::value,
             int> = 0>
-    constexpr tuple const& operator= (tuple<UTypes...>&& other) const
+    constexpr tuple const& operator=(tuple<UTypes...>&& other) const
         noexcept(traits::template is_nothrow_const_assignable<UTypes&&...>::value) {
         return assign(move(other), index_sequence_for<Types...>{});
     }
@@ -1274,7 +1286,7 @@ public:
         enable_if_t<disjunction<negation<
                         typename traits::template is_const_assignable<UTypes&&...>>>::value,
             int> = 1>
-    constexpr tuple const& operator= (tuple<UTypes...>&& other) const = delete;
+    constexpr tuple const& operator=(tuple<UTypes...>&& other) const = delete;
 #endif
 
 public:
@@ -1284,7 +1296,7 @@ public:
                         TT_SCOPE rebind_references_t<traits::template is_assignable, TupleLike,
                             sizeof...(Types)>>::value,
             int> = 0>
-    UTL_CONSTEXPR_CXX14 tuple& operator= (TupleLike&& other) noexcept(
+    UTL_CONSTEXPR_CXX14 tuple& operator=(TupleLike&& other) noexcept(
         conjunction<TT_SCOPE is_all_nothrow_gettable<TupleLike, sizeof...(Types)>,
             TT_SCOPE         rebind_references_t<traits::template is_nothrow_assignable, TupleLike,
                 sizeof...(Types)>>::value) {
@@ -1297,7 +1309,7 @@ public:
                         TT_SCOPE rebind_references_t<traits::template is_const_assignable,
                             TupleLike, sizeof...(Types)>>::value,
             int> = 1>
-    constexpr tuple const& operator= (TupleLike&& other) const
+    constexpr tuple const& operator=(TupleLike&& other) const
         noexcept(conjunction<TT_SCOPE is_all_nothrow_gettable<TupleLike, sizeof...(Types)>,
             TT_SCOPE rebind_references_t<traits::template is_nothrow_const_assignable, TupleLike,
                 sizeof...(Types)>>::value) {
@@ -1305,7 +1317,8 @@ public:
     }
 };
 
-template <size_t I, typename T> struct tuple_element_offset;
+template <size_t I, typename T>
+struct tuple_element_offset;
 
 template <size_t I, typename... Ts>
 struct tuple_element_offset<I, tuple<Ts...>> :
@@ -1363,7 +1376,7 @@ constexpr bool equals(T const& l, U const& r) noexcept(compare_ops::has_nothrow_
 template <typename... Ts, typename... Us>
 UTL_NODISCARD constexpr enable_if_t<
     conjunction<compare_ops::all_have_eq<tuple<Ts...>, tuple<Us...>>>::value, bool>
-operator== (tuple<Ts...> const& l, tuple<Us...> const& r) noexcept(details::tuple::equals(l, r)) {
+operator==(tuple<Ts...> const& l, tuple<Us...> const& r) noexcept(details::tuple::equals(l, r)) {
     return details::tuple::equals(l, r);
 }
 
@@ -1372,44 +1385,44 @@ UTL_NODISCARD constexpr enable_if_t<
     conjunction<compare_ops::all_have_eq<tuple<Ts...>, tuple<Us...>>,
         compare_ops::all_have_lt<tuple<Ts...>, tuple<Us...>>>::value,
     bool>
-operator< (tuple<Ts...> const& l, tuple<Us...> const& r) noexcept(details::tuple::less(l, r)) {
+operator<(tuple<Ts...> const& l, tuple<Us...> const& r) noexcept(details::tuple::less(l, r)) {
     return details::tuple::less(l, r);
 }
 
 UTL_ATTRIBUTES(NODISCARD, CONST)
-constexpr bool operator== (tuple<> const& l, tuple<> const& r) noexcept {
+constexpr bool operator==(tuple<> const& l, tuple<> const& r) noexcept {
     return true;
 }
 
 UTL_ATTRIBUTES(NODISCARD, CONST)
-constexpr bool operator< (tuple<> const& l, tuple<> const& r) noexcept {
+constexpr bool operator<(tuple<> const& l, tuple<> const& r) noexcept {
     return false;
 }
 
 template <typename... Ts, typename... Us>
 UTL_NODISCARD constexpr enable_if_t<compare_ops::has_eq<tuple<Ts...>, tuple<Us...>>::value, bool>
-operator!= (tuple<Ts...> const& l, tuple<Us...> const& r) noexcept(
+operator!=(tuple<Ts...> const& l, tuple<Us...> const& r) noexcept(
     is_nothrow_equality_comparable<tuple<Ts...>, tuple<Us...>>::value) {
     return !(l == r);
 }
 
 template <typename... Ts, typename... Us>
 UTL_NODISCARD constexpr enable_if_t<compare_ops::has_lt<tuple<Us...>, tuple<Ts...>>::value, bool>
-operator<= (tuple<Ts...> const& l, tuple<Us...> const& r) noexcept(
+operator<=(tuple<Ts...> const& l, tuple<Us...> const& r) noexcept(
     compare_ops::has_nothrow_lt<tuple<Us...>, tuple<Ts...>>::value) {
     return !(r < l);
 }
 
 template <typename... Ts, typename... Us>
 UTL_NODISCARD constexpr enable_if_t<compare_ops::has_lt<tuple<Us...>, tuple<Ts...>>::value, bool>
-operator> (tuple<Ts...> const& l, tuple<Us...> const& r) noexcept(
+operator>(tuple<Ts...> const& l, tuple<Us...> const& r) noexcept(
     compare_ops::has_nothrow_lt<tuple<Us...>, tuple<Ts...>>::value) {
     return static_cast<bool>(r < l);
 }
 
 template <typename... Ts, typename... Us>
 UTL_NODISCARD constexpr enable_if_t<compare_ops::has_lt<tuple<Ts...>, tuple<Us...>>::value, bool>
-operator>= (tuple<Ts...> const& l, tuple<Us...> const& r) noexcept(
+operator>=(tuple<Ts...> const& l, tuple<Us...> const& r) noexcept(
     compare_ops::has_nothrow_lt<tuple<Ts...>, tuple<Us...>>::value) {
     return !(l < r);
 }

--- a/include/utl/tuple/utl_tuple_fwd.h
+++ b/include/utl/tuple/utl_tuple_fwd.h
@@ -14,28 +14,37 @@ UTL_STD_NAMESPACE_BEGIN
  * for e.g. structured bindings
  * RANT: Things like these that interact with core language SHOULD provide forward declarations
  */
-template <typename> struct tuple_size;
-template <decltype(sizeof(0)), typename> struct tuple_element;
+template <typename>
+struct tuple_size;
+template <decltype(sizeof(0)), typename>
+struct tuple_element;
 UTL_STD_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
 using size_t = decltype(sizeof(0));
 
-template <typename> struct tuple_size;
-template <size_t, typename> struct tuple_element;
-template <typename T> struct is_tuple;
+template <typename>
+struct tuple_size;
+template <size_t, typename>
+struct tuple_element;
+template <typename T>
+struct is_tuple;
 
 #  ifdef UTL_CXX14
 
-template <typename T> UTL_INLINE_CXX17 constexpr size_t tuple_size_v = tuple_size<T>::value;
-template <typename T> UTL_INLINE_CXX17 constexpr bool   is_tuple_v = is_tuple<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr size_t tuple_size_v = tuple_size<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_tuple_v = is_tuple<T>::value;
 
 #  endif
 
-template <size_t I, typename T> using tuple_element_t = typename tuple_element<I, T>::type;
+template <size_t I, typename T>
+using tuple_element_t = typename tuple_element<I, T>::type;
 
-template <typename...> class tuple;
+template <typename...>
+class tuple;
 
 UTL_NAMESPACE_END
 

--- a/include/utl/tuple/utl_tuple_latest.h
+++ b/include/utl/tuple/utl_tuple_latest.h
@@ -41,13 +41,13 @@
 // TODO: if std is included or forward declared use std, else use UTL
 namespace std {
 template <typename... Ts, typename... Us>
-    requires (... && requires { typename UTL_SCOPE common_type<Ts, Us>::type; })
+requires (... && requires { typename UTL_SCOPE common_type<Ts, Us>::type; })
 struct common_type<UTL_SCOPE tuple<Ts...>, UTL_SCOPE tuple<Us...>> {
     using type = UTL_SCOPE tuple<common_type_t<Ts, Us>...>;
 };
 template <typename... Ts, typename... Us, template <typename> class TQual,
     template <typename> class UQual>
-    requires (... && requires { typename UTL_SCOPE common_reference<TQual<Ts>, UQual<Us>>::type; })
+requires (... && requires { typename UTL_SCOPE common_reference<TQual<Ts>, UQual<Us>>::type; })
 struct basic_common_reference<UTL_SCOPE tuple<Ts...>, UTL_SCOPE tuple<Us...>, TQual, UQual> {
     using type = UTL_SCOPE tuple<UTL_SCOPE common_reference_t<TQual<Ts>, UQual<Us>>...>;
 };
@@ -68,11 +68,13 @@ consteval decltype(auto) conjunction_sequence(F&& func, index_sequence<Is...>) n
 }
 } // namespace details
 
-template <size_t N, typename F> consteval decltype(auto) disjunction_sequence(F&& func) noexcept {
+template <size_t N, typename F>
+consteval decltype(auto) disjunction_sequence(F&& func) noexcept {
     return details::disjunction_sequence(forward<F>(func), make_index_sequence<N>());
 }
 
-template <size_t N, typename F> consteval decltype(auto) conjunction_sequence(F&& func) noexcept {
+template <size_t N, typename F>
+consteval decltype(auto) conjunction_sequence(F&& func) noexcept {
     return details::conjunction_sequence(forward<F>(func), make_index_sequence<N>());
 }
 } // namespace utility
@@ -80,7 +82,8 @@ template <size_t N, typename F> consteval decltype(auto) conjunction_sequence(F&
 namespace details {
 namespace tuple {
 
-template <typename...> struct invalid_swap_t {
+template <typename...>
+struct invalid_swap_t {
     inline constexpr void swap(invalid_swap_t& other) const noexcept {}
     inline constexpr void swap(invalid_swap_t const& other) const noexcept {}
 
@@ -88,23 +91,28 @@ private:
     ~invalid_swap_t() = default;
 };
 
-template <typename...> struct storage;
-template <size_t I, typename T, typename = void> struct offset_impl;
+template <typename...>
+struct storage;
+template <size_t I, typename T, typename = void>
+struct offset_impl;
 struct invalid_t {
 private:
     ~invalid_t() = default;
 };
 
-template <> struct storage<> {
+template <>
+struct storage<> {
     constexpr storage() noexcept = default;
-    constexpr storage& operator= (storage const&) noexcept = default;
-    constexpr storage& operator= (storage&&) noexcept = default;
+    constexpr storage& operator=(storage const&) noexcept = default;
+    constexpr storage& operator=(storage&&) noexcept = default;
     constexpr void     swap(storage<>& other) noexcept {}
 };
 
-template <typename T> struct storage<T> : variadic_traits<T> {
+template <typename T>
+struct storage<T> : variadic_traits<T> {
 public:
-    template <typename U> using not_this = is_same<storage<T>, remove_cvref_t<U>>;
+    template <typename U>
+    using not_this = is_same<storage<T>, remove_cvref_t<U>>;
     using traits = variadic_traits<T>;
     using head_type = T;
     using move_assign_t = conditional_t<traits::is_move_assignable, invalid_t, storage>;
@@ -112,25 +120,25 @@ public:
 
     constexpr storage() noexcept(traits::is_nothrow_default_constructible) = default;
     constexpr storage(storage const&) noexcept(traits::is_nothrow_copy_constructible) = default;
-    constexpr storage& operator= (storage const&) noexcept(
+    constexpr storage& operator=(storage const&) noexcept(
         traits::is_nothrow_copy_assignable) = default;
 
 #ifdef UTL_ENFORCE_NONMOVABILIITY
     constexpr storage(move_construct_t&&) noexcept(traits::is_nothrow_move_constructible) = delete;
-    constexpr storage& operator= (move_assign_t&&) noexcept(
+    constexpr storage& operator=(move_assign_t&&) noexcept(
         traits::is_nothrow_move_assignable) = delete;
 #else
     constexpr storage(storage&&) noexcept(traits::is_nothrow_move_constructible) = default;
-    constexpr storage& operator= (storage&&) noexcept(traits::is_nothrow_move_assignable) = default;
+    constexpr storage& operator=(storage&&) noexcept(traits::is_nothrow_move_assignable) = default;
 #endif
 
     template <typename U>
-        requires (!not_this<U>::value)
+    requires (!not_this<U>::value)
     constexpr storage(U&& head) noexcept(traits::template is_nothrow_constructible<U>::value)
         : head(forward<U>(head)) {}
 
     template <typename Alloc>
-        requires UTL_SCOPE
+    requires UTL_SCOPE
     uses_allocator<T, Alloc>::value&&
         UTL_SCOPE is_constructible<T, allocator_arg_t, Alloc const&>::value constexpr storage(
             allocator_arg_t, Alloc const& alloc) noexcept(requires(Alloc const& a) {
@@ -139,7 +147,7 @@ public:
         : head(allocator_arg, alloc) {}
 
     template <typename Alloc>
-        requires UTL_SCOPE
+    requires UTL_SCOPE
     uses_allocator<T, Alloc>::value &&
         (!UTL_SCOPE is_constructible<T, allocator_arg_t, Alloc const&>::value) &&
         UTL_SCOPE is_constructible<T, Alloc const&>::value
@@ -149,13 +157,13 @@ public:
         : head(alloc) {}
 
     template <typename Alloc>
-        requires (!UTL_SCOPE uses_allocator<T, Alloc>::value)
+    requires (!UTL_SCOPE uses_allocator<T, Alloc>::value)
     constexpr storage(allocator_arg_t, Alloc const& alloc) noexcept(requires {
         { T() } noexcept;
     }) : head() {}
 
     template <typename Alloc, typename U>
-        requires UTL_SCOPE
+    requires UTL_SCOPE
     uses_allocator<T, Alloc>::value&&
         UTL_SCOPE is_constructible<T, allocator_arg_t, Alloc const&, U>::value constexpr storage(
             allocator_arg_t, Alloc const& alloc,
@@ -165,7 +173,7 @@ public:
         : head(allocator_arg, alloc, forward<U>(other_head)) {}
 
     template <typename Alloc, typename U>
-        requires UTL_SCOPE
+    requires UTL_SCOPE
     uses_allocator<T, Alloc>::value &&
         (!UTL_SCOPE is_constructible<T, allocator_arg_t, Alloc const&, U>::value) &&
         UTL_SCOPE is_constructible<T, Alloc const&, U>::value constexpr storage(allocator_arg_t,
@@ -175,7 +183,7 @@ public:
         : head(forward<U>(other_head), alloc) {}
 
     template <typename Alloc, typename U>
-        requires (!UTL_SCOPE uses_allocator<T, Alloc>::value)
+    requires (!UTL_SCOPE uses_allocator<T, Alloc>::value)
     constexpr storage(allocator_arg_t, Alloc const& alloc, U&& other_head) noexcept(
         requires(U&& u) {
             { T(forward<U>(u)) } noexcept;
@@ -223,25 +231,25 @@ public:
     }
 
     template <size_t I>
-        requires (I == 0)
+    requires (I == 0)
     UTL_ATTRIBUTES(NODISCARD, CONST) constexpr auto get() && noexcept -> T&& {
         return move(head);
     }
 
     template <size_t I>
-        requires (I == 0)
+    requires (I == 0)
     UTL_ATTRIBUTES(NODISCARD, CONST) constexpr auto get() & noexcept -> T& {
         return head;
     }
 
     template <size_t I>
-        requires (I == 0)
+    requires (I == 0)
     UTL_ATTRIBUTES(NODISCARD, CONST) constexpr auto get() const&& noexcept -> T const&& {
         return move(head);
     }
 
     template <size_t I>
-        requires (I == 0)
+    requires (I == 0)
     UTL_ATTRIBUTES(NODISCARD, CONST) constexpr auto get() const& noexcept -> T const& {
         return head;
     }
@@ -249,7 +257,8 @@ public:
     UTL_ATTRIBUTE(NO_UNIQUE_ADDRESS) head_type head;
 };
 
-template <typename T, typename... Tail> struct storage<T, Tail...> : variadic_traits<T, Tail...> {
+template <typename T, typename... Tail>
+struct storage<T, Tail...> : variadic_traits<T, Tail...> {
     using traits = variadic_traits<T, Tail...>;
     using head_type = T;
     using tail_type = storage<Tail...>;
@@ -258,20 +267,20 @@ template <typename T, typename... Tail> struct storage<T, Tail...> : variadic_tr
 
     constexpr storage() noexcept(traits::is_nothrow_default_constructible) = default;
     constexpr storage(storage const&) noexcept(traits::is_nothrow_copy_constructible) = default;
-    constexpr storage& operator= (storage const&) noexcept(
+    constexpr storage& operator=(storage const&) noexcept(
         traits::is_nothrow_copy_assignable) = default;
 
 #ifdef UTL_ENFORCE_NONMOVABILIITY
     constexpr storage(move_construct_t&&) noexcept(traits::is_nothrow_move_constructible) = delete;
-    constexpr storage& operator= (move_assign_t&&) noexcept(
+    constexpr storage& operator=(move_assign_t&&) noexcept(
         traits::is_nothrow_move_assignable) = delete;
 #else
     constexpr storage(storage&&) noexcept(traits::is_nothrow_move_constructible) = default;
-    constexpr storage& operator= (storage&&) noexcept(traits::is_nothrow_move_assignable) = default;
+    constexpr storage& operator=(storage&&) noexcept(traits::is_nothrow_move_assignable) = default;
 #endif
 
     template <typename UHead, typename... UTail>
-        requires (sizeof...(UTail) == sizeof...(Tail))
+    requires (sizeof...(UTail) == sizeof...(Tail))
     constexpr storage(UHead&& other_head, UTail&&... other_tail) noexcept(
         requires(UHead&& h, UTail&&... ts) {
             { head_type(forward<UHead>(h)) } noexcept;
@@ -281,7 +290,7 @@ template <typename T, typename... Tail> struct storage<T, Tail...> : variadic_tr
         , tail(forward<UTail>(other_tail)...) {}
 
     template <typename Alloc>
-        requires UTL_SCOPE
+    requires UTL_SCOPE
     uses_allocator<T, Alloc>::value&&
         UTL_SCOPE is_constructible<T, allocator_arg_t, Alloc const&>::value constexpr storage(
             allocator_arg_t, Alloc const& alloc) noexcept(requires(Alloc const& a) {
@@ -292,7 +301,7 @@ template <typename T, typename... Tail> struct storage<T, Tail...> : variadic_tr
         , tail(allocator_arg, alloc) {}
 
     template <typename Alloc>
-        requires UTL_SCOPE
+    requires UTL_SCOPE
     uses_allocator<T, Alloc>::value &&
         (!UTL_SCOPE is_constructible<T, allocator_arg_t, Alloc const&>::value) &&
         UTL_SCOPE is_constructible<T, Alloc const&>::value
@@ -304,7 +313,7 @@ template <typename T, typename... Tail> struct storage<T, Tail...> : variadic_tr
         , tail(allocator_arg, alloc) {}
 
     template <typename Alloc>
-        requires (!UTL_SCOPE uses_allocator<T, Alloc>::value)
+    requires (!UTL_SCOPE uses_allocator<T, Alloc>::value)
     constexpr storage(allocator_arg_t, Alloc const& alloc) noexcept(requires(Alloc const& a) {
         { head_type() } noexcept;
         { tail_type(allocator_arg, a) } noexcept;
@@ -312,7 +321,7 @@ template <typename T, typename... Tail> struct storage<T, Tail...> : variadic_tr
        , tail(allocator_arg, alloc) {}
 
     template <typename Alloc, typename UHead, typename... UTail>
-        requires UTL_SCOPE
+    requires UTL_SCOPE
     uses_allocator<T, Alloc>::value&& UTL_SCOPE
         is_constructible<T, allocator_arg_t, Alloc const&, UHead>::value constexpr storage(
             allocator_arg_t, Alloc const& alloc, UHead&& other_head,
@@ -324,7 +333,7 @@ template <typename T, typename... Tail> struct storage<T, Tail...> : variadic_tr
         , tail(allocator_arg, alloc, forward<UTail>(other_tail)...) {}
 
     template <typename Alloc, typename UHead, typename... UTail>
-        requires UTL_SCOPE
+    requires UTL_SCOPE
     uses_allocator<T, Alloc>::value &&
         (!UTL_SCOPE is_constructible<T, allocator_arg_t, Alloc const&, UHead>::value) &&
         UTL_SCOPE is_constructible<T, UHead, Alloc const&>::value
@@ -337,7 +346,7 @@ template <typename T, typename... Tail> struct storage<T, Tail...> : variadic_tr
         , tail(allocator_arg, alloc, forward<UTail>(other_tail)...) {}
 
     template <typename Alloc, typename UHead, typename... UTail>
-        requires (!UTL_SCOPE uses_allocator<T, Alloc>::value)
+    requires (!UTL_SCOPE uses_allocator<T, Alloc>::value)
     constexpr storage(allocator_arg_t, Alloc const& alloc, UHead&& other_head,
         UTail&&... other_tail) noexcept(requires(Alloc const& a, UHead&& h, UTail&&... ts) {
         { head_type(forward<UHead>(h)) } noexcept;
@@ -390,56 +399,56 @@ template <typename T, typename... Tail> struct storage<T, Tail...> : variadic_tr
     }
 
     template <size_t I>
-        requires (I == 0)
+    requires (I == 0)
     UTL_ATTRIBUTES(NODISCARD, CONST) constexpr auto get() && noexcept UTL_ATTRIBUTE(LIFETIMEBOUND)
         -> T&& {
         return move(head);
     }
 
     template <size_t I>
-        requires (I == 0)
+    requires (I == 0)
     UTL_ATTRIBUTES(NODISCARD, CONST) constexpr auto get() & noexcept UTL_ATTRIBUTE(LIFETIMEBOUND)
         -> T& {
         return head;
     }
 
     template <size_t I>
-        requires (I == 0)
+    requires (I == 0)
     UTL_ATTRIBUTES(NODISCARD, CONST) constexpr auto get() const&& noexcept
         UTL_ATTRIBUTE(LIFETIMEBOUND) -> T const&& {
         return move(head);
     }
 
     template <size_t I>
-        requires (I == 0)
+    requires (I == 0)
     UTL_ATTRIBUTES(NODISCARD, CONST) constexpr auto get() const& noexcept
         UTL_ATTRIBUTE(LIFETIMEBOUND) -> T const& {
         return head;
     }
 
     template <size_t I>
-        requires (I > 0) && (I < traits::size)
+    requires (I > 0) && (I < traits::size)
     UTL_ATTRIBUTES(NODISCARD, CONST, FLATTEN) constexpr auto get() && noexcept
         UTL_ATTRIBUTE(LIFETIMEBOUND) -> template_element_t<I, storage>&& {
         return move(tail).template get<I - 1>();
     }
 
     template <size_t I>
-        requires (I > 0) && (I < traits::size)
+    requires (I > 0) && (I < traits::size)
     UTL_ATTRIBUTES(NODISCARD, CONST, FLATTEN) constexpr auto get() & noexcept
         UTL_ATTRIBUTE(LIFETIMEBOUND) -> template_element_t<I, storage>& {
         return tail.template get<I - 1>();
     }
 
     template <size_t I>
-        requires (I > 0) && (I < traits::size)
+    requires (I > 0) && (I < traits::size)
     UTL_ATTRIBUTES(NODISCARD, CONST, FLATTEN) constexpr auto get() const&& noexcept
         UTL_ATTRIBUTE(LIFETIMEBOUND) -> template_element_t<I, storage> const&& {
         return move(tail).template get<I - 1>();
     }
 
     template <size_t I>
-        requires (I > 0) && (I < traits::size)
+    requires (I > 0) && (I < traits::size)
     UTL_ATTRIBUTES(NODISCARD, CONST, FLATTEN) constexpr auto get() const& noexcept
         UTL_ATTRIBUTE(LIFETIMEBOUND) -> template_element_t<I, storage> const& {
         return tail.template get<I - 1>();
@@ -449,7 +458,8 @@ template <typename T, typename... Tail> struct storage<T, Tail...> : variadic_tr
     UTL_ATTRIBUTE(NO_UNIQUE_ADDRESS) tail_type tail;
 };
 
-template <typename... Ts> struct offset_impl<0, storage<Ts...>> {
+template <typename... Ts>
+struct offset_impl<0, storage<Ts...>> {
     using type = storage<Ts...>;
     static_assert(is_standard_layout<type>::value, "Must be standard layout");
     static constexpr size_t value = offsetof(type, head);
@@ -467,7 +477,8 @@ struct offset_impl<I, storage<T0, Ts...>, enable_if_t<(I > 0)>> {
 } // namespace tuple
 } // namespace details
 
-template <> class tuple<> : private details::tuple::storage<> {
+template <>
+class tuple<> : private details::tuple::storage<> {
 public:
     using storage::storage;
     using storage::operator=;
@@ -475,9 +486,11 @@ public:
     friend inline constexpr void swap(tuple const&, tuple const&) noexcept {}
 };
 
-template <typename... Types> class tuple : private details::tuple::storage<Types...> {
+template <typename... Types>
+class tuple : private details::tuple::storage<Types...> {
 private:
-    template <size_t I, typename T> friend struct tuple_element_offset;
+    template <size_t I, typename T>
+    friend struct tuple_element_offset;
 
     using base_type = details::tuple::storage<Types...>;
     using traits = typename base_type::traits;
@@ -489,7 +502,8 @@ private:
         conditional_t<traits::is_move_assignable, details::tuple::invalid_t, tuple>;
     using move_construct_t =
         conditional_t<traits::is_move_constructible, details::tuple::invalid_t, tuple>;
-    template <typename T> using not_this = negation<is_same<T, tuple>>;
+    template <typename T>
+    using not_this = negation<is_same<T, tuple>>;
     using base_type::get;
 
     template <typename TupleLike, size_t... Is>
@@ -522,28 +536,27 @@ private:
 
 public:
     constexpr tuple(tuple const&) noexcept(traits::is_nothrow_copy_constructible) = default;
-    constexpr tuple& operator= (tuple const&) noexcept(
-        traits::is_nothrow_copy_assignable) = default;
+    constexpr tuple& operator=(tuple const&) noexcept(traits::is_nothrow_copy_assignable) = default;
     constexpr tuple(tuple&&) noexcept(traits::is_nothrow_move_constructible) = default;
-    constexpr tuple& operator= (tuple&&) noexcept(traits::is_nothrow_move_assignable) = default;
+    constexpr tuple& operator=(tuple&&) noexcept(traits::is_nothrow_move_assignable) = default;
 
     UTL_CONSTEXPR_CXX20 ~tuple() = default;
 
     template <same_as<tuple> U = tuple>
-    constexpr tuple const& operator= (U const& other) const
+    constexpr tuple const& operator=(U const& other) const
         noexcept(noexcept(assign(other, index_sequence_for<Types...>{}))) {
         return assign(other, index_sequence_for<Types...>{});
     }
 
     template <same_as<tuple> U = tuple>
-    constexpr tuple const& operator= (U&& other) const
+    constexpr tuple const& operator=(U&& other) const
         noexcept(noexcept(assign(declval<U>(), index_sequence_for<Types...>{}))) {
         return assign(move(other), index_sequence_for<Types...>{});
     }
 
 public:
     template <same_as<Types>... Us>
-        requires traits::template
+    requires traits::template
     is_swappable_with<Us&...>::value constexpr void swap(tuple<Us...>& other) noexcept(
         traits::template is_nothrow_swappable_with<Us&...>::value) {
         static_assert(is_base_of<details::tuple::storage<Us...>, tuple<Us...>>::value,
@@ -552,7 +565,7 @@ public:
     }
 
     template <same_as<Types>... Us>
-        requires traits::template
+    requires traits::template
     is_const_swappable_with<Us const&...>::value constexpr void swap(
         tuple<Us...> const& other) const
         noexcept(traits::template is_nothrow_const_swappable_with<Us const&...>::value) {
@@ -586,7 +599,7 @@ public:
 
 public:
     template <typename UHead, typename... UTail>
-        requires (sizeof...(Types) == sizeof...(UTail) + 1) && traits::template
+    requires (sizeof...(Types) == sizeof...(UTail) + 1) && traits::template
     is_constructible<UHead, UTail...>::value &&
         (!traits::template is_dangling<UHead&&, UTail&&...>::value) explicit(
             traits::template is_explicit_constructible<UHead,
@@ -597,7 +610,7 @@ public:
         : base_type(forward<UHead>(head), forward<UTail>(tail)...) {}
 
     template <typename UHead, typename... UTail>
-        requires (sizeof...(Types) == sizeof...(UTail) + 1) && traits::template
+    requires (sizeof...(Types) == sizeof...(UTail) + 1) && traits::template
     is_constructible<UHead, UTail...>::value&&
         traits::template is_dangling<UHead&&, UTail&&...>::value explicit(
             traits::template is_explicit_constructible<UHead,
@@ -607,7 +620,7 @@ public:
 
 public:
     template <typename... UTypes>
-        requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
+    requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
     is_constructible<UTypes&...>::value &&
         (!traits::template is_dangling<UTypes&...>::value) explicit(
             traits::template is_explicit_constructible<
@@ -618,7 +631,7 @@ public:
         : tuple(other, index_sequence_for<UTypes...>{}) {}
 
     template <typename... UTypes>
-        requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
+    requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
     is_constructible<UTypes&...>::value&& traits::template is_dangling<UTypes&...>::value explicit(
         traits::template is_explicit_constructible<
             UTypes&...>::value) constexpr tuple(tuple<UTypes...>& other) noexcept((... &&
@@ -628,7 +641,7 @@ public:
 
 public:
     template <typename... UTypes>
-        requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
+    requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
     is_constructible<UTypes const&...>::value &&
         (!traits::template is_dangling<UTypes const&...>::value) explicit(
             traits::template is_explicit_constructible<UTypes const&...>::
@@ -639,7 +652,7 @@ public:
         : tuple(other, index_sequence_for<UTypes...>{}) {}
 
     template <typename... UTypes>
-        requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
+    requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
     is_constructible<UTypes const&...>::value&&
         traits::template is_dangling<UTypes const&...>::value explicit(
             traits::template is_explicit_constructible<
@@ -650,7 +663,7 @@ public:
 
 public:
     template <typename... UTypes>
-        requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
+    requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
     is_constructible<UTypes&&...>::value &&
         (!traits::template is_dangling<UTypes&&...>::value) explicit(
             traits::template is_explicit_constructible<
@@ -661,7 +674,7 @@ public:
         : tuple(move(other), index_sequence_for<UTypes...>{}) {}
 
     template <typename... UTypes>
-        requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
+    requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
     is_constructible<UTypes&&...>::value&&
         traits::template is_dangling<UTypes&&...>::value explicit(
             traits::template is_explicit_constructible<
@@ -675,14 +688,14 @@ public:
      * Non-standard overload
      */
     template <typename... UTypes>
-        requires (sizeof...(Types) == sizeof...(UTypes)) &&
+    requires (sizeof...(Types) == sizeof...(UTypes)) &&
         (!traits::template is_constructible<UTypes && ...>::value)
     constexpr tuple(tuple<UTypes...>&&) = delete;
 #endif
 
 public:
     template <typename... UTypes>
-        requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
+    requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
     is_constructible<UTypes const&&...>::value &&
         (!traits::template is_dangling<UTypes const&&...>::value) explicit(
             traits::template is_explicit_constructible<
@@ -693,7 +706,7 @@ public:
         : tuple(move(other), index_sequence_for<UTypes...>{}) {}
 
     template <typename... UTypes>
-        requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
+    requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
     is_constructible<UTypes const&&...>::value&&
         traits::template is_dangling<UTypes const&&...>::value explicit(
             traits::template is_explicit_constructible<UTypes const&&...>::
@@ -707,30 +720,30 @@ public:
      * Non-standard overload
      */
     template <typename... UTypes>
-        requires (sizeof...(Types) == sizeof...(UTypes)) &&
+    requires (sizeof...(Types) == sizeof...(UTypes)) &&
         (!traits::template is_constructible<UTypes const && ...>::value)
     constexpr tuple(tuple<UTypes...> const&&) = delete;
 #endif
 
 public:
     template <tuple_like TupleLike>
-        requires requires {
-            requires tuple_size<TupleLike>::value == sizeof...(Types);
-            requires !same_as<remove_cvref_t<TupleLike>, tuple>;
-            requires utility::conjunction_sequence<sizeof...(Types)>([](auto i) {
-                using constant_t = decltype(i);
-                using element_t = tuple_element_t<constant_t::value, tuple>;
-                return requires(TupleLike&& t) {
-                    { element_t(get<constant_t::value>(t)) };
-                };
-            });
-            requires utility::conjunction_sequence<sizeof...(Types)>([](auto i) {
-                using constant_t = decltype(i);
-                using element_t = tuple_element_t<constant_t::value, tuple>;
-                using param_t = decltype(TT_SCOPE decl_element<constant_t::value, TupleLike&&>());
-                return !reference_constructs_from_temporary<element_t, param_t>::value;
-            });
-        }
+    requires requires {
+        requires tuple_size<TupleLike>::value == sizeof...(Types);
+        requires !same_as<remove_cvref_t<TupleLike>, tuple>;
+        requires utility::conjunction_sequence<sizeof...(Types)>([](auto i) {
+            using constant_t = decltype(i);
+            using element_t = tuple_element_t<constant_t::value, tuple>;
+            return requires(TupleLike&& t) {
+                { element_t(get<constant_t::value>(t)) };
+            };
+        });
+        requires utility::conjunction_sequence<sizeof...(Types)>([](auto i) {
+            using constant_t = decltype(i);
+            using element_t = tuple_element_t<constant_t::value, tuple>;
+            using param_t = decltype(TT_SCOPE decl_element<constant_t::value, TupleLike&&>());
+            return !reference_constructs_from_temporary<element_t, param_t>::value;
+        });
+    }
     explicit(TT_SCOPE rebind_references_t<traits::template is_explicit_constructible, TupleLike,
         sizeof...(Types)>::value) constexpr tuple(TupleLike&& p) noexcept(requires(TupleLike&& t) {
         { tuple(forward<TupleLike>(t), index_sequence_for<Types...>{}) } noexcept;
@@ -738,13 +751,12 @@ public:
         : tuple(forward<TupleLike>(p), index_sequence_for<Types...>{}) {}
 
     template <tuple_like TupleLike>
-        requires requires {
-            requires tuple_size<TupleLike>::value == sizeof...(Types);
-            requires !same_as<remove_cvref_t<TupleLike>, tuple>;
-            requires TT_SCOPE
-                rebind_references_t<traits::template is_constructible, TupleLike>::value;
-            requires TT_SCOPE rebind_references_t<traits::template is_dangling, TupleLike>::value;
-        }
+    requires requires {
+        requires tuple_size<TupleLike>::value == sizeof...(Types);
+        requires !same_as<remove_cvref_t<TupleLike>, tuple>;
+        requires TT_SCOPE rebind_references_t<traits::template is_constructible, TupleLike>::value;
+        requires TT_SCOPE rebind_references_t<traits::template is_dangling, TupleLike>::value;
+    }
     explicit(TT_SCOPE rebind_references_t<traits::template is_explicit_constructible, TupleLike,
         sizeof...(Types)>::value) constexpr tuple(TupleLike&& p) noexcept(requires(TupleLike&& t) {
         { tuple(forward<TupleLike>(t), index_sequence_for<Types...>{}) } noexcept;
@@ -752,7 +764,7 @@ public:
 
 public:
     template <typename Alloc>
-        requires traits::template
+    requires traits::template
     is_constructible_with_allocator<Alloc>::value explicit(
         traits::template is_explicit_constructible_with_allocator<
             Alloc>::value) constexpr tuple(allocator_arg_t,
@@ -762,8 +774,7 @@ public:
 
 public:
     template <typename Alloc>
-        requires (
-            ... && traits::template is_constructible_with_allocator<Alloc, Types const&>::value)
+    requires (... && traits::template is_constructible_with_allocator<Alloc, Types const&>::value)
     explicit(traits::template is_explicit_constructible_with_allocator<Alloc,
         Types const&>::value) constexpr tuple(allocator_arg_t, Alloc const& alloc,
         Types const&... args) noexcept(traits::
@@ -772,7 +783,7 @@ public:
 
 public:
     template <typename Alloc, typename... UTypes>
-        requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
+    requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
     is_constructible_with_allocator<Alloc, UTypes...>::value&&
         traits::template is_explicit_constructible_with_allocator<Alloc, UTypes...>::value &&
         (!traits::template is_dangling_without_allocator<Alloc,
@@ -783,7 +794,7 @@ public:
         : base_type(allocator_arg, alloc, forward<UTypes>(args)...) {}
 
     template <typename Alloc, typename... UTypes>
-        requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
+    requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
     is_constructible_with_allocator<Alloc, UTypes...>::value&&
         traits::template is_implicit_constructible_with_allocator<Alloc, UTypes...>::value &&
         (!traits::template is_dangling_without_allocator<Alloc, UTypes...>::value) constexpr tuple(
@@ -794,7 +805,7 @@ public:
         : base_type(allocator_arg, alloc, forward<UTypes>(args)...) {}
 
     template <typename Alloc, typename... UTypes>
-        requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
+    requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
     is_constructible_with_allocator<Alloc, UTypes...>::value&&
             traits::template is_explicit_constructible_with_allocator<Alloc, UTypes...>::value&&
             traits::template is_dangling_without_allocator<Alloc,
@@ -804,7 +815,7 @@ public:
             }) = delete;
 
     template <typename Alloc, typename... UTypes>
-        requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
+    requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
     is_constructible_with_allocator<Alloc, UTypes...>::value&&
             traits::template is_implicit_constructible_with_allocator<Alloc, UTypes...>::value&&
             traits::template is_dangling_without_allocator<Alloc, UTypes...>::value constexpr tuple(
@@ -815,7 +826,7 @@ public:
 
 public:
     template <typename Alloc, typename... UTypes>
-        requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
+    requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
     is_constructible_with_allocator<Alloc, UTypes&...>::value &&
         (!traits::template is_dangling_without_allocator<Alloc, UTypes&...>::value) explicit(
             traits::template is_explicit_constructible_with_allocator<Alloc,
@@ -827,7 +838,7 @@ public:
         : tuple(allocator_arg, alloc, other, index_sequence_for<UTypes...>{}) {}
 
     template <typename Alloc, typename... UTypes>
-        requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
+    requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
     is_constructible_with_allocator<Alloc, UTypes&...>::value&&
         traits::template is_dangling_without_allocator<Alloc, UTypes&...>::value explicit(
             traits::template is_explicit_constructible_with_allocator<Alloc,
@@ -839,7 +850,7 @@ public:
 
 public:
     template <typename Alloc, typename... UTypes>
-        requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
+    requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
     is_constructible_with_allocator<Alloc, UTypes const&...>::value &&
         (!traits::template is_dangling_without_allocator<Alloc, UTypes const&...>::value) explicit(
             traits::template is_explicit_constructible_with_allocator<Alloc,
@@ -851,7 +862,7 @@ public:
         : tuple(allocator_arg, alloc, other, index_sequence_for<UTypes...>{}) {}
 
     template <typename Alloc, typename... UTypes>
-        requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
+    requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
     is_constructible_with_allocator<Alloc, UTypes const&...>::value&&
         traits::template is_dangling_without_allocator<Alloc, UTypes const&...>::value explicit(
             traits::template is_explicit_constructible_with_allocator<Alloc,
@@ -863,7 +874,7 @@ public:
 
 public:
     template <typename Alloc, typename... UTypes>
-        requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
+    requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
     is_constructible_with_allocator<Alloc, UTypes&&...>::value &&
         (!traits::template is_dangling_without_allocator<Alloc, UTypes&&...>::value) explicit(
             traits::template is_explicit_constructible_with_allocator<Alloc,
@@ -875,7 +886,7 @@ public:
         : tuple(allocator_arg, alloc, move(other), index_sequence_for<UTypes...>{}) {}
 
     template <typename Alloc, typename... UTypes>
-        requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
+    requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
     is_constructible_with_allocator<Alloc, UTypes&&...>::value&&
         traits::template is_dangling_without_allocator<Alloc, UTypes&&...>::value explicit(
             traits::template is_explicit_constructible_with_allocator<Alloc,
@@ -890,14 +901,14 @@ public:
      * Non-standard overload
      */
     template <typename Alloc, typename... UTypes>
-        requires (sizeof...(Types) == sizeof...(UTypes)) &&
+    requires (sizeof...(Types) == sizeof...(UTypes)) &&
         (!traits::template is_constructible_with_allocator<Alloc, UTypes && ...>::value)
     constexpr tuple(allocator_arg_t, Alloc const& alloc, tuple<UTypes...>&& other) = delete;
 #endif
 
 public:
     template <typename Alloc, typename... UTypes>
-        requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
+    requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
     is_constructible_with_allocator<Alloc, UTypes const&&...>::value &&
         (!traits::template is_dangling_without_allocator<Alloc, UTypes const&&...>::value) explicit(
             traits::template is_explicit_constructible_with_allocator<Alloc,
@@ -909,7 +920,7 @@ public:
         : tuple(allocator_arg, alloc, move(other), index_sequence_for<UTypes...>{}) {}
 
     template <typename Alloc, typename... UTypes>
-        requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
+    requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
     is_constructible_with_allocator<Alloc, UTypes const&&...>::value&&
         traits::template is_dangling_without_allocator<Alloc, UTypes const&&...>::value explicit(
             traits::template is_explicit_constructible_with_allocator<Alloc,
@@ -924,25 +935,23 @@ public:
      * Non-standard overload
      */
     template <typename Alloc, typename... UTypes>
-        requires (sizeof...(Types) == sizeof...(UTypes)) &&
+    requires (sizeof...(Types) == sizeof...(UTypes)) &&
         (!traits::template is_constructible_with_allocator<Alloc, UTypes const && ...>::value)
     constexpr tuple(allocator_arg_t, Alloc const& alloc, tuple<UTypes...> const&& other) = delete;
 #endif
 
 public:
     template <typename Alloc, tuple_like TupleLike>
-        requires requires {
-            requires tuple_size<TupleLike>::value == sizeof...(Types);
-            requires !same_as<remove_cvref_t<TupleLike>, tuple>;
-            requires TT_SCOPE
-                rebind_references_t<variadic_proxy<traits::template is_constructible_with_allocator,
-                                        Alloc>::template apply,
-                    TupleLike>::value;
-            requires !TT_SCOPE rebind_references_t<
-                variadic_proxy<traits::template is_dangling_without_allocator,
-                    Alloc>::template apply,
-                TupleLike>::value;
-        }
+    requires requires {
+        requires tuple_size<TupleLike>::value == sizeof...(Types);
+        requires !same_as<remove_cvref_t<TupleLike>, tuple>;
+        requires TT_SCOPE rebind_references_t<
+            variadic_proxy<traits::template is_constructible_with_allocator, Alloc>::template apply,
+            TupleLike>::value;
+        requires !TT_SCOPE rebind_references_t<
+            variadic_proxy<traits::template is_dangling_without_allocator, Alloc>::template apply,
+            TupleLike>::value;
+    }
     explicit(TT_SCOPE rebind_references_t<
         variadic_proxy<traits::template is_explicit_constructible_with_allocator,
             Alloc>::template apply,
@@ -955,18 +964,16 @@ public:
         : tuple(allocator_arg, alloc, forward<TupleLike>(other), index_sequence_for<Types...>{}) {}
 
     template <typename Alloc, tuple_like TupleLike>
-        requires requires {
-            requires tuple_size<TupleLike>::value == sizeof...(Types);
-            requires !same_as<remove_cvref_t<TupleLike>, tuple>;
-            requires TT_SCOPE
-                rebind_references_t<variadic_proxy<traits::template is_constructible_with_allocator,
-                                        Alloc>::template apply,
-                    TupleLike>::value;
-            requires TT_SCOPE
-                rebind_references_t<variadic_proxy<traits::template is_dangling_without_allocator,
-                                        Alloc>::template apply,
-                    TupleLike>::value;
-        }
+    requires requires {
+        requires tuple_size<TupleLike>::value == sizeof...(Types);
+        requires !same_as<remove_cvref_t<TupleLike>, tuple>;
+        requires TT_SCOPE rebind_references_t<
+            variadic_proxy<traits::template is_constructible_with_allocator, Alloc>::template apply,
+            TupleLike>::value;
+        requires TT_SCOPE rebind_references_t<
+            variadic_proxy<traits::template is_dangling_without_allocator, Alloc>::template apply,
+            TupleLike>::value;
+    }
     explicit(TT_SCOPE rebind_references_t<
         variadic_proxy<traits::template is_explicit_constructible_with_allocator,
             Alloc>::template apply,
@@ -979,7 +986,7 @@ public:
 
 public:
     template <typename Alloc>
-        requires traits::template
+    requires traits::template
     is_constructible_with_allocator<Alloc, Types const&...>::value constexpr tuple(allocator_arg_t,
         Alloc const& alloc,
         tuple const& other) noexcept(requires(Alloc const& alloc, tuple const& other) {
@@ -988,7 +995,7 @@ public:
         : tuple(allocator_arg, alloc, other, index_sequence_for<Types...>{}) {}
 
     template <typename Alloc>
-        requires traits::template
+    requires traits::template
     is_constructible_with_allocator<Alloc, Types&&...>::value constexpr tuple(allocator_arg_t,
         Alloc const& alloc, tuple&& other) noexcept(requires(Alloc const& alloc, tuple&& other) {
         { tuple(allocator_arg, alloc, move(other), index_sequence_for<Types...>{}) } noexcept;
@@ -996,7 +1003,7 @@ public:
         : tuple(allocator_arg, alloc, move(other), index_sequence_for<Types...>{}) {}
 
     template <typename Alloc>
-        requires traits::template
+    requires traits::template
     is_constructible_with_allocator<Alloc, Types const&&...>::value constexpr tuple(allocator_arg_t,
         Alloc const&  alloc,
         tuple const&& other) noexcept(requires(Alloc const& alloc, tuple const&& other) {
@@ -1006,8 +1013,8 @@ public:
 
 public:
     template <typename... UTypes>
-        requires traits::template
-    is_assignable<UTypes const&...>::value constexpr tuple& operator= (
+    requires traits::template
+    is_assignable<UTypes const&...>::value constexpr tuple& operator=(
         tuple<UTypes...> const& other) noexcept(requires(tuple& t, tuple<UTypes...> const& other) {
         { t.assign(other, index_sequence_for<Types...>{}) } noexcept;
     }) {
@@ -1015,8 +1022,8 @@ public:
     }
 
     template <assignable_from<Types const&>... UTypes>
-        requires traits::template
-    is_const_assignable<UTypes const&...>::value constexpr tuple const& operator= (
+    requires traits::template
+    is_const_assignable<UTypes const&...>::value constexpr tuple const& operator=(
         tuple<UTypes...> const& other) const
         noexcept(requires(tuple const& t, tuple<UTypes...> const& other) {
             { t.assign(other, index_sequence_for<Types...>{}) } noexcept;
@@ -1026,8 +1033,8 @@ public:
 
 public:
     template <typename... UTypes>
-        requires traits::template
-    is_assignable<UTypes&...>::value constexpr tuple& operator= (tuple<UTypes...>& other) noexcept(
+    requires traits::template
+    is_assignable<UTypes&...>::value constexpr tuple& operator=(tuple<UTypes...>& other) noexcept(
         requires(tuple& t, tuple<UTypes...>& other) {
             { t.assign(other, index_sequence_for<Types...>{}) } noexcept;
         }) {
@@ -1035,8 +1042,8 @@ public:
     }
 
     template <assignable_from<Types&>... UTypes>
-        requires traits::template
-    is_const_assignable<UTypes&...>::value constexpr tuple const& operator= (
+    requires traits::template
+    is_const_assignable<UTypes&...>::value constexpr tuple const& operator=(
         tuple<UTypes...>& other) const noexcept(requires(tuple const& t, tuple<UTypes...>& other) {
         { t.assign(other, index_sequence_for<Types...>{}) } noexcept;
     }) {
@@ -1045,11 +1052,11 @@ public:
 
 public:
     template <typename... UTypes>
-        requires traits::template
-    is_assignable<UTypes&&...>::value constexpr tuple& operator= (
-        tuple<UTypes...>&& other) noexcept(requires(tuple& t, tuple<UTypes...>&& other) {
-        { t.assign(move(other), index_sequence_for<Types...>{}) } noexcept;
-    }) {
+    requires traits::template
+    is_assignable<UTypes&&...>::value constexpr tuple& operator=(tuple<UTypes...>&& other) noexcept(
+        requires(tuple& t, tuple<UTypes...>&& other) {
+            { t.assign(move(other), index_sequence_for<Types...>{}) } noexcept;
+        }) {
         return assign(move(other), index_sequence_for<Types...>{});
     }
 
@@ -1057,13 +1064,13 @@ public:
      * Non-standard overload
      */
     template <typename... UTypes>
-        requires (!traits::template is_assignable<UTypes && ...>::value)
-    constexpr tuple& operator= (tuple<UTypes...>&& other) = delete;
+    requires (!traits::template is_assignable<UTypes && ...>::value)
+    constexpr tuple& operator=(tuple<UTypes...>&& other) = delete;
 
 public:
     template <typename... UTypes>
-        requires traits::template
-    is_const_assignable<UTypes&&...>::value constexpr tuple const& operator= (
+    requires traits::template
+    is_const_assignable<UTypes&&...>::value constexpr tuple const& operator=(
         tuple<UTypes...>&& other) const
         noexcept(requires(tuple const& t, tuple<UTypes...>&& other) {
             { t.assign(move(other), index_sequence_for<Types...>{}) } noexcept;
@@ -1076,14 +1083,14 @@ public:
      * Non-standard overload
      */
     template <typename... UTypes>
-        requires (!traits::template is_const_assignable<UTypes && ...>::value)
-    constexpr tuple const& operator= (tuple<UTypes...>&& other) const = delete;
+    requires (!traits::template is_const_assignable<UTypes && ...>::value)
+    constexpr tuple const& operator=(tuple<UTypes...>&& other) const = delete;
 #endif
 
 public:
     template <typename... UTypes>
-        requires traits::template
-    is_assignable<UTypes const&&...>::value constexpr tuple& operator= (
+    requires traits::template
+    is_assignable<UTypes const&&...>::value constexpr tuple& operator=(
         tuple<UTypes...> const&& other) noexcept(requires(tuple& t,
         tuple<UTypes...> const&&                                 other) {
         { t.assign(move(other), index_sequence_for<Types...>{}) } noexcept;
@@ -1096,14 +1103,14 @@ public:
      * Non-standard overload
      */
     template <typename... UTypes>
-        requires (!traits::template is_assignable<UTypes const && ...>::value)
-    constexpr tuple& operator= (tuple<UTypes...> const&& other) = delete;
+    requires (!traits::template is_assignable<UTypes const && ...>::value)
+    constexpr tuple& operator=(tuple<UTypes...> const&& other) = delete;
 #endif
 
 public:
     template <typename... UTypes>
-        requires traits::template
-    is_const_assignable<UTypes const&&...>::value constexpr tuple const& operator= (
+    requires traits::template
+    is_const_assignable<UTypes const&&...>::value constexpr tuple const& operator=(
         tuple<UTypes...> const&& other) const
         noexcept(requires(tuple const& t, tuple<UTypes...> const&& other) {
             { t.assign(move(other), index_sequence_for<Types...>{}) } noexcept;
@@ -1116,32 +1123,32 @@ public:
      * Non-standard overload
      */
     template <typename... UTypes>
-        requires (!traits::template is_const_assignable<UTypes const && ...>::value)
-    constexpr tuple const& operator= (tuple<UTypes...> const&& other) const = delete;
+    requires (!traits::template is_const_assignable<UTypes const && ...>::value)
+    constexpr tuple const& operator=(tuple<UTypes...> const&& other) const = delete;
 #endif
 
 public:
     template <tuple_like TupleLike>
-        requires requires {
-            requires tuple_size<TupleLike>::value == sizeof...(Types);
-            requires !same_as<remove_cvref_t<TupleLike>, tuple>;
-            requires TT_SCOPE rebind_references_t<traits::template is_assignable, TupleLike,
-                sizeof...(Types)>::value;
-        }
-    constexpr tuple& operator= (TupleLike&& other) noexcept(requires(tuple& t, TupleLike&& other) {
+    requires requires {
+        requires tuple_size<TupleLike>::value == sizeof...(Types);
+        requires !same_as<remove_cvref_t<TupleLike>, tuple>;
+        requires TT_SCOPE
+            rebind_references_t<traits::template is_assignable, TupleLike, sizeof...(Types)>::value;
+    }
+    constexpr tuple& operator=(TupleLike&& other) noexcept(requires(tuple& t, TupleLike&& other) {
         { t.assign(forward<TupleLike>(other), index_sequence_for<Types...>{}) } noexcept;
     }) {
         return assign(forward<TupleLike>(other), index_sequence_for<Types...>{});
     }
 
     template <tuple_like TupleLike>
-        requires requires {
-            requires tuple_size<TupleLike>::value == sizeof...(Types);
-            requires !same_as<remove_cvref_t<TupleLike>, tuple>;
-            requires TT_SCOPE rebind_references_t<traits::template is_const_assignable, TupleLike,
-                sizeof...(Types)>::value;
-        }
-    constexpr tuple const& operator= (TupleLike&& other) const
+    requires requires {
+        requires tuple_size<TupleLike>::value == sizeof...(Types);
+        requires !same_as<remove_cvref_t<TupleLike>, tuple>;
+        requires TT_SCOPE rebind_references_t<traits::template is_const_assignable, TupleLike,
+            sizeof...(Types)>::value;
+    }
+    constexpr tuple const& operator=(TupleLike&& other) const
         noexcept(requires(tuple const& t, TupleLike&& other) {
             { t.assign(forward<TupleLike>(other), index_sequence_for<Types...>{}) } noexcept;
         }) {
@@ -1149,7 +1156,8 @@ public:
     }
 };
 
-template <size_t I, typename T> struct tuple_element_offset;
+template <size_t I, typename T>
+struct tuple_element_offset;
 
 template <size_t I, typename... Ts>
 struct tuple_element_offset<I, tuple<Ts...>> :

--- a/include/utl/tuple/utl_tuple_traits.h
+++ b/include/utl/tuple/utl_tuple_traits.h
@@ -28,15 +28,23 @@ struct uses_allocator<UTL_SCOPE tuple<T...>, Alloc> : true_type {};
 } // namespace std
 
 UTL_NAMESPACE_BEGIN
-template <typename T> struct is_tuple : false_type {};
-template <typename T> struct is_tuple<T&&> : is_tuple<T> {};
-template <typename T> struct is_tuple<T&> : is_tuple<T> {};
-template <typename T> struct is_tuple<T const> : is_tuple<T> {};
-template <typename T> struct is_tuple<T volatile> : is_tuple<T> {};
-template <typename T> struct is_tuple<T const volatile> : is_tuple<T> {};
-template <typename... T> struct is_tuple<tuple<T...>> : true_type {};
+template <typename T>
+struct is_tuple : false_type {};
+template <typename T>
+struct is_tuple<T&&> : is_tuple<T> {};
+template <typename T>
+struct is_tuple<T&> : is_tuple<T> {};
+template <typename T>
+struct is_tuple<T const> : is_tuple<T> {};
+template <typename T>
+struct is_tuple<T volatile> : is_tuple<T> {};
+template <typename T>
+struct is_tuple<T const volatile> : is_tuple<T> {};
+template <typename... T>
+struct is_tuple<tuple<T...>> : true_type {};
 
-template <typename T> using tuple_index_sequence = make_index_sequence<tuple_size<T>::value>;
+template <typename T>
+using tuple_index_sequence = make_index_sequence<tuple_size<T>::value>;
 
 namespace tuple_traits {
 namespace details {
@@ -56,24 +64,36 @@ template <size_t I, typename T UTL_REQUIRES_CXX11(sizeof(::std::tuple_element<I,
 UTL_REQUIRES_CXX20(sizeof(::std::tuple_element<I, T>) > 0)
 auto element_impl(int) noexcept -> ::std::tuple_element<I, T>;
 
-template <size_t I, typename T> auto element_impl(...) noexcept -> invalid_element_t;
+template <size_t I, typename T>
+auto element_impl(...) noexcept -> invalid_element_t;
 } // namespace details
 } // namespace tuple_traits
 
-template <typename T> struct tuple_size : decltype(tuple_traits::details::size_impl<T>(0)) {};
-template <typename T> struct tuple_size<T const> : tuple_size<T> {};
-template <typename T> struct tuple_size<T volatile> : tuple_size<T> {};
-template <typename T> struct tuple_size<T const volatile> : tuple_size<T> {};
-template <typename T> struct tuple_size<T&&> : tuple_size<T> {};
-template <typename T> struct tuple_size<T&> : tuple_size<T> {};
+template <typename T>
+struct tuple_size : decltype(tuple_traits::details::size_impl<T>(0)) {};
+template <typename T>
+struct tuple_size<T const> : tuple_size<T> {};
+template <typename T>
+struct tuple_size<T volatile> : tuple_size<T> {};
+template <typename T>
+struct tuple_size<T const volatile> : tuple_size<T> {};
+template <typename T>
+struct tuple_size<T&&> : tuple_size<T> {};
+template <typename T>
+struct tuple_size<T&> : tuple_size<T> {};
 
 template <size_t I, typename T>
 struct tuple_element : decltype(tuple_traits::details::element_impl<I, T>(0)) {};
-template <size_t I, typename T> struct tuple_element<I, T const> : tuple_element<I, T> {};
-template <size_t I, typename T> struct tuple_element<I, T volatile> : tuple_element<I, T> {};
-template <size_t I, typename T> struct tuple_element<I, T const volatile> : tuple_element<I, T> {};
-template <size_t I, typename T> struct tuple_element<I, T&&> : tuple_element<I, T> {};
-template <size_t I, typename T> struct tuple_element<I, T&> : tuple_element<I, T> {};
+template <size_t I, typename T>
+struct tuple_element<I, T const> : tuple_element<I, T> {};
+template <size_t I, typename T>
+struct tuple_element<I, T volatile> : tuple_element<I, T> {};
+template <size_t I, typename T>
+struct tuple_element<I, T const volatile> : tuple_element<I, T> {};
+template <size_t I, typename T>
+struct tuple_element<I, T&&> : tuple_element<I, T> {};
+template <size_t I, typename T>
+struct tuple_element<I, T&> : tuple_element<I, T> {};
 
 namespace tuple_traits {
 namespace details {
@@ -81,7 +101,8 @@ template <size_t I, typename T UTL_REQUIRES_CXX11(I < tuple_size<T>::value)>
 UTL_REQUIRES_CXX20(I < tuple_size<T>::value)
 using result_t = copy_cvref_t<T&&, tuple_element_t<I, T>>;
 
-template <size_t I, typename T, typename = void> struct is_member_invocable : false_type {};
+template <size_t I, typename T, typename = void>
+struct is_member_invocable : false_type {};
 template <size_t I, typename T>
 struct is_member_invocable<I, T,
     enable_if_t<is_convertible<decltype(declval<T>().template get<I>()), result_t<I, T>>::value>> :
@@ -92,30 +113,33 @@ enable_if_t<is_member_invocable<I, T>::value, result_t<I, T>> get(T&& t) noexcep
     return t.template get<I>();
 }
 
-template <size_t I> struct get_cpo_t {
+template <size_t I>
+struct get_cpo_t {
     constexpr get_cpo_t() noexcept = default;
     template <typename T>
     UTL_ATTRIBUTES(NODISCARD, FLATTEN)
     constexpr enable_if_t<sizeof(get<I>(declval<T>())) && !is_tuple<T>::value, result_t<I, T>>
-    operator() (T&& t UTL_ATTRIBUTE(LIFETIMEBOUND)) const noexcept(noexcept(get<I>(declval<T>()))) {
+    operator()(T&& t UTL_ATTRIBUTE(LIFETIMEBOUND)) const noexcept(noexcept(get<I>(declval<T>()))) {
         return get<I>(forward<T>(t));
     }
 
     template <typename T>
     UTL_ATTRIBUTES(NODISCARD, FLATTEN, CONST)
     constexpr enable_if_t<sizeof(get<I>(declval<T>())) && is_tuple<T>::value, result_t<I, T>>
-    operator() (T&& t UTL_ATTRIBUTE(LIFETIMEBOUND)) const noexcept(noexcept(get<I>(declval<T>()))) {
+    operator()(T&& t UTL_ATTRIBUTE(LIFETIMEBOUND)) const noexcept(noexcept(get<I>(declval<T>()))) {
         return get<I>(forward<T>(t));
     }
 };
 
 } // namespace details
 
-template <size_t I, typename T> details::result_t<I, T> decl_element() noexcept;
+template <size_t I, typename T>
+details::result_t<I, T> decl_element() noexcept;
 
 #ifdef UTL_CXX14
 
-template <size_t I> UTL_INLINE_CXX17 constexpr details::get_cpo_t<I> get = {};
+template <size_t I>
+UTL_INLINE_CXX17 constexpr details::get_cpo_t<I> get = {};
 
 #else // ifdef UTL_CXX14
 
@@ -140,14 +164,17 @@ constexpr enable_if_t<is_tuple<T>::value, result_t<I, T>> get(
 namespace details {
 template <size_t I, typename T>
 auto nothrow_test(int) -> bool_constant<noexcept(UTL_SCOPE tuple_traits::get<I>(declval<T>()))>;
-template <size_t I, typename> auto nothrow_test(float) -> false_type;
+template <size_t I, typename>
+auto nothrow_test(float) -> false_type;
 
-template <size_t I, typename T, typename = void> struct is_callable : false_type {};
+template <size_t I, typename T, typename = void>
+struct is_callable : false_type {};
 template <size_t I, typename T>
 struct is_callable<I, T, void_t<decltype(UTL_SCOPE tuple_traits::get<I>(declval<T>()))>> :
     true_type {};
 
-template <size_t I, typename T> using is_nothrow = decltype(nothrow_test<I, T>(0));
+template <size_t I, typename T>
+using is_nothrow = decltype(nothrow_test<I, T>(0));
 } // namespace details
 
 template <size_t I, typename T>
@@ -162,7 +189,8 @@ template <typename TupleLike, size_t N = tuple_size<remove_cvref_t<TupleLike>>::
 struct is_all_gettable :
     conjunction<is_gettable<N - 1, TupleLike>, is_all_gettable<TupleLike, N - 1>> {};
 
-template <typename TupleLike> struct is_all_gettable<TupleLike, 0> : is_gettable<0, TupleLike> {};
+template <typename TupleLike>
+struct is_all_gettable<TupleLike, 0> : is_gettable<0, TupleLike> {};
 
 template <typename TupleLike, size_t N = tuple_size<remove_cvref_t<TupleLike>>::value>
 struct is_all_nothrow_gettable :
@@ -174,14 +202,16 @@ struct is_all_nothrow_gettable<TupleLike, 0> : is_nothrow_gettable<0, TupleLike>
 
 namespace details {
 
-template <typename T, typename = void> struct is_tuple_like_impl : false_type {};
+template <typename T, typename = void>
+struct is_tuple_like_impl : false_type {};
 
 template <typename T>
 struct is_tuple_like_impl<T, void_t<decltype(tuple_size<T>::value)>> :
     is_all_gettable<T, tuple_size<T>::value> {};
 } // namespace details
 
-template <typename T> struct is_tuple_like : details::is_tuple_like_impl<T> {};
+template <typename T>
+struct is_tuple_like : details::is_tuple_like_impl<T> {};
 
 namespace details {
 
@@ -241,9 +271,11 @@ struct rebind_elements {
     using type = rebind_elements_t<Target, TupleLike, N>;
 };
 
-template <typename... Ts> struct concat_elements;
+template <typename... Ts>
+struct concat_elements;
 
-template <typename... Ts> using concat_elements_t = typename concat_elements<Ts...>::type;
+template <typename... Ts>
+using concat_elements_t = typename concat_elements<Ts...>::type;
 
 namespace details {
 template <typename T0, typename T1, size_t... Is, size_t... Js>
@@ -264,7 +296,8 @@ template <typename T0, size_t... Is>
 auto concat_elements_helper(index_sequence<Is...>) noexcept
     -> UTL_SCOPE tuple<tuple_element_t<Is, T0>...>;
 
-template <typename T0> auto concat_elements_helper(index_sequence<>) noexcept -> UTL_SCOPE tuple<>;
+template <typename T0>
+auto concat_elements_helper(index_sequence<>) noexcept -> UTL_SCOPE tuple<>;
 
 template <typename T0, typename T1>
 auto concat_elements_helper() noexcept -> decltype(concat_elements_helper<T0, T1>(
@@ -275,16 +308,19 @@ auto concat_elements_helper() noexcept
     -> decltype(concat_elements_helper<T0>(tuple_index_sequence<T0>{}));
 } // namespace details
 
-template <typename... Ts> struct concat_elements<UTL_SCOPE tuple<Ts...>> {
+template <typename... Ts>
+struct concat_elements<UTL_SCOPE tuple<Ts...>> {
     using type = UTL_SCOPE tuple<Ts...>;
 };
 
-template <typename T0> struct concat_elements<T0> {
+template <typename T0>
+struct concat_elements<T0> {
     static_assert(is_tuple_like<T0>::value, "Only tuple_like types can be concatenated");
     using type = decltype(details::concat_elements_helper<T0>());
 };
 
-template <typename T0, typename T1> struct concat_elements<T0, T1> {
+template <typename T0, typename T1>
+struct concat_elements<T0, T1> {
     static_assert(is_tuple_like<T0>::value, "Only tuple_like types can be concatenated");
     static_assert(is_tuple_like<T1>::value, "Only tuple_like types can be concatenated");
     using type = decltype(details::concat_elements_helper<T0, T1>());

--- a/include/utl/type_traits/utl_boolean_testable.h
+++ b/include/utl/type_traits/utl_boolean_testable.h
@@ -13,38 +13,49 @@ UTL_NAMESPACE_BEGIN
 namespace details {
 namespace bool_testable {
 
-template <typename T> struct is_boolean : false_type {};
+template <typename T>
+struct is_boolean : false_type {};
 
-template <> struct is_boolean<bool> : true_type {};
-template <> struct is_boolean<bool const> : true_type {};
-template <> struct is_boolean<bool volatile> : true_type {};
-template <> struct is_boolean<bool const volatile> : true_type {};
+template <>
+struct is_boolean<bool> : true_type {};
+template <>
+struct is_boolean<bool const> : true_type {};
+template <>
+struct is_boolean<bool volatile> : true_type {};
+template <>
+struct is_boolean<bool const volatile> : true_type {};
 
 /**
  *  These checks don't check the result of mixed types operations, only with boolean
  */
-template <typename T, typename = void> struct no_adl_and_l : true_type {};
+template <typename T, typename = void>
+struct no_adl_and_l : true_type {};
 template <typename T>
-struct no_adl_and_l<T, void_t<decltype(operator&& (declval<T>(), true))>> : false_type {};
-template <typename T, typename = void> struct no_adl_and_r : true_type {};
+struct no_adl_and_l<T, void_t<decltype(operator&&(declval<T>(), true))>> : false_type {};
+template <typename T, typename = void>
+struct no_adl_and_r : true_type {};
 template <typename T>
-struct no_adl_and_r<T, void_t<decltype(operator&& (true, declval<T>()))>> : false_type {};
-template <typename T, typename = void> struct no_adl_and_lr : true_type {};
+struct no_adl_and_r<T, void_t<decltype(operator&&(true, declval<T>()))>> : false_type {};
+template <typename T, typename = void>
+struct no_adl_and_lr : true_type {};
 template <typename T>
-struct no_adl_and_lr<T, void_t<decltype(operator&& (declval<T>(), declval<T>()))>> : false_type {};
+struct no_adl_and_lr<T, void_t<decltype(operator&&(declval<T>(), declval<T>()))>> : false_type {};
 template <typename T>
 using no_adl_and = conjunction<no_adl_and_l<T>, no_adl_and_r<T>, no_adl_and_lr<T>>;
 
-template <typename T, typename = void> struct no_member_and_l : true_type {};
+template <typename T, typename = void>
+struct no_member_and_l : true_type {};
 template <typename T>
-struct no_member_and_l<T, void_t<decltype(declval<T>().operator&& (true))>> : false_type {};
-template <typename T, typename = void> struct no_member_and_lr : true_type {};
+struct no_member_and_l<T, void_t<decltype(declval<T>().operator&&(true))>> : false_type {};
+template <typename T, typename = void>
+struct no_member_and_lr : true_type {};
 template <typename T>
-struct no_member_and_lr<T, void_t<decltype(declval<T>().operator&& (declval<T>()))>> :
-    false_type {};
-template <typename T> using no_member_and = conjunction<no_member_and_l<T>, no_member_and_lr<T>>;
+struct no_member_and_lr<T, void_t<decltype(declval<T>().operator&&(declval<T>()))>> : false_type {};
+template <typename T>
+using no_member_and = conjunction<no_member_and_l<T>, no_member_and_lr<T>>;
 
-template <typename T, typename = void> struct has_native_and : false_type {};
+template <typename T, typename = void>
+struct has_native_and : false_type {};
 template <typename T>
 struct has_native_and<T,
     enable_if_t<conjunction<is_boolean<decltype(declval<T>() && true)>,
@@ -56,27 +67,34 @@ struct has_native_and<T,
 template <typename T>
 struct conjunctable : conjunction<no_adl_and<T>, no_member_and<T>, has_native_and<T>> {};
 
-template <typename T, typename = void> struct no_adl_or_l : true_type {};
+template <typename T, typename = void>
+struct no_adl_or_l : true_type {};
 template <typename T>
-struct no_adl_or_l<T, void_t<decltype(operator|| (declval<T>(), true))>> : false_type {};
-template <typename T, typename = void> struct no_adl_or_r : true_type {};
+struct no_adl_or_l<T, void_t<decltype(operator||(declval<T>(), true))>> : false_type {};
+template <typename T, typename = void>
+struct no_adl_or_r : true_type {};
 template <typename T>
-struct no_adl_or_r<T, void_t<decltype(operator|| (true, declval<T>()))>> : false_type {};
-template <typename T, typename = void> struct no_adl_or_lr : true_type {};
+struct no_adl_or_r<T, void_t<decltype(operator||(true, declval<T>()))>> : false_type {};
+template <typename T, typename = void>
+struct no_adl_or_lr : true_type {};
 template <typename T>
-struct no_adl_or_lr<T, void_t<decltype(operator|| (declval<T>(), declval<T>()))>> : false_type {};
+struct no_adl_or_lr<T, void_t<decltype(operator||(declval<T>(), declval<T>()))>> : false_type {};
 template <typename T>
 using no_adl_or = conjunction<no_adl_or_l<T>, no_adl_or_r<T>, no_adl_or_lr<T>>;
 
-template <typename T, typename = void> struct no_member_or_l : true_type {};
+template <typename T, typename = void>
+struct no_member_or_l : true_type {};
 template <typename T>
-struct no_member_or_l<T, void_t<decltype(declval<T>().operator|| (true))>> : false_type {};
-template <typename T, typename = void> struct no_member_or_lr : true_type {};
+struct no_member_or_l<T, void_t<decltype(declval<T>().operator||(true))>> : false_type {};
+template <typename T, typename = void>
+struct no_member_or_lr : true_type {};
 template <typename T>
-struct no_member_or_lr<T, void_t<decltype(declval<T>().operator|| (declval<T>()))>> : false_type {};
-template <typename T> using no_member_or = conjunction<no_member_or_l<T>, no_member_or_lr<T>>;
+struct no_member_or_lr<T, void_t<decltype(declval<T>().operator||(declval<T>()))>> : false_type {};
+template <typename T>
+using no_member_or = conjunction<no_member_or_l<T>, no_member_or_lr<T>>;
 
-template <typename T, typename = void> struct has_native_or : false_type {};
+template <typename T, typename = void>
+struct has_native_or : false_type {};
 template <typename T>
 struct has_native_or<T,
     enable_if_t<conjunction<is_boolean<decltype(declval<T>() || false)>,
@@ -88,22 +106,28 @@ struct has_native_or<T,
 template <typename T>
 struct disjunctable : conjunction<no_adl_or<T>, no_member_or<T>, has_native_or<T>> {};
 
-template <typename T, typename = void> struct no_adl_neg : true_type {};
+template <typename T, typename = void>
+struct no_adl_neg : true_type {};
 template <typename T>
 struct no_adl_neg<T, void_t<decltype(operator!(declval<T>()))>> : false_type {};
 
-template <typename T, typename = void> struct no_member_neg : true_type {};
+template <typename T, typename = void>
+struct no_member_neg : true_type {};
 template <typename T>
 struct no_member_neg<T, void_t<decltype(declval<T>().operator!())>> : false_type {};
 
-template <typename T, typename = bool> struct has_native_neg : false_type {};
-template <typename T> struct has_native_neg<T, decltype(!declval<T>())> : true_type {};
+template <typename T, typename = bool>
+struct has_native_neg : false_type {};
+template <typename T>
+struct has_native_neg<T, decltype(!declval<T>())> : true_type {};
 
 template <typename T>
 struct negatable : conjunction<no_adl_neg<T>, no_member_neg<T>, has_native_neg<T>> {};
 
-template <typename T, typename = bool> struct castable : false_type {};
-template <typename T> struct castable<T, decltype(static_cast<bool>(declval<T>()))> : true_type {};
+template <typename T, typename = bool>
+struct castable : false_type {};
+template <typename T>
+struct castable<T, decltype(static_cast<bool>(declval<T>()))> : true_type {};
 
 } // namespace bool_testable
 } // namespace details

--- a/include/utl/type_traits/utl_common_reference.h
+++ b/include/utl/type_traits/utl_common_reference.h
@@ -61,32 +61,41 @@ struct basic_common_reference :
 template <typename T, typename U, template <typename> class TQual, template <typename> class UQual>
 using basic_common_reference_t = typename basic_common_reference<T, U, TQual, UQual>::type;
 
-template <typename...> struct common_reference;
+template <typename...>
+struct common_reference;
 
-template <typename... Ts> using common_reference_t = typename common_reference<Ts...>::type;
+template <typename... Ts>
+using common_reference_t = typename common_reference<Ts...>::type;
 
-template <> struct common_reference<> {};
-template <typename T> struct common_reference<T> {
+template <>
+struct common_reference<> {};
+template <typename T>
+struct common_reference<T> {
     using type = T;
 };
 
 namespace details {
 namespace common_reference {
 
-template <typename T> struct copy_cvref_from {
-    template <typename U> using apply = copy_cvref_t<T, U>;
+template <typename T>
+struct copy_cvref_from {
+    template <typename U>
+    using apply = copy_cvref_t<T, U>;
 };
 
-template <typename T0, typename T1, typename = void> struct ternary_result {};
+template <typename T0, typename T1, typename = void>
+struct ternary_result {};
 template <typename T0, typename T1>
 struct ternary_result<T0, T1,
     void_t<decltype(false ? declval<T0 (&)()>()() : declval<T1 (&)()>()())>> {
     using type = decltype(false ? declval<T0 (&)()>()() : declval<T1 (&)()>()());
 };
 
-template <typename T0, typename T1> using ternary_result_t = typename ternary_result<T0, T1>::type;
+template <typename T0, typename T1>
+using ternary_result_t = typename ternary_result<T0, T1>::type;
 
-template <typename T0, typename T1, typename = void> struct simple_common_ref;
+template <typename T0, typename T1, typename = void>
+struct simple_common_ref;
 
 template <typename T0, typename T1>
 using simple_common_ref_t = typename simple_common_ref<T0, T1>::type;
@@ -100,8 +109,10 @@ struct simple_common_ref<T0&, T1&,
 
 template <typename Target, typename... Ts>
 using all_convertible_to = conjunction<is_convertible<Ts, Target>...>;
-template <typename T> using rvalue_ref = add_rvalue_reference<remove_reference_t<T>>;
-template <typename T> using rvalue_ref_t = typename rvalue_ref<T>::type;
+template <typename T>
+using rvalue_ref = add_rvalue_reference<remove_reference_t<T>>;
+template <typename T>
+using rvalue_ref_t = typename rvalue_ref<T>::type;
 
 template <typename T0, typename T1>
 struct simple_common_ref<T0&&, T1&&,
@@ -119,9 +130,11 @@ template <typename T0, typename T1>
 struct simple_common_ref<T0&&, T1&, void_t<simple_common_ref_t<T1&, T0&&>> // void_t
     > : simple_common_ref<T1&, T0&&> {};
 
-template <typename...> struct first_type;
+template <typename...>
+struct first_type;
 
-template <> struct first_type<> {};
+template <>
+struct first_type<> {};
 
 template <typename T, typename... Ts>
 struct first_type<T, Ts...> : conditional_t<has_type<T>::value, T, first_type<Ts...>> {};
@@ -132,7 +145,8 @@ using impl = first_type<simple_common_ref<T, U>,
         copy_cvref_from<U>::template apply>, // basic_common_reference
     ternary_result<T, U>, common_type<T, U>>;
 
-template <typename List, typename = void> struct sfinae_gt_2 {};
+template <typename List, typename = void>
+struct sfinae_gt_2 {};
 
 template <typename T, typename U, typename... Vs>
 struct sfinae_gt_2<type_list<T, U, Vs...>, void_t<UTL_SCOPE common_reference_t<T, U>>> :

--- a/include/utl/type_traits/utl_common_type.h
+++ b/include/utl/type_traits/utl_common_type.h
@@ -10,7 +10,8 @@
 
 UTL_STD_NAMESPACE_BEGIN
 /* UTL_UNDEFINED_BEHAVIOUR */
-template <typename...> struct common_type;
+template <typename...>
+struct common_type;
 UTL_STD_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN

--- a/include/utl/type_traits/utl_constants.h
+++ b/include/utl/type_traits/utl_constants.h
@@ -9,28 +9,34 @@ UTL_NAMESPACE_BEGIN
 
 using size_t = decltype(sizeof(0));
 
-template <typename T, T N> struct integral_constant {
+template <typename T, T N>
+struct integral_constant {
     static constexpr T value = N;
     using value_type = T;
     using type = integral_constant;
-    constexpr            operator value_type () const noexcept { return N; }
-    constexpr value_type operator() () const noexcept { return N; }
+    constexpr            operator value_type() const noexcept { return N; }
+    constexpr value_type operator()() const noexcept { return N; }
 };
 
-template <typename T, T N> using value_constant = integral_constant<T, N>;
+template <typename T, T N>
+using value_constant = integral_constant<T, N>;
 
-template <size_t N> using size_constant = integral_constant<size_t, N>;
+template <size_t N>
+using size_constant = integral_constant<size_t, N>;
 
 using npos_type = size_constant<(size_t)-1>;
 
-template <bool B> using bool_constant = integral_constant<bool, B>;
+template <bool B>
+using bool_constant = integral_constant<bool, B>;
 using true_type = bool_constant<true>;
 using false_type = bool_constant<false>;
 
 #ifdef UTL_CXX14
-template <typename T, T N> UTL_INLINE_CXX17 constexpr T integral_constant_v = N;
+template <typename T, T N>
+UTL_INLINE_CXX17 constexpr T integral_constant_v = N;
 
-template <typename T, T N> UTL_INLINE_CXX17 constexpr T value_constant_v = N;
+template <typename T, T N>
+UTL_INLINE_CXX17 constexpr T value_constant_v = N;
 #endif
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_constructor_traits.h
+++ b/include/utl/type_traits/utl_constructor_traits.h
@@ -16,7 +16,8 @@ template <typename T, typename THead>
 auto implicit_test(int) -> conjunction<is_convertible<THead, T>, is_constructible<T, THead>>;
 template <typename T>
 auto implicit_test(int) -> decltype((declval<void(T)>()({}), is_default_constructible<T>{}));
-template <typename T, typename...> auto implicit_test(...) -> false_type;
+template <typename T, typename...>
+auto implicit_test(...) -> false_type;
 
 template <typename TTarget, typename... TArgs>
 using is_implicit = decltype(implicit_test<TTarget, TArgs...>(0));
@@ -34,7 +35,8 @@ auto explicit_test(int)
 template <typename T>
 auto explicit_test(int) -> conjunction<negation<decltype(implicit_test<T>(0))>,
     decltype((declval<void(T)>()(T{}), is_default_constructible<T>{}))>;
-template <typename T, typename...> auto explicit_test(...) -> false_type;
+template <typename T, typename...>
+auto explicit_test(...) -> false_type;
 
 template <typename TTarget, typename... TArgs>
 using is_explicit = decltype(explicit_test<TTarget, TArgs...>(0));

--- a/include/utl/type_traits/utl_copy_cvref.h
+++ b/include/utl/type_traits/utl_copy_cvref.h
@@ -7,14 +7,18 @@
 
 UTL_NAMESPACE_BEGIN
 
-template <typename From, typename To> struct copy_cvref : copy_cv<From, To> {};
-template <typename From, typename To> struct copy_cvref<From&, To> {
+template <typename From, typename To>
+struct copy_cvref : copy_cv<From, To> {};
+template <typename From, typename To>
+struct copy_cvref<From&, To> {
     using type = typename copy_cv<From, To>::type&;
 };
-template <typename From, typename To> struct copy_cvref<From&&, To> {
+template <typename From, typename To>
+struct copy_cvref<From&&, To> {
     using type = typename copy_cv<From, To>::type&&;
 };
 
-template <typename F, typename T> using copy_cvref_t = typename copy_cvref<F, T>::type;
+template <typename F, typename T>
+using copy_cvref_t = typename copy_cvref<F, T>::type;
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_copy_reference.h
+++ b/include/utl/type_traits/utl_copy_reference.h
@@ -6,16 +6,20 @@
 
 UTL_NAMESPACE_BEGIN
 
-template <typename From, typename To> struct copy_reference {
+template <typename From, typename To>
+struct copy_reference {
     using type = To;
 };
-template <typename From, typename To> struct copy_reference<From&&, To> {
+template <typename From, typename To>
+struct copy_reference<From&&, To> {
     using type = To&&;
 };
-template <typename From, typename To> struct copy_reference<From&, To> {
+template <typename From, typename To>
+struct copy_reference<From&, To> {
     using type = To&;
 };
 
-template <typename F, typename T> using copy_reference_t = typename copy_reference<F, T>::type;
+template <typename F, typename T>
+using copy_reference_t = typename copy_reference<F, T>::type;
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_copy_x_cv.h
+++ b/include/utl/type_traits/utl_copy_x_cv.h
@@ -6,35 +6,46 @@
 
 UTL_NAMESPACE_BEGIN
 
-template <typename From, typename To> struct copy_const {
+template <typename From, typename To>
+struct copy_const {
     using type = To;
 };
-template <typename From, typename To> struct copy_const<From const, To> {
+template <typename From, typename To>
+struct copy_const<From const, To> {
     using type = To const;
 };
 
-template <typename From, typename To> struct copy_volatile {
+template <typename From, typename To>
+struct copy_volatile {
     using type = To;
 };
-template <typename From, typename To> struct copy_volatile<From volatile, To> {
+template <typename From, typename To>
+struct copy_volatile<From volatile, To> {
     using type = To volatile;
 };
 
-template <typename From, typename To> struct copy_cv {
+template <typename From, typename To>
+struct copy_cv {
     using type = To;
 };
-template <typename From, typename To> struct copy_cv<From const, To> {
+template <typename From, typename To>
+struct copy_cv<From const, To> {
     using type = To const;
 };
-template <typename From, typename To> struct copy_cv<From volatile, To> {
+template <typename From, typename To>
+struct copy_cv<From volatile, To> {
     using type = To volatile;
 };
-template <typename From, typename To> struct copy_cv<From const volatile, To> {
+template <typename From, typename To>
+struct copy_cv<From const volatile, To> {
     using type = To const volatile;
 };
 
-template <typename F, typename T> using copy_const_t = typename copy_const<F, T>::type;
-template <typename F, typename T> using copy_volatile_t = typename copy_volatile<F, T>::type;
-template <typename F, typename T> using copy_cv_t = typename copy_cv<F, T>::type;
+template <typename F, typename T>
+using copy_const_t = typename copy_const<F, T>::type;
+template <typename F, typename T>
+using copy_volatile_t = typename copy_volatile<F, T>::type;
+template <typename F, typename T>
+using copy_cv_t = typename copy_cv<F, T>::type;
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_copy_x_extent.h
+++ b/include/utl/type_traits/utl_copy_x_extent.h
@@ -6,17 +6,21 @@
 
 UTL_NAMESPACE_BEGIN
 
-template <typename From, typename To> struct copy_extent {
+template <typename From, typename To>
+struct copy_extent {
     using type = To;
 };
-template <typename From, typename To> struct copy_extent<From[], To> {
+template <typename From, typename To>
+struct copy_extent<From[], To> {
     using type = To[];
 };
-template <typename From, typename To, size_t N> struct copy_extent<From[N], To> {
+template <typename From, typename To, size_t N>
+struct copy_extent<From[N], To> {
     using type = To[N];
 };
 
-template <typename From, typename To> struct copy_all_extents {
+template <typename From, typename To>
+struct copy_all_extents {
     using type = To;
 };
 template <typename From, typename To>
@@ -24,7 +28,9 @@ struct copy_all_extents<From[], To> : copy_all_extents<From, To[]> {};
 template <typename From, typename To, size_t N>
 struct copy_all_extents<From[N], To> : copy_all_extents<From, To[N]> {};
 
-template <typename F, typename T> using copy_extent_t = typename copy_extent<F, T>::type;
-template <typename F, typename T> using copy_all_extents_t = typename copy_all_extents<F, T>::type;
+template <typename F, typename T>
+using copy_extent_t = typename copy_extent<F, T>::type;
+template <typename F, typename T>
+using copy_all_extents_t = typename copy_all_extents<F, T>::type;
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_copy_x_pointer.h
+++ b/include/utl/type_traits/utl_copy_x_pointer.h
@@ -6,20 +6,24 @@
 
 UTL_NAMESPACE_BEGIN
 
-template <typename From, typename To> struct copy_pointer {
+template <typename From, typename To>
+struct copy_pointer {
     using type = To;
 };
-template <typename From, typename To> struct copy_pointer<From*, To> {
+template <typename From, typename To>
+struct copy_pointer<From*, To> {
     using type = To*;
 };
 
-template <typename From, typename To> struct copy_all_pointers {
+template <typename From, typename To>
+struct copy_all_pointers {
     using type = To;
 };
 template <typename From, typename To>
 struct copy_all_pointers<From*, To> : copy_all_pointers<From, To*> {};
 
-template <typename F, typename T> using copy_pointer_t = typename copy_pointer<F, T>::type;
+template <typename F, typename T>
+using copy_pointer_t = typename copy_pointer<F, T>::type;
 template <typename F, typename T>
 using copy_all_pointers_t = typename copy_all_pointers<F, T>::type;
 

--- a/include/utl/type_traits/utl_decay.h
+++ b/include/utl/type_traits/utl_decay.h
@@ -18,7 +18,8 @@ using std::decay_t;
 
 #  else // UTL_CXX14
 
-template <typename T> using decay_t = typename decay<T>::type;
+template <typename T>
+using decay_t = typename decay<T>::type;
 
 #  endif // UTL_CXX14
 
@@ -38,11 +39,13 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct decay {
+template <typename T>
+struct decay {
     using type = UTL_BUILTIN_decay(T);
 };
 
-template <typename T> using decay_t = UTL_BUILTIN_decay(T);
+template <typename T>
+using decay_t = UTL_BUILTIN_decay(T);
 
 UTL_NAMESPACE_END
 
@@ -57,25 +60,30 @@ UTL_NAMESPACE_BEGIN
 
 namespace details {
 namespace type_traits {
-template <typename T, typename = void> struct decay_impl {
+template <typename T, typename = void>
+struct decay_impl {
     using type = remove_cv_t<T>;
 };
 
-template <typename T> struct decay_impl<T, enable_if_t<is_function<T>::value>> {
+template <typename T>
+struct decay_impl<T, enable_if_t<is_function<T>::value>> {
     using type = T*;
 };
 
-template <typename T> struct decay_impl<T[]> {
+template <typename T>
+struct decay_impl<T[]> {
     using type = T*;
 };
 
-template <typename T, size_t N> struct decay_impl<T[N]> {
+template <typename T, size_t N>
+struct decay_impl<T[N]> {
     using type = T*;
 };
 } // namespace type_traits
 } // namespace details
 
-template <typename T> struct decay : details::type_traits::decay_impl<remove_reference_t<T>> {};
+template <typename T>
+struct decay : details::type_traits::decay_impl<remove_reference_t<T>> {};
 
 using decay_t = typename details::type_traits::decay_impl<remove_reference_t<T>>::type;
 

--- a/include/utl/type_traits/utl_declval.h
+++ b/include/utl/type_traits/utl_declval.h
@@ -8,12 +8,15 @@ UTL_NAMESPACE_BEGIN
 
 namespace utility {
 namespace details {
-template <typename T> T&& declval_impl(int) noexcept;
+template <typename T>
+T&& declval_impl(int) noexcept;
 
-template <typename T> T declval_impl(float) noexcept;
+template <typename T>
+T declval_impl(float) noexcept;
 } // namespace details
 } // namespace utility
 
-template <typename T> auto declval() noexcept -> decltype(utility::details::declval_impl<T>(0));
+template <typename T>
+auto declval() noexcept -> decltype(utility::details::declval_impl<T>(0));
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_enable_if.h
+++ b/include/utl/type_traits/utl_enable_if.h
@@ -6,13 +6,16 @@
 
 UTL_NAMESPACE_BEGIN
 
-template <bool, typename = void> struct enable_if;
+template <bool, typename = void>
+struct enable_if;
 
-template <typename T> struct enable_if<true, T> {
+template <typename T>
+struct enable_if<true, T> {
     using type = T;
 };
 
-template <bool B, typename T = void> using enable_if_t = typename enable_if<B, T>::type;
+template <bool B, typename T = void>
+using enable_if_t = typename enable_if<B, T>::type;
 
 UTL_NAMESPACE_END
 

--- a/include/utl/type_traits/utl_extent.h
+++ b/include/utl/type_traits/utl_extent.h
@@ -47,11 +47,16 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T, size_t Dim> struct extent : size_constant<0> {};
-template <typename T> struct extent<T[], 0> : size_constant<0> {};
-template <typename T, size_t Dim> struct extent<T[], Dim> : extent<T, Dim - 1> {};
-template <typename T> struct extent<T[N], 0> : size_constant<N> {};
-template <typename T, size_t Dim> struct extent<T[N], Dim> : extent<T, Dim - 1> {};
+template <typename T, size_t Dim>
+struct extent : size_constant<0> {};
+template <typename T>
+struct extent<T[], 0> : size_constant<0> {};
+template <typename T, size_t Dim>
+struct extent<T[], Dim> : extent<T, Dim - 1> {};
+template <typename T>
+struct extent<T[N], 0> : size_constant<N> {};
+template <typename T, size_t Dim>
+struct extent<T[N], Dim> : extent<T, Dim - 1> {};
 
 UTL_IMPLEMENT_VALUE_TRAIT(extent, (typename, T), (size_t, Dim))
 

--- a/include/utl/type_traits/utl_has_type.h
+++ b/include/utl/type_traits/utl_has_type.h
@@ -9,16 +9,20 @@ UTL_NAMESPACE_BEGIN
 
 namespace type_traits {
 namespace details {
-template <typename T, typename = void> struct has_type_impl : false_type {};
+template <typename T, typename = void>
+struct has_type_impl : false_type {};
 
-template <typename T> struct has_type_impl<T, void_t<typename T::type>> : true_type {};
+template <typename T>
+struct has_type_impl<T, void_t<typename T::type>> : true_type {};
 } // namespace details
 } // namespace type_traits
 
-template <typename T> struct has_type : type_traits::details::has_type_impl<T> {};
+template <typename T>
+struct has_type : type_traits::details::has_type_impl<T> {};
 
 #ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool has_type_v = has_type<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool has_type_v = has_type<T>::value;
 #endif // UTL_CXX14
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_is_arithmetic.h
+++ b/include/utl/type_traits/utl_is_arithmetic.h
@@ -15,7 +15,8 @@ using std::is_arithmetic;
 #  ifdef UTL_CXX17
 using std::is_arithmetic_v;
 #  elif defined(UTL_CXX14) // ifdef UTL_CXX17
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_arithmetic_v = is_arithmetic<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_arithmetic_v = is_arithmetic<T>::value;
 #  endif                   // ifdef UTL_CXX17
 
 UTL_NAMESPACE_END
@@ -34,7 +35,8 @@ template <typename T>
 struct is_arithmetic : bool_constant<is_integral<T>::value || is_floating_point<T>::value> {};
 
 #  ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_arithmetic_v = is_arithmetic<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_arithmetic_v = is_arithmetic<T>::value;
 #  endif // UTL_CXX14
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_is_base_of.h
+++ b/include/utl/type_traits/utl_is_base_of.h
@@ -76,7 +76,8 @@ template <typename Base, typename Derive>
 struct is_base_of : type_traits::details::is_unambiguous_public_inheritance<Base, Derive> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_base_of_v = is_base_of<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_base_of_v = is_base_of<T>::value;
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_is_class.h
+++ b/include/utl/type_traits/utl_is_class.h
@@ -15,7 +15,8 @@ using std::is_class;
 #  ifdef UTL_CXX17
 using std::is_class_v;
 #  elif defined(UTL_CXX14) // ifdef UTL_CXX17
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_class_v = is_class<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_class_v = is_class<T>::value;
 #  endif                   // ifdef UTL_CXX17
 
 UTL_NAMESPACE_END
@@ -38,10 +39,12 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_class : bool_constant<UTL_BUILTIN_is_class(T)> {};
+template <typename T>
+struct is_class : bool_constant<UTL_BUILTIN_is_class(T)> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_class_v = UTL_BUILTIN_is_class(T);
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_class_v = UTL_BUILTIN_is_class(T);
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END
@@ -54,10 +57,12 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_class : undefined_trait<T> {};
+template <typename T>
+struct is_class : undefined_trait<T> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_class_v = is_class<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_class_v = is_class<T>::value;
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_is_complete.h
+++ b/include/utl/type_traits/utl_is_complete.h
@@ -12,9 +12,11 @@ namespace type_traits {
 namespace details {
 using size_t = decltype(sizeof(0));
 
-template <typename T, size_t = sizeof(T)> true_type is_complete(int);
+template <typename T, size_t = sizeof(T)>
+true_type is_complete(int);
 
-template <typename T> false_type is_complete(float);
+template <typename T>
+false_type is_complete(float);
 
 } // namespace details
 } // namespace type_traits

--- a/include/utl/type_traits/utl_is_compound.h
+++ b/include/utl/type_traits/utl_is_compound.h
@@ -15,7 +15,8 @@ using std::is_compound;
 #  ifdef UTL_CXX17
 using std::is_compound_v;
 #  elif defined(UTL_CXX14) // ifdef UTL_CXX17
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_compound_v = is_compund<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_compound_v = is_compund<T>::value;
 #  endif                   // ifdef UTL_CXX17
 
 UTL_NAMESPACE_END
@@ -38,10 +39,12 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_compound : bool_constant<UTL_BUILTIN_is_compound(T)> {};
+template <typename T>
+struct is_compound : bool_constant<UTL_BUILTIN_is_compound(T)> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_compound_v = UTL_BUILTIN_is_compound(T);
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_compound_v = UTL_BUILTIN_is_compound(T);
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END
@@ -54,10 +57,12 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_compound : bool_constant<!is_fundamental<T>::value> {};
+template <typename T>
+struct is_compound : bool_constant<!is_fundamental<T>::value> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_compound_v = is_compound<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_compound_v = is_compound<T>::value;
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_is_enum.h
+++ b/include/utl/type_traits/utl_is_enum.h
@@ -15,7 +15,8 @@ using std::is_enum;
 #  ifdef UTL_CXX17
 using std::is_enum_v;
 #  elif defined(UTL_CXX14) // ifdef UTL_CXX17
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_enum_v = is_enum<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_enum_v = is_enum<T>::value;
 #  endif                   // ifdef UTL_CXX17
 
 UTL_NAMESPACE_END
@@ -38,10 +39,12 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_enum : bool_constant<UTL_BUILTIN_is_enum(T)> {};
+template <typename T>
+struct is_enum : bool_constant<UTL_BUILTIN_is_enum(T)> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_enum_v = UTL_BUILTIN_is_enum(T);
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_enum_v = UTL_BUILTIN_is_enum(T);
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END
@@ -54,10 +57,12 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_enum : undefined_trait<T> {};
+template <typename T>
+struct is_enum : undefined_trait<T> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_enum_v = is_enum<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_enum_v = is_enum<T>::value;
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_is_floating_point.h
+++ b/include/utl/type_traits/utl_is_floating_point.h
@@ -39,7 +39,8 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_floating_point : bool_constant<UTL_BUILTIN_is_floating_point(T)> {};
+template <typename T>
+struct is_floating_point : bool_constant<UTL_BUILTIN_is_floating_point(T)> {};
 
 #    ifdef UTL_CXX14
 template <typename T>
@@ -52,14 +53,21 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_floating_point : false_type {};
+template <typename T>
+struct is_floating_point : false_type {};
 
-template <> struct is_floating_point<float> : true_type {};
-template <> struct is_floating_point<double> : true_type {};
-template <> struct is_floating_point<long double> : true_type {};
-template <typename T> struct is_floating_point<T const> : is_floating_point<T> {};
-template <typename T> struct is_floating_point<T volatile> : is_floating_point<T> {};
-template <typename T> struct is_floating_point<T const volatile> : is_floating_point<T> {};
+template <>
+struct is_floating_point<float> : true_type {};
+template <>
+struct is_floating_point<double> : true_type {};
+template <>
+struct is_floating_point<long double> : true_type {};
+template <typename T>
+struct is_floating_point<T const> : is_floating_point<T> {};
+template <typename T>
+struct is_floating_point<T volatile> : is_floating_point<T> {};
+template <typename T>
+struct is_floating_point<T const volatile> : is_floating_point<T> {};
 
 #    ifdef UTL_CXX14
 template <typename T>
@@ -79,23 +87,28 @@ UTL_NAMESPACE_END
 UTL_NAMESPACE_BEGIN
 #  ifdef UTL_SUPPORTS_FLOAT16
 using std::float16;
-template <> struct is_floating_point<float16> : true_type {};
+template <>
+struct is_floating_point<float16> : true_type {};
 #  endif // ifdef UTL_SUPPORTS_FLOAT16
 #  ifdef UTL_SUPPORTS_FLOAT32
 using std::float32;
-template <> struct is_floating_point<float32> : true_type {};
+template <>
+struct is_floating_point<float32> : true_type {};
 #  endif // ifdef UTL_SUPPORTS_FLOAT32
 #  ifdef UTL_SUPPORTS_FLOAT64
 using std::float64;
-template <> struct is_floating_point<float64> : true_type {};
+template <>
+struct is_floating_point<float64> : true_type {};
 #  endif // ifdef UTL_SUPPORTS_FLOAT64
 #  ifdef UTL_SUPPORTS_FLOAT128
 using std::float128;
-template <> struct is_floating_point<float128> : true_type {};
+template <>
+struct is_floating_point<float128> : true_type {};
 #  endif // ifdef UTL_SUPPORTS_FLOAT128
 #  ifdef UTL_SUPPORTS_BFLOAT16
 using std::bfloat16;
-template <> struct is_floating_point<bfloat16> : true_type {};
+template <>
+struct is_floating_point<bfloat16> : true_type {};
 #  endif // ifdef UTL_SUPPORTS_BFLOAT16
 UTL_NAMESPACE_END
 #endif // ifdef UTL_CXX23

--- a/include/utl/type_traits/utl_is_function.h
+++ b/include/utl/type_traits/utl_is_function.h
@@ -16,7 +16,8 @@ using std::is_function;
 #  ifdef UTL_CXX17
 using std::is_function_v;
 #  elif defined(UTL_CXX14) // ifdef UTL_CXX17
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_function_v = is_function<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_function_v = is_function<T>::value;
 #  endif                   // ifdef UTL_CXX17
 
 UTL_NAMESPACE_END
@@ -37,10 +38,12 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_function : bool_constant<UTL_BUILTIN_is_function(T)> {};
+template <typename T>
+struct is_function : bool_constant<UTL_BUILTIN_is_function(T)> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_function_v = UTL_BUILTIN_is_function(T);
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_function_v = UTL_BUILTIN_is_function(T);
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END
@@ -58,7 +61,8 @@ template <typename T>
 struct is_function : bool_constant<!is_const<T const>::value && !is_reference<T>::value> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_function_v = is_function<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_function_v = is_function<T>::value;
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_is_fundamental.h
+++ b/include/utl/type_traits/utl_is_fundamental.h
@@ -15,7 +15,8 @@ using std::is_fundamental;
 #  ifdef UTL_CXX17
 using std::is_fundamental_v;
 #  elif defined(UTL_CXX14) // ifdef UTL_CXX17
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_fundamental_v = is_fundamental<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_fundamental_v = is_fundamental<T>::value;
 #  endif                   // ifdef UTL_CXX17
 
 UTL_NAMESPACE_END
@@ -38,7 +39,8 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_fundamental : bool_constant<UTL_BUILTIN_is_fundamental(T)> {};
+template <typename T>
+struct is_fundamental : bool_constant<UTL_BUILTIN_is_fundamental(T)> {};
 
 #    ifdef UTL_CXX14
 template <typename T>
@@ -62,7 +64,8 @@ struct is_fundamental :
     bool_constant<is_void<T>::value || is_null_pointer<T>::value || is_arithmetic<T>::value> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_fundamental_v = is_fundamental<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_fundamental_v = is_fundamental<T>::value;
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_is_integral.h
+++ b/include/utl/type_traits/utl_is_integral.h
@@ -15,7 +15,8 @@ using std::is_integral;
 #  ifdef UTL_CXX17
 using std::is_integral_v;
 #  elif defined(UTL_CXX14) // ifdef UTL_CXX17
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_integral_v = is_integral<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_integral_v = is_integral<T>::value;
 #  endif                   // ifdef UTL_CXX17
 
 UTL_NAMESPACE_END
@@ -36,10 +37,12 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_integral : bool_constant<UTL_BUILTIN_is_integral(T)> {};
+template <typename T>
+struct is_integral : bool_constant<UTL_BUILTIN_is_integral(T)> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_integral_v = UTL_BUILTIN_is_integral(T);
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_integral_v = UTL_BUILTIN_is_integral(T);
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END
@@ -48,39 +51,62 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_integral : false_type {};
+template <typename T>
+struct is_integral : false_type {};
 
-template <> struct is_integral<bool> : true_type {};
-template <> struct is_integral<char> : true_type {};
-template <> struct is_integral<signed char> : true_type {};
-template <> struct is_integral<unsigned char> : true_type {};
-template <> struct is_integral<wchar_t> : true_type {};
-template <> struct is_integral<char16_t> : true_type {};
-template <> struct is_integral<char32_t> : true_type {};
-template <> struct is_integral<short> : true_type {};
-template <> struct is_integral<unsigned short> : true_type {};
-template <> struct is_integral<int> : true_type {};
-template <> struct is_integral<unsigned int> : true_type {};
-template <> struct is_integral<long> : true_type {};
-template <> struct is_integral<unsigned long> : true_type {};
-template <> struct is_integral<long long> : true_type {};
-template <> struct is_integral<unsigned long long> : true_type {};
+template <>
+struct is_integral<bool> : true_type {};
+template <>
+struct is_integral<char> : true_type {};
+template <>
+struct is_integral<signed char> : true_type {};
+template <>
+struct is_integral<unsigned char> : true_type {};
+template <>
+struct is_integral<wchar_t> : true_type {};
+template <>
+struct is_integral<char16_t> : true_type {};
+template <>
+struct is_integral<char32_t> : true_type {};
+template <>
+struct is_integral<short> : true_type {};
+template <>
+struct is_integral<unsigned short> : true_type {};
+template <>
+struct is_integral<int> : true_type {};
+template <>
+struct is_integral<unsigned int> : true_type {};
+template <>
+struct is_integral<long> : true_type {};
+template <>
+struct is_integral<unsigned long> : true_type {};
+template <>
+struct is_integral<long long> : true_type {};
+template <>
+struct is_integral<unsigned long long> : true_type {};
 
 #    if defined(UTL_CXX20)
-template <> struct is_integral<char8_t> : true_type {};
+template <>
+struct is_integral<char8_t> : true_type {};
 #    endif
 
 #    ifdef UTL_SUPPORTS_INT128
-template <> struct is_integral<__int128_t> : true_type {};
-template <> struct is_integral<__uint128_t> : true_type {};
+template <>
+struct is_integral<__int128_t> : true_type {};
+template <>
+struct is_integral<__uint128_t> : true_type {};
 #    endif
 
-template <typename T> struct is_integral<T const> : is_integral<T> {};
-template <typename T> struct is_integral<T volatile> : is_integral<T> {};
-template <typename T> struct is_integral<T const volatile> : is_integral<T> {};
+template <typename T>
+struct is_integral<T const> : is_integral<T> {};
+template <typename T>
+struct is_integral<T volatile> : is_integral<T> {};
+template <typename T>
+struct is_integral<T const volatile> : is_integral<T> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_integral_v = is_integral<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_integral_v = is_integral<T>::value;
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_is_member_x_pointer.h
+++ b/include/utl/type_traits/utl_is_member_x_pointer.h
@@ -64,7 +64,8 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_member_pointer : bool_constant<UTL_BUILTIN_is_member_pointer(T)> {};
+template <typename T>
+struct is_member_pointer : bool_constant<UTL_BUILTIN_is_member_pointer(T)> {};
 
 #    ifdef UTL_CXX14
 template <typename T>
@@ -77,9 +78,11 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_member_pointer : false_type {};
+template <typename T>
+struct is_member_pointer : false_type {};
 
-template <typename T, typename U> struct is_member_pointer<T U::*> : true_type {};
+template <typename T, typename U>
+struct is_member_pointer<T U::*> : true_type {};
 
 #    ifdef UTL_CXX14
 template <typename T>
@@ -111,9 +114,11 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_member_function_pointer : false_type {};
+template <typename T>
+struct is_member_function_pointer : false_type {};
 
-template <typename T, typename U> struct is_member_function_pointer<T U::*> : is_function<T> {};
+template <typename T, typename U>
+struct is_member_function_pointer<T U::*> : is_function<T> {};
 
 #    ifdef UTL_CXX14
 template <typename T>
@@ -145,7 +150,8 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_member_object_pointer : false_type {};
+template <typename T>
+struct is_member_object_pointer : false_type {};
 
 template <typename T, typename U>
 struct is_member_object_pointer<T U::*> : bool_constant<!is_function<T>::value> {};

--- a/include/utl/type_traits/utl_is_null_pointer.h
+++ b/include/utl/type_traits/utl_is_null_pointer.h
@@ -15,7 +15,8 @@ using std::is_null_pointer;
 #  ifdef UTL_CXX17
 using std::is_null_pointer_v;
 #  elif defined(UTL_CXX14) // ifdef UTL_CXX17
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_null_pointer_v = is_null_pointer<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_null_pointer_v = is_null_pointer<T>::value;
 #  endif                   // ifdef UTL_CXX17
 
 UTL_NAMESPACE_END
@@ -36,7 +37,8 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_null_pointer : bool_constant<UTL_BUILTIN_is_null_pointer(T)> {};
+template <typename T>
+struct is_null_pointer : bool_constant<UTL_BUILTIN_is_null_pointer(T)> {};
 
 #    ifdef UTL_CXX14
 template <typename T>
@@ -49,18 +51,24 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_null_pointer : false_type {};
+template <typename T>
+struct is_null_pointer : false_type {};
 
-template <> struct is_null_pointer<void> : true_type {};
+template <>
+struct is_null_pointer<void> : true_type {};
 
-template <> struct is_null_pointer<void const> : true_type {};
+template <>
+struct is_null_pointer<void const> : true_type {};
 
-template <> struct is_null_pointer<void volatile> : true_type {};
+template <>
+struct is_null_pointer<void volatile> : true_type {};
 
-template <> struct is_null_pointer<void const volatile> : true_type {};
+template <>
+struct is_null_pointer<void const volatile> : true_type {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_null_pointer_v = is_null_pointer<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_null_pointer_v = is_null_pointer<T>::value;
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_is_object.h
+++ b/include/utl/type_traits/utl_is_object.h
@@ -15,7 +15,8 @@ using std::is_object;
 #  ifdef UTL_CXX17
 using std::is_object_v;
 #  elif defined(UTL_CXX14) // ifdef UTL_CXX17
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_object_v = is_object<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_object_v = is_object<T>::value;
 #  endif                   // ifdef UTL_CXX17
 
 UTL_NAMESPACE_END
@@ -38,10 +39,12 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_object : bool_constant<UTL_BUILTIN_is_object(T)> {};
+template <typename T>
+struct is_object : bool_constant<UTL_BUILTIN_is_object(T)> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_object_v = UTL_BUILTIN_is_object(T);
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_object_v = UTL_BUILTIN_is_object(T);
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END
@@ -63,7 +66,8 @@ struct is_object :
         is_class<T>::value> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_object_v = is_object<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_object_v = is_object<T>::value;
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_is_pointer.h
+++ b/include/utl/type_traits/utl_is_pointer.h
@@ -15,7 +15,8 @@ using std::is_pointer;
 #  ifdef UTL_CXX17
 using std::is_pointer_v;
 #  elif defined(UTL_CXX14) // ifdef UTL_CXX17
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_pointer_v = is_pointer<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_pointer_v = is_pointer<T>::value;
 #  endif                   // ifdef UTL_CXX17
 
 UTL_NAMESPACE_END
@@ -36,10 +37,12 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_pointer : bool_constant<UTL_BUILTIN_is_pointer(T)> {};
+template <typename T>
+struct is_pointer : bool_constant<UTL_BUILTIN_is_pointer(T)> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_pointer_v = UTL_BUILTIN_is_pointer(T);
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_pointer_v = UTL_BUILTIN_is_pointer(T);
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END
@@ -48,18 +51,24 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_pointer : false_type {};
+template <typename T>
+struct is_pointer : false_type {};
 
-template <typename T> struct is_pointer<T*> : true_type {};
+template <typename T>
+struct is_pointer<T*> : true_type {};
 
-template <> struct is_pointer<T* const> : true_type {};
+template <>
+struct is_pointer<T* const> : true_type {};
 
-template <> struct is_pointer<T* volatile> : true_type {};
+template <>
+struct is_pointer<T* volatile> : true_type {};
 
-template <> struct is_pointer<T* const volatile> : true_type {};
+template <>
+struct is_pointer<T* const volatile> : true_type {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_pointer_v = is_pointer<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_pointer_v = is_pointer<T>::value;
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_is_same.h
+++ b/include/utl/type_traits/utl_is_same.h
@@ -15,7 +15,8 @@ using std::is_same;
 #  ifdef UTL_CXX17
 using std::is_same_v;
 #  elif defined(UTL_CXX14) // ifdef UTL_CXX17
-template <typename T, typename U> UTL_INLINE_CXX17 constexpr bool is_same_v = is_same<T, U>::value;
+template <typename T, typename U>
+UTL_INLINE_CXX17 constexpr bool is_same_v = is_same<T, U>::value;
 #  endif                   // ifdef UTL_CXX17
 
 UTL_NAMESPACE_END
@@ -36,7 +37,8 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T0, typename T1> struct is_same : bool_constant<UTL_BUILTIN_is_same(T0, T1)> {};
+template <typename T0, typename T1>
+struct is_same : bool_constant<UTL_BUILTIN_is_same(T0, T1)> {};
 
 #    ifdef UTL_CXX14
 template <typename T0, typename T1>
@@ -49,12 +51,15 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename, typename> struct is_same : false_type {};
+template <typename, typename>
+struct is_same : false_type {};
 
-template <typename T> struct is_same<T, T> : true_type {};
+template <typename T>
+struct is_same<T, T> : true_type {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_same_v = is_same<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_same_v = is_same<T>::value;
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_is_scalar.h
+++ b/include/utl/type_traits/utl_is_scalar.h
@@ -15,7 +15,8 @@ using std::is_scalar;
 #  ifdef UTL_CXX17
 using std::is_scalar_v;
 #  elif defined(UTL_CXX14) // ifdef UTL_CXX17
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_scalar_v = is_scalar<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_scalar_v = is_scalar<T>::value;
 #  endif                   // ifdef UTL_CXX17
 
 UTL_NAMESPACE_END
@@ -38,10 +39,12 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_scalar : bool_constant<UTL_BUILTIN_is_scalar(T)> {};
+template <typename T>
+struct is_scalar : bool_constant<UTL_BUILTIN_is_scalar(T)> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_scalar_v = UTL_BUILTIN_is_scalar(T);
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_scalar_v = UTL_BUILTIN_is_scalar(T);
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END
@@ -64,7 +67,8 @@ template <typename T>
     is_enum<T>::value >> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_scalar_v = is_scalar<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_scalar_v = is_scalar<T>::value;
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_is_union.h
+++ b/include/utl/type_traits/utl_is_union.h
@@ -15,7 +15,8 @@ using std::is_union;
 #  ifdef UTL_CXX17
 using std::is_union_v;
 #  elif defined(UTL_CXX14) // ifdef UTL_CXX17
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_union_v = is_union<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_union_v = is_union<T>::value;
 #  endif                   // ifdef UTL_CXX17
 
 UTL_NAMESPACE_END
@@ -38,10 +39,12 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_union : bool_constant<UTL_BUILTIN_is_union(T)> {};
+template <typename T>
+struct is_union : bool_constant<UTL_BUILTIN_is_union(T)> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_union_v = UTL_BUILTIN_is_union(T);
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_union_v = UTL_BUILTIN_is_union(T);
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END
@@ -54,10 +57,12 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_union : undefined_trait<T> {};
+template <typename T>
+struct is_union : undefined_trait<T> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_union_v = is_union<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_union_v = is_union<T>::value;
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_is_void.h
+++ b/include/utl/type_traits/utl_is_void.h
@@ -15,7 +15,8 @@ using std::is_void;
 #  ifdef UTL_CXX17
 using std::is_void_v;
 #  elif defined(UTL_CXX14) // ifdef UTL_CXX17
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_void_v = is_void<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_void_v = is_void<T>::value;
 #  endif                   // ifdef UTL_CXX17
 
 UTL_NAMESPACE_END
@@ -36,10 +37,12 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_void : bool_constant<UTL_BUILTIN_is_void(T)> {};
+template <typename T>
+struct is_void : bool_constant<UTL_BUILTIN_is_void(T)> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_void_v = UTL_BUILTIN_is_void(T);
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_void_v = UTL_BUILTIN_is_void(T);
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END
@@ -48,18 +51,24 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_void : false_type {};
+template <typename T>
+struct is_void : false_type {};
 
-template <> struct is_void<void> : true_type {};
+template <>
+struct is_void<void> : true_type {};
 
-template <> struct is_void<void const> : true_type {};
+template <>
+struct is_void<void const> : true_type {};
 
-template <> struct is_void<void volatile> : true_type {};
+template <>
+struct is_void<void volatile> : true_type {};
 
-template <> struct is_void<void const volatile> : true_type {};
+template <>
+struct is_void<void const volatile> : true_type {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_void_v = is_void<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_void_v = is_void<T>::value;
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_is_x_array.h
+++ b/include/utl/type_traits/utl_is_x_array.h
@@ -15,7 +15,8 @@ using std::is_array;
 #  ifdef UTL_CXX17
 using std::is_array_v;
 #  elif defined(UTL_CXX14) // ifdef UTL_CXX17
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_array_v = is_array<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_array_v = is_array<T>::value;
 #  endif                   // ifdef UTL_CXX17
 
 UTL_NAMESPACE_END
@@ -40,10 +41,12 @@ UTL_PRAGMA_WARN("builtin is_array is disabled by default and cannot be enabled")
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_array : bool_constant<UTL_BUILTIN_is_array(T)> {};
+template <typename T>
+struct is_array : bool_constant<UTL_BUILTIN_is_array(T)> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_array_v = UTL_BUILTIN_is_array(T);
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_array_v = UTL_BUILTIN_is_array(T);
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END
@@ -52,14 +55,18 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_array : false_type {};
+template <typename T>
+struct is_array : false_type {};
 
-template <typename T> struct is_array<T[]> : true_type {};
+template <typename T>
+struct is_array<T[]> : true_type {};
 
-template <typename T, size_t N> struct is_array<T[N]> : true_type {};
+template <typename T, size_t N>
+struct is_array<T[N]> : true_type {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_array_v = is_array<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_array_v = is_array<T>::value;
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END
@@ -101,11 +108,15 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_bounded_array : false_type {};
-template <typename T, decltype(sizeof(0)) N> struct is_bounded_array<T[N]> : true_type {};
+template <typename T>
+struct is_bounded_array : false_type {};
+template <typename T, decltype(sizeof(0)) N>
+struct is_bounded_array<T[N]> : true_type {};
 
-template <typename T> struct is_unbounded_array : false_type {};
-template <typename T> struct is_unbounded_array<T[]> : true_type {};
+template <typename T>
+struct is_unbounded_array : false_type {};
+template <typename T>
+struct is_unbounded_array<T[]> : true_type {};
 
 UTL_NAMESPACE_END
 

--- a/include/utl/type_traits/utl_is_x_cv.h
+++ b/include/utl/type_traits/utl_is_x_cv.h
@@ -20,8 +20,10 @@ using std::is_volatile_v;
 
 #  elif defined(UTL_CXX14) // ifdef UTL_CXX17
 
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_const_v = is_const<T>::value;
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_volatile_v = is_volatile<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_const_v = is_const<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_volatile_v = is_volatile<T>::value;
 
 #  endif // ifdef UTL_CXX17
 
@@ -53,10 +55,12 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_const : bool_constant<UTL_BUILTIN_is_const(T)> {};
+template <typename T>
+struct is_const : bool_constant<UTL_BUILTIN_is_const(T)> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_const_v = UTL_BUILTIN_is_const(T);
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_const_v = UTL_BUILTIN_is_const(T);
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END
@@ -65,12 +69,16 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_const : false_type {};
-template <typename T> struct is_const<T const> : true_type {};
-template <typename T> struct is_const<T const volatile> : true_type {};
+template <typename T>
+struct is_const : false_type {};
+template <typename T>
+struct is_const<T const> : true_type {};
+template <typename T>
+struct is_const<T const volatile> : true_type {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_const_v = is_const<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_const_v = is_const<T>::value;
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END
@@ -81,10 +89,12 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_volatile : bool_constant<UTL_BUILTIN_is_volatile(T)> {};
+template <typename T>
+struct is_volatile : bool_constant<UTL_BUILTIN_is_volatile(T)> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_volatile_v = UTL_BUILTIN_is_volatile(T);
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_volatile_v = UTL_BUILTIN_is_volatile(T);
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END
@@ -93,12 +103,16 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_volatile : false_type {};
-template <typename T> struct is_volatile<T volatile> : true_type {};
-template <typename T> struct is_volatile<T const volatile> : true_type {};
+template <typename T>
+struct is_volatile : false_type {};
+template <typename T>
+struct is_volatile<T volatile> : true_type {};
+template <typename T>
+struct is_volatile<T const volatile> : true_type {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_volatile_v = is_volatile<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_volatile_v = is_volatile<T>::value;
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_is_x_reference.h
+++ b/include/utl/type_traits/utl_is_x_reference.h
@@ -22,7 +22,8 @@ using std::is_rvalue_reference_v;
 
 #  elif defined(UTL_CXX14) // ifdef UTL_CXX17
 
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_reference_v = is_reference<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_reference_v = is_reference<T>::value;
 template <typename T>
 UTL_INLINE_CXX17 constexpr bool is_lvalue_reference_v = is_lvalue_reference<T>::value;
 template <typename T>
@@ -64,10 +65,12 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_reference : bool_constant<UTL_BUILTIN_is_reference(T)> {};
+template <typename T>
+struct is_reference : bool_constant<UTL_BUILTIN_is_reference(T)> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_reference_v = UTL_BUILTIN_is_reference(T);
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_reference_v = UTL_BUILTIN_is_reference(T);
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END
@@ -76,14 +79,18 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_reference : false_type {};
+template <typename T>
+struct is_reference : false_type {};
 
-template <typename T> struct is_reference<T&> : true_type {};
+template <typename T>
+struct is_reference<T&> : true_type {};
 
-template <typename T> struct is_reference<T&&> : true_type {};
+template <typename T>
+struct is_reference<T&&> : true_type {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_reference_v = is_reference<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_reference_v = is_reference<T>::value;
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END
@@ -108,9 +115,11 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_lvalue_reference : false_type {};
+template <typename T>
+struct is_lvalue_reference : false_type {};
 
-template <typename T> struct is_lvalue_reference<T&> : true_type {};
+template <typename T>
+struct is_lvalue_reference<T&> : true_type {};
 
 #    ifdef UTL_CXX14
 template <typename T>
@@ -139,9 +148,11 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_rvalue_reference : false_type {};
+template <typename T>
+struct is_rvalue_reference : false_type {};
 
-template <typename T> struct is_rvalue_reference<T&&> : true_type {};
+template <typename T>
+struct is_rvalue_reference<T&&> : true_type {};
 
 #    ifdef UTL_CXX14
 template <typename T>

--- a/include/utl/type_traits/utl_is_x_signed.h
+++ b/include/utl/type_traits/utl_is_x_signed.h
@@ -20,8 +20,10 @@ using std::is_unsigned_v;
 
 #  elif defined(UTL_CXX14) // ifdef UTL_CXX17
 
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_signed_v = is_signed<T>::value;
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_unsigned_v = is_unsigned<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_signed_v = is_signed<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_unsigned_v = is_unsigned<T>::value;
 
 #  endif // ifdef UTL_CXX17
 
@@ -50,10 +52,12 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_signed : bool_constant<UTL_BUILTIN_is_signed(T)> {};
+template <typename T>
+struct is_signed : bool_constant<UTL_BUILTIN_is_signed(T)> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_signed_v = UTL_BUILTIN_is_signed(T);
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_signed_v = UTL_BUILTIN_is_signed(T);
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END
@@ -71,7 +75,8 @@ template <typename T>
 struct is_signed : conjunction<is_arithmetic<T>, bool_constant<T(-1) < T(0)>> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_signed_v = is_signed<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_signed_v = is_signed<T>::value;
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END
@@ -84,10 +89,12 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct is_unsigned : bool_constant<UTL_BUILTIN_is_unsigned(T)> {};
+template <typename T>
+struct is_unsigned : bool_constant<UTL_BUILTIN_is_unsigned(T)> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_unsigned_v = UTL_BUILTIN_is_unsigned(T);
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_unsigned_v = UTL_BUILTIN_is_unsigned(T);
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END
@@ -104,10 +111,12 @@ UTL_NAMESPACE_BEGIN
 template <typename T>
     struct is_unsigned : conjunction < is_arithmetic<T>,
     bool_constant<T(-1)> T(0) >> {};
-template <> struct is_unsigned<bool> : true_type {};
+template <>
+struct is_unsigned<bool> : true_type {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr bool is_unsigned_v = is_unsigned<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_unsigned_v = is_unsigned<T>::value;
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_logical_traits.h
+++ b/include/utl/type_traits/utl_logical_traits.h
@@ -6,31 +6,42 @@
 #include "utl/type_traits/utl_constants.h"
 
 UTL_NAMESPACE_BEGIN
-template <bool B, typename T, typename> struct conditional {
+template <bool B, typename T, typename>
+struct conditional {
     using type = T;
 };
-template <typename T0, typename T1> struct conditional<false, T0, T1> {
+template <typename T0, typename T1>
+struct conditional<false, T0, T1> {
     using type = T1;
 };
 
-template <bool V, typename T, typename F> using conditional_t = typename conditional<V, T, F>::type;
+template <bool V, typename T, typename F>
+using conditional_t = typename conditional<V, T, F>::type;
 
-template <typename...> struct disjunction : false_type {};
-template <typename T> struct disjunction<T> : conditional_t<T::value, true_type, false_type> {};
+template <typename...>
+struct disjunction : false_type {};
+template <typename T>
+struct disjunction<T> : conditional_t<T::value, true_type, false_type> {};
 template <typename Head, typename... Tail>
 struct disjunction<Head, Tail...> : conditional_t<Head::value, true_type, disjunction<Tail...>> {};
 
-template <typename...> struct conjunction : true_type {};
-template <typename T> struct conjunction<T> : conditional_t<T::value, true_type, false_type> {};
+template <typename...>
+struct conjunction : true_type {};
+template <typename T>
+struct conjunction<T> : conditional_t<T::value, true_type, false_type> {};
 template <typename Head, typename... Tail>
 struct conjunction<Head, Tail...> : conditional_t<Head::value, conjunction<Tail...>, false_type> {};
 
-template <typename T> struct negation : bool_constant<!T::value> {};
+template <typename T>
+struct negation : bool_constant<!T::value> {};
 
 #ifdef UTL_CXX14
-template <typename... Ts> UTL_INLINE_CXX17 constexpr bool disjunction_v = disjunction<Ts...>::value;
-template <typename... Ts> UTL_INLINE_CXX17 constexpr bool conjunction_v = conjunction<Ts...>::value;
-template <typename T> UTL_INLINE_CXX17 constexpr bool     negation_v = !T::value;
+template <typename... Ts>
+UTL_INLINE_CXX17 constexpr bool disjunction_v = disjunction<Ts...>::value;
+template <typename... Ts>
+UTL_INLINE_CXX17 constexpr bool conjunction_v = conjunction<Ts...>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool negation_v = !T::value;
 #endif
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_make_x_signed.h
+++ b/include/utl/type_traits/utl_make_x_signed.h
@@ -19,8 +19,10 @@ using std::make_signed_t;
 using std::make_unsigned_t;
 
 #  else  // ifdef UTL_CXX14
-template <typename T> using make_signed_t = typename make_signed<T>::type;
-template <typename T> using make_unsigned_t = typename make_unsigned<T>::type;
+template <typename T>
+using make_signed_t = typename make_signed<T>::type;
+template <typename T>
+using make_unsigned_t = typename make_unsigned<T>::type;
 #  endif // ifdef UTL_CXX14
 
 UTL_NAMESPACE_END
@@ -60,11 +62,13 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct make_signed {
+template <typename T>
+struct make_signed {
     using type = UTL_BUILTIN_make_signed(T);
 };
 
-template <typename T> using make_signed_t = UTL_BUILTIN_make_signed(T);
+template <typename T>
+using make_signed_t = UTL_BUILTIN_make_signed(T);
 
 UTL_NAMESPACE_END
 
@@ -77,11 +81,14 @@ UTL_NAMESPACE_BEGIN
 namespace details {
 namespace type_traits {
 
-template <size_t I> struct signed_table_entry;
-template <size_t I> using signed_table_entry_t = typename signed_table_entry<I>::type;
-#    define UTL_GENERATE_TABLE_ENTRY(N, T)         \
-        template <> struct signed_table_entry<N> { \
-            using type = T;                        \
+template <size_t I>
+struct signed_table_entry;
+template <size_t I>
+using signed_table_entry_t = typename signed_table_entry<I>::type;
+#    define UTL_GENERATE_TABLE_ENTRY(N, T) \
+        template <>                        \
+        struct signed_table_entry<N> {     \
+            using type = T;                \
         }
 
 UTL_GENERATE_TABLE_ENTRY(0, signed char);
@@ -97,7 +104,8 @@ UTL_GENERATE_TABLE_ENTRY(5, __int128_t);
 
 template <typename T, size_t Idx = 0, bool = (is_integral<T>::value || is_enum<T>::value)>
 struct find_signed;
-template <typename T, size_t Idx = 0> using find_signed_t = typename find_signed<T, Idx>::type;
+template <typename T, size_t Idx = 0>
+using find_signed_t = typename find_signed<T, Idx>::type;
 
 template <typename T, size_t Idx>
 struct find_signed<T, Idx, true> :
@@ -106,54 +114,70 @@ struct find_signed<T, Idx, true> :
 } // namespace type_traits
 } // namespace details
 
-template <typename T> struct make_signed {
+template <typename T>
+struct make_signed {
     using type = details::type_traits::find_signed_t<T>;
 };
-template <typename T> struct make_signed<T const> {
+template <typename T>
+struct make_signed<T const> {
     using type = typename make_signed<T>::type const;
 };
-template <typename T> struct make_signed<T volatile> {
+template <typename T>
+struct make_signed<T volatile> {
     using type = typename make_signed<T>::type volatile;
 };
-template <typename T> struct make_signed<T const volatile> {
+template <typename T>
+struct make_signed<T const volatile> {
     using type = typename make_signed<T>::type const volatile;
 };
-template <> struct make_signed<bool> {};
-template <> struct make_signed<unsigned char> {
+template <>
+struct make_signed<bool> {};
+template <>
+struct make_signed<unsigned char> {
     using type = signed char;
 };
-template <> struct make_signed<signed char> {
+template <>
+struct make_signed<signed char> {
     using type = signed char;
 };
-template <> struct make_signed<unsigned short> {
+template <>
+struct make_signed<unsigned short> {
     using type = signed short;
 };
-template <> struct make_signed<signed short> {
+template <>
+struct make_signed<signed short> {
     using type = signed short;
 };
-template <> struct make_signed<unsigned int> {
+template <>
+struct make_signed<unsigned int> {
     using type = signed int;
 };
-template <> struct make_signed<signed int> {
+template <>
+struct make_signed<signed int> {
     using type = signed int;
 };
-template <> struct make_signed<unsigned long> {
+template <>
+struct make_signed<unsigned long> {
     using type = signed long;
 };
-template <> struct make_signed<signed long> {
+template <>
+struct make_signed<signed long> {
     using type = signed long;
 };
 
 #    ifdef UTL_SUPPORTS_INT128
-template <> struct make_signed<__uint128_t> {
+template <>
+struct make_signed<__uint128_t> {
     using type = __int128_t;
 };
-template <> struct make_signed<__int128_t> {
+template <>
+struct make_signed<__int128_t> {
     using type = __int128_t;
 };
 #    endif
 
-template <typename T> using make_signed_t = typename make_signed<T>::type;
+template <typename T>
+using make_signed_t = typename make_signed<T>::type;
 
 UTL_NAMESPACE_END
 
@@ -166,11 +190,13 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct make_unsigned {
+template <typename T>
+struct make_unsigned {
     using type = UTL_BUILTIN_make_unsigned(T);
 };
 
-template <typename T> using make_unsigned_t = UTL_BUILTIN_make_unsigned(T);
+template <typename T>
+using make_unsigned_t = UTL_BUILTIN_make_unsigned(T);
 
 UTL_NAMESPACE_END
 
@@ -181,11 +207,14 @@ UTL_NAMESPACE_END
 namespace details {
 namespace type_traits {
 
-template <size_t I> struct unsigned_table_entry;
-template <size_t I> using unsigned_table_entry_t = typename unsigned_table_entry<I>::type;
-#    define UTL_GENERATE_TABLE_ENTRY(N, T)           \
-        template <> struct unsigned_table_entry<N> { \
-            using type = T;                          \
+template <size_t I>
+struct unsigned_table_entry;
+template <size_t I>
+using unsigned_table_entry_t = typename unsigned_table_entry<I>::type;
+#    define UTL_GENERATE_TABLE_ENTRY(N, T) \
+        template <>                        \
+        struct unsigned_table_entry<N> {   \
+            using type = T;                \
         }
 
 UTL_GENERATE_TABLE_ENTRY(0, unsigned char);
@@ -201,7 +230,8 @@ UTL_GENERATE_TABLE_ENTRY(5, __uint128_t);
 
 template <typename T, size_t Idx = 0, bool = (is_integral<T>::value || is_enum<T>::value)>
 struct find_unsigned;
-template <typename T, size_t Idx = 0> using find_unsigned_t = typename find_unsigned<T, Idx>::type;
+template <typename T, size_t Idx = 0>
+using find_unsigned_t = typename find_unsigned<T, Idx>::type;
 
 template <typename T, size_t Idx>
 struct find_unsigned<T, Idx, true> :
@@ -212,54 +242,70 @@ struct find_unsigned<T, Idx, true> :
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct make_unsigned {
+template <typename T>
+struct make_unsigned {
     using type = details::type_traits::find_unsigned_t<T>;
 };
-template <typename T> struct make_unsigned<T const> {
+template <typename T>
+struct make_unsigned<T const> {
     using type = typename make_unsigned<T>::type const;
 };
-template <typename T> struct make_unsigned<T volatile> {
+template <typename T>
+struct make_unsigned<T volatile> {
     using type = typename make_unsigned<T>::type volatile;
 };
-template <typename T> struct make_unsigned<T const volatile> {
+template <typename T>
+struct make_unsigned<T const volatile> {
     using type = typename make_unsigned<T>::type const volatile;
 };
-template <> struct make_unsigned<bool> {};
-template <> struct make_unsigned<unsigned char> {
+template <>
+struct make_unsigned<bool> {};
+template <>
+struct make_unsigned<unsigned char> {
     using type = unsigned char;
 };
-template <> struct make_unsigned<signed char> {
+template <>
+struct make_unsigned<signed char> {
     using type = unsigned char;
 };
-template <> struct make_unsigned<unsigned short> {
+template <>
+struct make_unsigned<unsigned short> {
     using type = unsigned short;
 };
-template <> struct make_unsigned<signed short> {
+template <>
+struct make_unsigned<signed short> {
     using type = unsigned short;
 };
-template <> struct make_unsigned<unsigned int> {
+template <>
+struct make_unsigned<unsigned int> {
     using type = unsigned int;
 };
-template <> struct make_unsigned<signed int> {
+template <>
+struct make_unsigned<signed int> {
     using type = unsigned int;
 };
-template <> struct make_unsigned<unsigned long> {
+template <>
+struct make_unsigned<unsigned long> {
     using type = unsigned long;
 };
-template <> struct make_unsigned<signed long> {
+template <>
+struct make_unsigned<signed long> {
     using type = unsigned long;
 };
 
 #    ifdef UTL_SUPPORTS_INT128
-template <> struct make_unsigned<__uint128_t> {
+template <>
+struct make_unsigned<__uint128_t> {
     using type = __uint128_t;
 };
-template <> struct make_unsigned<__int128_t> {
+template <>
+struct make_unsigned<__int128_t> {
     using type = __uint128_t;
 };
 #    endif
 
-template <typename T> using make_unsigned_t = typename make_unsigned<T>::type;
+template <typename T>
+using make_unsigned_t = typename make_unsigned<T>::type;
 
 UTL_NAMESPACE_END
 

--- a/include/utl/type_traits/utl_merge_x_cv.h
+++ b/include/utl/type_traits/utl_merge_x_cv.h
@@ -17,7 +17,8 @@ UTL_NAMESPACE_BEGIN
  * @result typename type - const-qualified Target iff there is a const-qualified type in the type
  * list
  */
-template <typename Target, typename TypeList> struct merge_const;
+template <typename Target, typename TypeList>
+struct merge_const;
 template <typename Target, template <typename...> class TypeList>
 struct merge_const<Target, TypeList<>> {
     using type = Target;
@@ -41,7 +42,8 @@ using merge_const_t = typename merge_const<Target, TypeList>::type;
  * @result typename type - volatile-qualified Target iff there is a volatile-qualified type in the
  * type list
  */
-template <typename Target, typename TypeList> struct merge_volatile;
+template <typename Target, typename TypeList>
+struct merge_volatile;
 template <typename Target, template <typename...> class TypeList>
 struct merge_volatile<Target, TypeList<>> {
     using type = Target;
@@ -65,7 +67,8 @@ using merge_volatile_t = typename merge_volatile<Target, TypeList>::type;
  * @result typename type - cv-qualified Target depending on the const/volatile-ness of the elements
  * in the typelist
  */
-template <typename Target, typename TypeList> struct merge_cv;
+template <typename Target, typename TypeList>
+struct merge_cv;
 template <typename Target, template <typename...> class TypeList>
 struct merge_cv<Target, TypeList<>> {
     using type = Target;

--- a/include/utl/type_traits/utl_modify_pointer.h
+++ b/include/utl/type_traits/utl_modify_pointer.h
@@ -20,8 +20,10 @@ using std::remove_pointer_t;
 
 #  else // UTL_CXX14
 
-template <typename T> using add_pointer_t = typename add_pointer<T>::type;
-template <typename T> using remove_pointer_t = typename remove_pointer<T>::type;
+template <typename T>
+using add_pointer_t = typename add_pointer<T>::type;
+template <typename T>
+using remove_pointer_t = typename remove_pointer<T>::type;
 
 #  endif // UTL_CXX14
 
@@ -49,11 +51,13 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct add_pointer {
+template <typename T>
+struct add_pointer {
     using type = UTL_BUILTIN_add_pointer(T);
 };
 
-template <typename T> using add_pointer_t = UTL_BUILTIN_add_pointer(T);
+template <typename T>
+using add_pointer_t = UTL_BUILTIN_add_pointer(T);
 
 UTL_NAMESPACE_END
 
@@ -65,19 +69,23 @@ UTL_NAMESPACE_BEGIN
 
 namespace details {
 namespace type_traits {
-template <typename T, typename = T&> remove_reference_t<T>* add_ptr(int) noexcept;
+template <typename T, typename = T&>
+remove_reference_t<T>* add_ptr(int) noexcept;
 template <typename T>
 auto add_ptr(float) noexcept
     -> decltype(static_cast<T* (*)(T const volatile*)>(0)((void const volatile*)0));
-template <typename T> T add_ptr(...) noexcept;
+template <typename T>
+T add_ptr(...) noexcept;
 } // namespace type_traits
 } // namespace details
 
-template <typename T> struct add_pointer {
+template <typename T>
+struct add_pointer {
     using type = decltype(details::type_traits::add_ptr<T>(0));
 };
 
-template <typename T> using add_pointer_t = decltype(details::type_traits::add_ptr<T>(0));
+template <typename T>
+using add_pointer_t = decltype(details::type_traits::add_ptr<T>(0));
 
 UTL_NAMESPACE_END
 
@@ -87,11 +95,13 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct remove_pointer {
+template <typename T>
+struct remove_pointer {
     using type = UTL_BUILTIN_remove_pointer(T);
 };
 
-template <typename T> using remove_pointer_t = UTL_BUILTIN_remove_pointer(T);
+template <typename T>
+using remove_pointer_t = UTL_BUILTIN_remove_pointer(T);
 
 UTL_NAMESPACE_END
 
@@ -99,23 +109,29 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct remove_pointer {
+template <typename T>
+struct remove_pointer {
     using type = T;
 };
-template <typename T> struct remove_pointer<T*> {
+template <typename T>
+struct remove_pointer<T*> {
     using type = T;
 };
-template <typename T> struct remove_pointer<T* const> {
+template <typename T>
+struct remove_pointer<T* const> {
     using type = T;
 };
-template <typename T> struct remove_pointer<T* volatile> {
+template <typename T>
+struct remove_pointer<T* volatile> {
     using type = T;
 };
-template <typename T> struct remove_pointer<T* const volatile> {
+template <typename T>
+struct remove_pointer<T* const volatile> {
     using type = T;
 };
 
-template <typename T> using remove_pointer_t = typename remove_pointer<T>::type;
+template <typename T>
+using remove_pointer_t = typename remove_pointer<T>::type;
 
 UTL_NAMESPACE_END
 

--- a/include/utl/type_traits/utl_modify_x_cv.h
+++ b/include/utl/type_traits/utl_modify_x_cv.h
@@ -28,12 +28,18 @@ using std::remove_volatile_t;
 
 #  else // UTL_CXX14
 
-template <typename T> using add_const_t = T const;
-template <typename T> using add_volatile_t = T volatile;
-template <typename T> using add_cv_t = T const volatile;
-template <typename T> using remove_const_t = typename remove_const<T>::type;
-template <typename T> using remove_volatile_t = typename remove_volatile<T>::type;
-template <typename T> using remove_cv_t = typename remove_volatile<T>::type;
+template <typename T>
+using add_const_t = T const;
+template <typename T>
+using add_volatile_t = T volatile;
+template <typename T>
+using add_cv_t = T const volatile;
+template <typename T>
+using remove_const_t = typename remove_const<T>::type;
+template <typename T>
+using remove_volatile_t = typename remove_volatile<T>::type;
+template <typename T>
+using remove_cv_t = typename remove_volatile<T>::type;
 
 #  endif // UTL_CXX14
 
@@ -62,11 +68,13 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct remove_volatile {
+template <typename T>
+struct remove_volatile {
     using type = UTL_BUILTIN_remove_const(T);
 };
 
-template <typename T> using remove_const_t = UTL_BUILTIN_remove_const(T);
+template <typename T>
+using remove_const_t = UTL_BUILTIN_remove_const(T);
 
 UTL_NAMESPACE_END
 
@@ -74,14 +82,17 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct remove_const {
+template <typename T>
+struct remove_const {
     using type = T;
 };
-template <typename T> struct remove_const<T const> {
+template <typename T>
+struct remove_const<T const> {
     using type = T;
 };
 
-template <typename T> using remove_const_t = typename remove_const<T>::type;
+template <typename T>
+using remove_const_t = typename remove_const<T>::type;
 
 UTL_NAMESPACE_END
 
@@ -91,11 +102,13 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct remove_volatile {
+template <typename T>
+struct remove_volatile {
     using type = UTL_BUILTIN_remove_volatile(T);
 };
 
-template <typename T> using remove_volatile_t = UTL_BUILTIN_remove_volatile(T);
+template <typename T>
+using remove_volatile_t = UTL_BUILTIN_remove_volatile(T);
 
 UTL_NAMESPACE_END
 
@@ -103,14 +116,17 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct remove_volatile {
+template <typename T>
+struct remove_volatile {
     using type = T;
 };
-template <typename T> struct remove_volatile<T volatile> {
+template <typename T>
+struct remove_volatile<T volatile> {
     using type = T;
 };
 
-template <typename T> using remove_volatile_t = typename remove_volatile<T>::type;
+template <typename T>
+using remove_volatile_t = typename remove_volatile<T>::type;
 
 UTL_NAMESPACE_END
 
@@ -118,23 +134,31 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct add_const {
+template <typename T>
+struct add_const {
     using type = T const;
 };
-template <typename T> struct add_volatile {
+template <typename T>
+struct add_volatile {
     using type = T volatile;
 };
-template <typename T> struct add_cv {
+template <typename T>
+struct add_cv {
     using type = T const volatile;
 };
-template <typename T> struct remove_cv {
+template <typename T>
+struct remove_cv {
     using type = remove_const_t<remove_volatile_t<T>>;
 };
 
-template <typename T> using add_const_t = T const;
-template <typename T> using add_volatile_t = T volatile;
-template <typename T> using add_cv_t = T const volatile;
-template <typename T> using remove_cv_t = remove_const_t<remove_volatile_t<T>>;
+template <typename T>
+using add_const_t = T const;
+template <typename T>
+using add_volatile_t = T volatile;
+template <typename T>
+using add_cv_t = T const volatile;
+template <typename T>
+using remove_cv_t = remove_const_t<remove_volatile_t<T>>;
 
 UTL_NAMESPACE_END
 

--- a/include/utl/type_traits/utl_modify_x_reference.h
+++ b/include/utl/type_traits/utl_modify_x_reference.h
@@ -21,9 +21,12 @@ using std::add_rvalue_reference_t;
 using std::remove_reference_t;
 
 #  else  // ifdef UTL_CXX14
-template <typename T> using add_lvalue_reference_t = typename add_lvalue_reference<T>::type;
-template <typename T> using add_rvalue_reference_t = typename add_rvalue_reference<T>::type;
-template <typename T> using remove_reference_t = typename remove_reference<T>::type;
+template <typename T>
+using add_lvalue_reference_t = typename add_lvalue_reference<T>::type;
+template <typename T>
+using add_rvalue_reference_t = typename add_rvalue_reference<T>::type;
+template <typename T>
+using remove_reference_t = typename remove_reference<T>::type;
 #  endif // ifdef UTL_CXX14
 
 UTL_NAMESPACE_END
@@ -64,11 +67,13 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct remove_reference {
+template <typename T>
+struct remove_reference {
     using type = UTL_BUILTIN_remove_reference(T);
 };
 
-template <typename T> using remove_reference_t = UTL_BUILTIN_remove_reference(T);
+template <typename T>
+using remove_reference_t = UTL_BUILTIN_remove_reference(T);
 
 UTL_NAMESPACE_END
 
@@ -76,17 +81,21 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct remove_reference {
+template <typename T>
+struct remove_reference {
     using type = T;
 };
-template <typename T> struct remove_reference<T&> {
+template <typename T>
+struct remove_reference<T&> {
     using type = T;
 };
-template <typename T> struct remove_reference<T&&> {
+template <typename T>
+struct remove_reference<T&&> {
     using type = T;
 };
 
-template <typename T> using remove_reference_t = typename remove_reference<T>::type;
+template <typename T>
+using remove_reference_t = typename remove_reference<T>::type;
 
 UTL_NAMESPACE_END
 
@@ -96,11 +105,13 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct add_lvalue_reference {
+template <typename T>
+struct add_lvalue_reference {
     using type = UTL_BUILTIN_add_lvalue_reference(T);
 };
 
-template <typename T> using add_lvalue_reference_t = UTL_BUILTIN_add_lvalue_reference(T);
+template <typename T>
+using add_lvalue_reference_t = UTL_BUILTIN_add_lvalue_reference(T);
 
 UTL_NAMESPACE_END
 
@@ -110,12 +121,15 @@ UTL_NAMESPACE_BEGIN
 
 namespace details {
 namespace type_traits {
-template <typename T> T& add_lvalue_ref(int) noexcept;
-template <typename T> T  add_lvalue_ref(float) noexcept;
+template <typename T>
+T& add_lvalue_ref(int) noexcept;
+template <typename T>
+T add_lvalue_ref(float) noexcept;
 } // namespace type_traits
 } // namespace details
 
-template <typename T> struct add_lvalue_reference {
+template <typename T>
+struct add_lvalue_reference {
     using type = decltype(details::type_traits::add_rvalue_ref<T>(0));
 };
 
@@ -130,11 +144,13 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct add_rvalue_reference {
+template <typename T>
+struct add_rvalue_reference {
     using type = UTL_BUILTIN_add_rvalue_reference(T);
 };
 
-template <typename T> using add_rvalue_reference_t = UTL_BUILTIN_add_rvalue_reference(T);
+template <typename T>
+using add_rvalue_reference_t = UTL_BUILTIN_add_rvalue_reference(T);
 
 UTL_NAMESPACE_END
 
@@ -144,12 +160,15 @@ UTL_NAMESPACE_BEGIN
 
 namespace details {
 namespace type_traits {
-template <typename T> T&& add_rvalue_ref(int) noexcept;
-template <typename T> T   add_rvalue_ref(float) noexcept;
+template <typename T>
+T&& add_rvalue_ref(int) noexcept;
+template <typename T>
+T add_rvalue_ref(float) noexcept;
 } // namespace type_traits
 } // namespace details
 
-template <typename T> struct add_rvalue_reference {
+template <typename T>
+struct add_rvalue_reference {
     using type = decltype(details::type_traits::add_rvalue_ref<T>(0));
 };
 

--- a/include/utl/type_traits/utl_rank.h
+++ b/include/utl/type_traits/utl_rank.h
@@ -15,7 +15,8 @@ using std::rank;
 #  ifdef UTL_CXX17
 using std::rank_v;
 #  elif defined(UTL_CXX14) // UTL_CXX17
-template <typename T> UTL_INLINE_CXX17 constexpr bool rank_v = rank<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool rank_v = rank<T>::value;
 #  endif                   // UTL_CXX17
 
 UTL_NAMESPACE_END
@@ -39,10 +40,12 @@ UTL_PRAGMA_WARN("builtin array_rank is disabled by default and cannot be enabled
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct rank : size_constant<UTL_BUILTIN_array_rank(T)> {};
+template <typename T>
+struct rank : size_constant<UTL_BUILTIN_array_rank(T)> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr size_t rank_v = UTL_BUILTIN_array_rank(T);
+template <typename T>
+UTL_INLINE_CXX17 constexpr size_t rank_v = UTL_BUILTIN_array_rank(T);
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END
@@ -51,12 +54,16 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct rank : size_constant<0> {};
-template <typename T> struct rank<T[]> : size_constant<rank<T>::value + 1> {};
-template <typename T, size_t N> struct rank<T[N]> : size_constant<rank<T>::value + 1> {};
+template <typename T>
+struct rank : size_constant<0> {};
+template <typename T>
+struct rank<T[]> : size_constant<rank<T>::value + 1> {};
+template <typename T, size_t N>
+struct rank<T[N]> : size_constant<rank<T>::value + 1> {};
 
 #    ifdef UTL_CXX14
-template <typename T> UTL_INLINE_CXX17 constexpr size_t rank_v = rank<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr size_t rank_v = rank<T>::value;
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_rebind_template.h
+++ b/include/utl/type_traits/utl_rebind_template.h
@@ -6,7 +6,8 @@
 
 UTL_NAMESPACE_BEGIN
 
-template <typename From, template <typename...> To> struct rebind_template;
+template <typename From, template <typename...> To>
+struct rebind_template;
 
 template <template <typename...> class From, template <typename...> class To, typename... A>
 struct rebind_template<From<A...>, To> {

--- a/include/utl/type_traits/utl_remove_all_pointers.h
+++ b/include/utl/type_traits/utl_remove_all_pointers.h
@@ -4,11 +4,14 @@
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct remove_all_pointers {
+template <typename T>
+struct remove_all_pointers {
     using type = T;
 };
-template <typename T> struct remove_all_pointers<T*> : remove_all_pointers<T> {};
+template <typename T>
+struct remove_all_pointers<T*> : remove_all_pointers<T> {};
 
-template <typename T> using remove_all_pointers = typename remove_all_pointers<T>::type;
+template <typename T>
+using remove_all_pointers = typename remove_all_pointers<T>::type;
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_remove_cvref.h
+++ b/include/utl/type_traits/utl_remove_cvref.h
@@ -30,11 +30,13 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct remove_cvref {
+template <typename T>
+struct remove_cvref {
     using type = UTL_BUILTIN_remove_cvref(T);
 };
 
-template <typename T> using remove_cvref_t = UTL_BUILTIN_remove_cvref(T);
+template <typename T>
+using remove_cvref_t = UTL_BUILTIN_remove_cvref(T);
 
 UTL_NAMESPACE_END
 
@@ -44,9 +46,11 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct remove_cvref : remove_cv<remove_reference_t<T>> {};
+template <typename T>
+struct remove_cvref : remove_cv<remove_reference_t<T>> {};
 
-template <typename T> using remove_cvref_t = typename remove_cvref<T>::type;
+template <typename T>
+using remove_cvref_t = typename remove_cvref<T>::type;
 
 UTL_NAMESPACE_END
 

--- a/include/utl/type_traits/utl_remove_x_extent.h
+++ b/include/utl/type_traits/utl_remove_x_extent.h
@@ -20,8 +20,10 @@ using std::remove_extent_t;
 
 #  else // UTL_CXX14
 
-template <typename T> using remove_extent_t = typename remove_extent<T>::type;
-template <typename T> using remove_all_extent_t = typename remove_all_extent<T>::type;
+template <typename T>
+using remove_extent_t = typename remove_extent<T>::type;
+template <typename T>
+using remove_all_extent_t = typename remove_all_extent<T>::type;
 
 #  endif // UTL_CXX14
 
@@ -41,11 +43,13 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct remove_extent {
+template <typename T>
+struct remove_extent {
     using type = UTL_BUILTIN_remove_extent(T);
 };
 
-template <typename T> using remove_extent_t = UTL_BUILTIN_remove_extent(T);
+template <typename T>
+using remove_extent_t = UTL_BUILTIN_remove_extent(T);
 
 UTL_NAMESPACE_END
 
@@ -55,16 +59,20 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct remove_extent {
+template <typename T>
+struct remove_extent {
     using type = T;
 };
-template <typename T> struct remove_extent<T[]> {
+template <typename T>
+struct remove_extent<T[]> {
     using type = T;
 };
-template <typename T, size_t N> struct remove_extent<T[N]> {
+template <typename T, size_t N>
+struct remove_extent<T[N]> {
     using type = T;
 };
-template <typename T> using remove_extent_t = typename remove_extent<T>::type;
+template <typename T>
+using remove_extent_t = typename remove_extent<T>::type;
 
 UTL_NAMESPACE_END
 
@@ -72,15 +80,19 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct remove_all_extent {
+template <typename T>
+struct remove_all_extent {
     using type = T;
 };
-template <typename T> using remove_all_extent_t = typename remove_all_extent<T>::type;
+template <typename T>
+using remove_all_extent_t = typename remove_all_extent<T>::type;
 
-template <typename T> struct remove_all_extent<T[]> {
+template <typename T>
+struct remove_all_extent<T[]> {
     using type = remove_all_extent_t<T>;
 };
-template <typename T, size_t N> struct remove_all_extent<T[N]> {
+template <typename T, size_t N>
+struct remove_all_extent<T[N]> {
     using type = remove_all_extent_t<T>;
 };
 

--- a/include/utl/type_traits/utl_std_traits.h
+++ b/include/utl/type_traits/utl_std_traits.h
@@ -88,27 +88,33 @@ using ::std::has_virtual_destructor;
 
 using ::std::alignment_of;
 
-template <typename... Ts> struct common_type : ::std::common_type<Ts...> {};
+template <typename... Ts>
+struct common_type : ::std::common_type<Ts...> {};
 
 using ::std::underlying_type;
 
-template <typename... T> using common_type_t = typename common_type<T...>::type;
-template <typename T> using underlying_type_t = typename underlying_type<T>::type;
+template <typename... T>
+using common_type_t = typename common_type<T...>::type;
+template <typename T>
+using underlying_type_t = typename underlying_type<T>::type;
 
 namespace details {
 namespace convertible {
 template <typename From, typename To>
 auto nothrow_test(int) -> enable_if_t<is_convertible<From, To>::value,
     bool_constant<noexcept(static_cast<To>(declval<From>()))>>;
-template <typename, typename> false_type nothrow_test(float);
-template <typename From, typename To> using is_nothrow = decltype(nothrow_test<From, To>(0));
+template <typename, typename>
+false_type nothrow_test(float);
+template <typename From, typename To>
+using is_nothrow = decltype(nothrow_test<From, To>(0));
 
 } /* namespace convertible */
 } /* namespace details */
 
 template <typename From, typename To>
 struct is_nothrow_convertible : details::convertible::is_nothrow<From, To> {};
-template <typename To> struct is_nothrow_convertible<To, To> : true_type {};
+template <typename To>
+struct is_nothrow_convertible<To, To> : true_type {};
 
 #ifdef UTL_BUILTIN_is_layout_compatible
 template <typename T, typename U>
@@ -121,8 +127,10 @@ UTL_INLINE_CXX17 constexpr bool is_layout_compatible_v = UTL_BUILTIN_is_layout_c
 
 #  define UTL_TRAIT_SUPPORTED_is_layout_compatible 1
 #else /* ifdef UTL_BUILTIN_is_layout_compatible */
-template <typename, typename> struct is_layout_compatible : false_type {};
-template <typename T> struct is_layout_compatible<T, T> : true_type {};
+template <typename, typename>
+struct is_layout_compatible : false_type {};
+template <typename T>
+struct is_layout_compatible<T, T> : true_type {};
 
 #  ifdef UTL_CXX14
 template <typename T, typename U>
@@ -147,8 +155,10 @@ UTL_INLINE_CXX17 constexpr bool is_pointer_interconvertible_base_of_v =
 
 #  define UTL_TRAIT_SUPPORTED_is_pointer_interconvertible_base_of 1
 #else /* ifdef UTL_BUILTIN_is_pointer_interconvertible_base_of */
-template <typename, typename> struct is_pointer_interconvertible_base_of : false_type {};
-template <typename T> struct is_pointer_interconvertible_base_of<T, T> : true_type {};
+template <typename, typename>
+struct is_pointer_interconvertible_base_of : false_type {};
+template <typename T>
+struct is_pointer_interconvertible_base_of<T, T> : true_type {};
 
 #  ifdef UTL_CXX14
 template <typename T, typename U>
@@ -173,7 +183,8 @@ UTL_INLINE_CXX17 constexpr bool reference_constructs_from_temporary_v =
 #  endif
 
 #else /* ifdef UTL_BUILTIN_reference_constructs_from_temporary */
-template <typename, typename> struct reference_constructs_from_temporary : false_type {};
+template <typename, typename>
+struct reference_constructs_from_temporary : false_type {};
 
 #  ifdef UTL_CXX14
 template <typename T, typename U>

--- a/include/utl/type_traits/utl_template_list.h
+++ b/include/utl/type_traits/utl_template_list.h
@@ -9,9 +9,11 @@ UTL_NAMESPACE_BEGIN
 
 using size_t = decltype(sizeof(0));
 
-template <size_t I, typename List> struct template_element;
+template <size_t I, typename List>
+struct template_element;
 
-template <typename List> struct template_size;
+template <typename List>
+struct template_size;
 
 template <size_t I, typename List>
 using template_element_t = typename template_element<I, List>::type;
@@ -21,16 +23,19 @@ struct template_element<0, List<Head, Tail...>> {
     using type = Head;
 };
 
-template <typename... T> struct type_list;
+template <typename... T>
+struct type_list;
 
 template <size_t I, template <typename...> class List, typename Head, typename... Tail>
 struct template_element<I, List<Head, Tail...>> : template_element<I - 1, type_list<Tail...>> {};
 
-template <template <typename...> class List, typename... Args> struct template_size<List<Args...>> {
+template <template <typename...> class List, typename... Args>
+struct template_size<List<Args...>> {
     static constexpr size_t value = sizeof...(Args);
 };
 
-template <typename T, typename List> struct template_count;
+template <typename T, typename List>
+struct template_count;
 
 template <typename T, template <typename...> class List>
 struct template_count<T, List<>> : integral_constant<size_t, 0> {};
@@ -53,16 +58,19 @@ template <typename T, template <typename...> class TList, typename Head, typenam
 struct template_index<T, TList<Head, Tail...>> :
     integral_constant<size_t, 1 + template_index<T, TList<Tail...>>::value> {};
 
-template <typename T, typename U> struct template_concat;
+template <typename T, typename U>
+struct template_concat;
 template <template <typename...> class List, typename... Ts, typename... Us>
 struct template_concat<List<Ts...>, List<Us...>> {
     using type = List<Ts..., Us...>;
 };
-template <typename T, typename U> using template_concat_t = typename template_concat<T, U>::type;
+template <typename T, typename U>
+using template_concat_t = typename template_concat<T, U>::type;
 
 #ifdef UTL_CXX17
 
-template <auto... V> struct auto_list;
+template <auto... V>
+struct auto_list;
 
 template <template <auto...> class List, auto Head, auto... Tail>
 struct template_element<0, List<Head, Tail...>> {
@@ -72,7 +80,8 @@ struct template_element<0, List<Head, Tail...>> {
 template <size_t I, template <auto...> class List, auto Head, auto... Tail>
 struct template_element<I, List<Head, Tail...>> : template_element<I - 1, auto_list<Tail...>> {};
 
-template <template <auto...> class List, auto... Tail> struct template_size<List<Tail...>> {
+template <template <auto...> class List, auto... Tail>
+struct template_size<List<Tail...>> {
     static constexpr size_t value = sizeof...(Tail);
 };
 
@@ -84,7 +93,8 @@ struct template_count<value_constant<T, Value>, List<Value, Tail...>> :
     integral_constant<size_t,
         1 + template_count<value_constant<T, Value>, auto_list<Tail...>>::value> {};
 
-template <auto V> using auto_constant = value_constant<decltype(V), V>;
+template <auto V>
+using auto_constant = value_constant<decltype(V), V>;
 
 #endif // ifdef UTL_CXX17
 

--- a/include/utl/type_traits/utl_type_identity.h
+++ b/include/utl/type_traits/utl_type_identity.h
@@ -6,10 +6,12 @@
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> struct type_identity {
+template <typename T>
+struct type_identity {
     using type = T;
 };
-template <typename T> using type_identity_t = typename type_identity<T>::type;
+template <typename T>
+using type_identity_t = typename type_identity<T>::type;
 
 UTL_NAMESPACE_END
 

--- a/include/utl/type_traits/utl_undefined_trait.h
+++ b/include/utl/type_traits/utl_undefined_trait.h
@@ -6,9 +6,11 @@ UTL_NAMESPACE_BEGIN
 
 using size_t = decltype(sizeof(0));
 
-template <typename... Ts> struct undefined_trait {
+template <typename... Ts>
+struct undefined_trait {
 private:
-    template <typename U> static UTL_CONSTEVAL_CXX20 size_t sum_of_sizes() noexcept {
+    template <typename U>
+    static UTL_CONSTEVAL_CXX20 size_t sum_of_sizes() noexcept {
         return sizeof(U);
     }
 

--- a/include/utl/type_traits/utl_unwrap_reference.h
+++ b/include/utl/type_traits/utl_unwrap_reference.h
@@ -6,26 +6,32 @@
 
 UTL_STD_NAMESPACE_BEGIN
 /* UTL_UNDEFINED_BEHAVIOUR */
-template <typename> class reference_wrapper;
+template <typename>
+class reference_wrapper;
 UTL_STD_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename> class reference_wrapper;
+template <typename>
+class reference_wrapper;
 
-template <typename T> struct unwrap_reference {
+template <typename T>
+struct unwrap_reference {
     using type = T;
 };
 
-template <typename T> struct unwrap_reference<reference_wrapper<T>> {
+template <typename T>
+struct unwrap_reference<reference_wrapper<T>> {
     using type = T&;
 };
 
-template <typename T> struct unwrap_reference<::std::reference_wrapper<T>> {
+template <typename T>
+struct unwrap_reference<::std::reference_wrapper<T>> {
     using type = T&;
 };
 
-template <typename T> using unwrap_reference_t = typename unwrap_reference<T>::type;
+template <typename T>
+using unwrap_reference_t = typename unwrap_reference<T>::type;
 
 UTL_NAMESPACE_END
 

--- a/include/utl/type_traits/utl_variadic_proxy.h
+++ b/include/utl/type_traits/utl_variadic_proxy.h
@@ -6,8 +6,10 @@
 
 UTL_NAMESPACE_BEGIN
 
-template <template <typename...> class Variadic, typename... Types> struct variadic_proxy {
-    template <typename... UTypes> using apply = Variadic<Types..., UTypes...>;
+template <template <typename...> class Variadic, typename... Types>
+struct variadic_proxy {
+    template <typename... UTypes>
+    using apply = Variadic<Types..., UTypes...>;
 };
 
 UTL_NAMESPACE_END

--- a/include/utl/type_traits/utl_variadic_traits.h
+++ b/include/utl/type_traits/utl_variadic_traits.h
@@ -13,7 +13,8 @@ UTL_NAMESPACE_BEGIN
 
 using size_t = decltype(sizeof(0));
 
-template <typename... Types> struct variadic_traits {
+template <typename... Types>
+struct variadic_traits {
     static constexpr size_t size = sizeof...(Types);
 
     static constexpr bool is_nothrow_swappable =

--- a/include/utl/type_traits/utl_void_t.h
+++ b/include/utl/type_traits/utl_void_t.h
@@ -4,7 +4,8 @@
 
 UTL_NAMESPACE_BEGIN
 
-template <typename...> using void_t = void;
+template <typename...>
+using void_t = void;
 
 UTL_NAMESPACE_END
 

--- a/include/utl/utility/utl_as_const.h
+++ b/include/utl/utility/utl_as_const.h
@@ -26,7 +26,8 @@ UTL_PRAGMA_WARN(
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T> void as_const(T&&) noexcept = delete;
+template <typename T>
+void as_const(T&&) noexcept = delete;
 
 template <typename T>
 UTL_ATTRIBUTES(NODISCARD, CONST, INTRINSIC)

--- a/include/utl/utility/utl_as_constant_type.h
+++ b/include/utl/utility/utl_as_constant_type.h
@@ -26,8 +26,10 @@ constexpr integral_constant<decltype(V), V> as_integral_constant() noexcept {
     return {};
 }
 
-template <auto V> using index_constant_t = decltype(as_index_constant<V>());
-template <auto V> using integral_constant_t = decltype(as_integral_constant<V>());
+template <auto V>
+using index_constant_t = decltype(as_index_constant<V>());
+template <auto V>
+using integral_constant_t = decltype(as_integral_constant<V>());
 
 UTL_NAMESPACE_END
 

--- a/include/utl/utility/utl_ignore.h
+++ b/include/utl/utility/utl_ignore.h
@@ -8,11 +8,15 @@
 UTL_NAMESPACE_BEGIN
 
 struct ignore_t {
-#ifdef UTL_CXX14
     explicit constexpr ignore_t() noexcept = default;
-    template <typename T> constexpr void operator= (T&&) const noexcept {}
+#ifdef UTL_CXX14
+    template <typename T>
+    constexpr void operator=(T&&) const noexcept {}
 #else
-    template <typename T> constexpr ignore_t const& operator= (T&&) const noexcept { return *this; }
+    template <typename T>
+    constexpr ignore_t const& operator=(T&&) const noexcept {
+        return *this;
+    }
 #endif
 };
 

--- a/include/utl/utility/utl_pair.h
+++ b/include/utl/utility/utl_pair.h
@@ -43,17 +43,26 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T0, typename T1> struct pair;
+template <typename T0, typename T1>
+struct pair;
 
-template <typename...> class tuple;
+template <typename...>
+class tuple;
 
-template <typename T> struct is_pair : false_type {};
-template <typename T> struct is_pair<T&&> : is_pair<T> {};
-template <typename T> struct is_pair<T&> : is_pair<T> {};
-template <typename T> struct is_pair<T const> : is_pair<T> {};
-template <typename T> struct is_pair<T volatile> : is_pair<T> {};
-template <typename T> struct is_pair<T const volatile> : is_pair<T> {};
-template <typename T, typename U> struct is_pair<pair<T, U>> : true_type {};
+template <typename T>
+struct is_pair : false_type {};
+template <typename T>
+struct is_pair<T&&> : is_pair<T> {};
+template <typename T>
+struct is_pair<T&> : is_pair<T> {};
+template <typename T>
+struct is_pair<T const> : is_pair<T> {};
+template <typename T>
+struct is_pair<T volatile> : is_pair<T> {};
+template <typename T>
+struct is_pair<T const volatile> : is_pair<T> {};
+template <typename T, typename U>
+struct is_pair<pair<T, U>> : true_type {};
 
 struct piecewise_construct_t {
     explicit constexpr piecewise_construct_t() noexcept = default;
@@ -165,7 +174,8 @@ UTL_END_REGION(pair_get)
 namespace details {
 namespace pair {
 
-template <typename, typename> struct invalid_swap_t {
+template <typename, typename>
+struct invalid_swap_t {
     inline UTL_CONSTEXPR_CXX14 void swap(invalid_swap_t& other) const noexcept {}
     inline UTL_CONSTEXPR_CXX14 void swap(invalid_swap_t const& other) const noexcept {}
 };
@@ -173,7 +183,8 @@ template <typename, typename> struct invalid_swap_t {
 } // namespace pair
 } // namespace details
 
-template <typename T0, typename T1> struct pair : private variadic_traits<T0, T1> {
+template <typename T0, typename T1>
+struct pair : private variadic_traits<T0, T1> {
 private:
     using traits = variadic_traits<T0, T1>;
     using this_type = pair<T0, T1>;
@@ -182,7 +193,8 @@ private:
     using const_swap_type = conditional_t<traits::template is_const_swappable, pair,
         details::pair::invalid_swap_t<T0, T1>> const;
 
-    template <typename V, typename...> using defer = V;
+    template <typename V, typename...>
+    using defer = V;
 
     template <typename U0, typename U1>
     UTL_CONSTEXPR_CXX14 pair& assign(U0&& other_first, U1&& other_second) noexcept(
@@ -218,21 +230,21 @@ public:
 
     constexpr pair(pair const&) noexcept(traits::is_nothrow_copy_constructible) = default;
     constexpr pair(pair&&) noexcept(traits::is_nothrow_move_constructible) = default;
-    UTL_CONSTEXPR_CXX14 pair& operator= (pair const&) noexcept(
+    UTL_CONSTEXPR_CXX14 pair& operator=(pair const&) noexcept(
         traits::is_nothrow_copy_assignable) = default;
-    UTL_CONSTEXPR_CXX14 pair& operator= (pair&&) noexcept(
+    UTL_CONSTEXPR_CXX14 pair& operator=(pair&&) noexcept(
         traits::is_nothrow_move_assignable) = default;
 
     template <typename U0 = T0, typename U1 = T1,
         typename V = defer<bool_constant<traits::is_const_copy_assignable>, T0, T1>>
-    UTL_CONSTEXPR_CXX14 enable_if_t<V::value, pair const&> operator= (pair const& other) const
+    UTL_CONSTEXPR_CXX14 enable_if_t<V::value, pair const&> operator=(pair const& other) const
         noexcept(traits::is_nothrow_const_copy_assignable) {
         return assign(other.first, other.second);
     }
 
     template <typename U0 = T0, typename U1 = T1,
         typename V = defer<bool_constant<traits::is_const_move_assignable>, T0, T1>>
-    UTL_CONSTEXPR_CXX14 enable_if_t<V::value, pair const&> operator= (pair&& other) const
+    UTL_CONSTEXPR_CXX14 enable_if_t<V::value, pair const&> operator=(pair&& other) const
         noexcept(traits::is_nothrow_const_move_assignable) {
         return assign(other.first, other.second);
     }
@@ -539,7 +551,7 @@ public:
     template <typename U0, typename U1>
     UTL_CONSTEXPR_CXX14
         enable_if_t<traits::template is_assignable<U0 const&, U1 const&>::value, pair&>
-        operator= (pair<U0, U1> const& p) noexcept(
+        operator=(pair<U0, U1> const& p) noexcept(
             traits::template is_nothrow_assignable<U0 const&, U1 const&>::value) {
         return assign(p.first, p.second);
     }
@@ -547,7 +559,7 @@ public:
     template <typename U0, typename U1>
     UTL_CONSTEXPR_CXX14
         enable_if_t<traits::template is_const_assignable<U0 const&, U1 const&>::value, pair const&>
-        operator= (pair<U0, U1> const& p) const
+        operator=(pair<U0, U1> const& p) const
         noexcept(traits::template is_nothrow_const_assignable<U0 const&, U1 const&>::value) {
         return assign(p.first, p.second);
     }
@@ -555,7 +567,7 @@ public:
 public:
     template <typename U0, typename U1>
     UTL_CONSTEXPR_CXX14 enable_if_t<traits::template is_assignable<U0&&, U1&&>::value, pair&>
-                        operator= (pair<U0, U1>&& p) noexcept(
+                        operator=(pair<U0, U1>&& p) noexcept(
         traits::template is_nothrow_assignable<U0&&, U1&&>::value) {
         return assign(move(p).first, move(p).second);
     }
@@ -563,7 +575,7 @@ public:
     template <typename U0, typename U1>
     UTL_CONSTEXPR_CXX14
         enable_if_t<traits::template is_const_assignable<U0&&, U1&&>::value, pair const&>
-        operator= (pair<U0, U1>&& p) const
+        operator=(pair<U0, U1>&& p) const
         noexcept(traits::template is_nothrow_const_assignable<U0&&, U1&&>::value) {
         return assign(move(p).first, move(p).second);
     }
@@ -574,7 +586,7 @@ public:
             conjunction<TT_SCOPE is_all_gettable<P>,
                 TT_SCOPE         rebind_references_t<traits::template is_assignable, P>>::value,
         pair&>
-                        operator= (P&& p) noexcept(TT_SCOPE is_all_nothrow_gettable<P>::value &&
+                        operator=(P&& p) noexcept(TT_SCOPE is_all_nothrow_gettable<P>::value &&
         TT_SCOPE rebind_references_t<traits::template is_nothrow_assignable, P>::value) {
         return assign(TT_SCOPE get<0>(forward<P>(p)), TT_SCOPE get<1>(forward<P>(p)));
     }
@@ -584,7 +596,7 @@ public:
             conjunction<TT_SCOPE is_all_gettable<P>,
                 TT_SCOPE rebind_references_t<traits::template is_const_assignable, P>>::value,
         pair const&>
-    operator= (P&& p) const noexcept(TT_SCOPE is_all_nothrow_gettable<P, 2>::value &&
+    operator=(P&& p) const noexcept(TT_SCOPE is_all_nothrow_gettable<P, 2>::value &&
         TT_SCOPE rebind_references_t<traits::template is_nothrow_const_assignable, P, 2>::value) {
         return assign(TT_SCOPE get<0>(forward<P>(p)), TT_SCOPE get<1>(forward<P>(p)));
     }
@@ -603,7 +615,7 @@ public:
 template <typename T0, typename T1, typename U0, typename U1>
 UTL_NODISCARD constexpr enable_if_t<
     conjunction<is_equality_comparable<T0, U0>, is_equality_comparable<T1, U1>>::value, bool>
-operator== (pair<T0, T1> const& l, pair<U0, U1> const& r) noexcept(
+operator==(pair<T0, T1> const& l, pair<U0, U1> const& r) noexcept(
     conjunction<is_nothrow_equality_comparable<T0, U0>,
         is_nothrow_equality_comparable<T1, U1>>::value) {
     return static_cast<bool>(l.first == r.first) && static_cast<bool>(l.second == r.second);
@@ -614,7 +626,7 @@ UTL_NODISCARD constexpr enable_if_t<
     conjunction<is_equality_comparable<T0, U0>, is_less_comparable<T0, U0>,
         is_less_comparable<T1, U1>>::value,
     bool>
-operator< (pair<T0, T1> const& l, pair<U0, U1> const& r) noexcept(
+operator<(pair<T0, T1> const& l, pair<U0, U1> const& r) noexcept(
     conjunction<is_nothrow_equality_comparable<T0, U0>, is_nothrow_less_comparable<T0, U0>,
         is_nothrow_less_comparable<T1, U1>>::value) {
     return static_cast<bool>(l.first < r.first) ||
@@ -623,28 +635,28 @@ operator< (pair<T0, T1> const& l, pair<U0, U1> const& r) noexcept(
 
 template <typename T0, typename T1, typename U0, typename U1>
 UTL_NODISCARD constexpr enable_if_t<is_equality_comparable<pair<T0, T1>, pair<U0, U1>>::value, bool>
-operator!= (pair<T0, T1> const& l, pair<U0, U1> const& r) noexcept(
+operator!=(pair<T0, T1> const& l, pair<U0, U1> const& r) noexcept(
     is_nothrow_equality_comparable<pair<T0, T1>, pair<U0, U1>>::value) {
     return !static_cast<bool>(l == r);
 }
 
 template <typename T0, typename T1, typename U0, typename U1>
 UTL_NODISCARD constexpr enable_if_t<is_less_comparable<pair<U0, U1>, pair<T0, T1>>::value, bool>
-operator<= (pair<T0, T1> const& l, pair<U0, U1> const& r) noexcept(
+operator<=(pair<T0, T1> const& l, pair<U0, U1> const& r) noexcept(
     is_nothrow_less_comparable<pair<U0, U1>, pair<T0, T1>>::value) {
     return !static_cast<bool>(r < l);
 }
 
 template <typename T0, typename T1, typename U0, typename U1>
 UTL_NODISCARD constexpr enable_if_t<is_less_comparable<pair<U0, U1>, pair<T0, T1>>::value, bool>
-operator> (pair<T0, T1> const& l, pair<U0, U1> const& r) noexcept(
+operator>(pair<T0, T1> const& l, pair<U0, U1> const& r) noexcept(
     is_nothrow_less_comparable<pair<U0, U1>, pair<T0, T1>>::value) {
     return static_cast<bool>(r < l);
 }
 
 template <typename T0, typename T1, typename U0, typename U1>
 UTL_NODISCARD constexpr enable_if_t<is_less_comparable<pair<T0, T1>, pair<U0, U1>>::value, bool>
-operator>= (pair<T0, T1> const& l, pair<U0, U1> const& r) noexcept(
+operator>=(pair<T0, T1> const& l, pair<U0, U1> const& r) noexcept(
     is_nothrow_less_comparable<pair<T0, T1>, pair<U0, U1>>::value) {
     return !static_cast<bool>(l < r);
 }
@@ -707,17 +719,17 @@ struct basic_common_reference<pair<T0, T1>, pair<U0, U1>, TQual, UQual> :
 
 namespace std {
 template <typename T0, typename T1, typename U0, typename U1>
-    requires requires { typename pair<common_type_t<T0, U0>, common_type_t<T1, U1>>; }
+requires requires { typename pair<common_type_t<T0, U0>, common_type_t<T1, U1>>; }
 struct common_type<pair<T0, T1>, pair<U0, U1>> {
     using type = pair<common_type_t<T0, U0>, common_type_t<T1, U1>>;
 };
 
 template <typename T0, typename T1, typename U0, typename U1, template <typename> class TQual,
     template <typename> class UQual>
-    requires requires {
-        typename pair<common_reference_t<TQual<T0>, UQual<U0>>,
-            common_reference_t<TQual<T1>, UQual<U1>>>;
-    }
+requires requires {
+    typename pair<common_reference_t<TQual<T0>, UQual<U0>>,
+        common_reference_t<TQual<T1>, UQual<U1>>>;
+}
 struct basic_common_reference<pair<T0, T1>, pair<U0, U1>, TQual, UQual> {
     using type =
         pair<common_reference_t<TQual<T0>, UQual<U0>>, common_reference_t<TQual<T1>, UQual<U1>>>;

--- a/include/utl/utility/utl_seq.h
+++ b/include/utl/utility/utl_seq.h
@@ -13,34 +13,53 @@ UTL_NAMESPACE_BEGIN
 
 namespace seq {
 namespace details {
-template <typename T> UTL_ATTRIBUTES(NODISCARD) UTL_CONSTEVAL_CXX20 T pow(T n, size_t p) noexcept {
+template <typename T>
+UTL_ATTRIBUTES(NODISCARD)
+UTL_CONSTEVAL_CXX20 T pow(T n, size_t p) noexcept {
     return !p ? 1 : ((p & 1) ? n : 1) * pow(n * n, p >> 1);
 }
 } // namespace details
 
-template <typename T, T... Is> using array_t = T const[sizeof...(Is)];
+template <typename T, T... Is>
+using array_t = T const[sizeof...(Is)];
 
-template <typename T, T... Is> UTL_INLINE_CXX17 constexpr array_t<T, Is...> array{Is...};
+template <typename T, T... Is>
+UTL_INLINE_CXX17 constexpr array_t<T, Is...> array{Is...};
 
-template <typename T, T N> using scalar_t = integral_constant<T, N>;
+template <typename T, T N>
+using scalar_t = integral_constant<T, N>;
 
-template <uint8_t N> using uscalar8_t = scalar_t<decltype(N), N>;
-template <uint16_t N> using uscalar16_t = scalar_t<decltype(N), N>;
-template <uint32_t N> using uscalar32_t = scalar_t<decltype(N), N>;
-template <uint64_t N> using uscalar64_t = scalar_t<decltype(N), N>;
+template <uint8_t N>
+using uscalar8_t = scalar_t<decltype(N), N>;
+template <uint16_t N>
+using uscalar16_t = scalar_t<decltype(N), N>;
+template <uint32_t N>
+using uscalar32_t = scalar_t<decltype(N), N>;
+template <uint64_t N>
+using uscalar64_t = scalar_t<decltype(N), N>;
 
-template <int8_t N> using scalar8_t = scalar_t<decltype(N), N>;
-template <int16_t N> using scalar16_t = scalar_t<decltype(N), N>;
-template <int32_t N> using scalar32_t = scalar_t<decltype(N), N>;
-template <int64_t N> using scalar64_t = scalar_t<decltype(N), N>;
+template <int8_t N>
+using scalar8_t = scalar_t<decltype(N), N>;
+template <int16_t N>
+using scalar16_t = scalar_t<decltype(N), N>;
+template <int32_t N>
+using scalar32_t = scalar_t<decltype(N), N>;
+template <int64_t N>
+using scalar64_t = scalar_t<decltype(N), N>;
 
-template <make_signed_t<size_t> N> using sindex_t = scalar_t<decltype(N), N>;
-template <size_t N> using index_t = scalar_t<decltype(N), N>;
+template <make_signed_t<size_t> N>
+using sindex_t = scalar_t<decltype(N), N>;
+template <size_t N>
+using index_t = scalar_t<decltype(N), N>;
 
-template <typename T, size_t N> using range_t = make_integer_sequence<T, N>;
-template <typename T, T... Is> using sequence_t = integer_sequence<T, Is...>;
-template <typename T, size_t N> UTL_INLINE_CXX17 constexpr range_t<T, N>       range = {};
-template <typename T, T... Is> UTL_INLINE_CXX17 constexpr sequence_t<T, Is...> sequence = {};
+template <typename T, size_t N>
+using range_t = make_integer_sequence<T, N>;
+template <typename T, T... Is>
+using sequence_t = integer_sequence<T, Is...>;
+template <typename T, size_t N>
+UTL_INLINE_CXX17 constexpr range_t<T, N> range = {};
+template <typename T, T... Is>
+UTL_INLINE_CXX17 constexpr sequence_t<T, Is...> sequence = {};
 
 template <typename T, T I>
 UTL_ATTRIBUTES(NODISCARD, CONST)
@@ -69,13 +88,13 @@ constexpr auto NAME(sequence_t<T, Is...>, sequence_t<U, Js...>) noexcept
 }
 template <typename T, T... Is, typename U, U J>
 UTL_ATTRIBUTES(NODISCARD, CONST)
-constexpr auto operator SYM (sequence_t<T, Is...>, scalar_t<U, J>) noexcept
+constexpr auto operator SYM(sequence_t<T, Is...>, scalar_t<U, J>) noexcept
     -> sequence_t<UTL_BINOP_RESULT(SYM, T, U), (Is SYM J)...> {
     return {};
 }
 template <typename T, T... Is, typename U, U... Js>
 UTL_ATTRIBUTES(NODISCARD, CONST)
-constexpr auto operator SYM (sequence_t<T, Is...>, sequence_t<U, Js...>) noexcept
+constexpr auto operator SYM(sequence_t<T, Is...>, sequence_t<U, Js...>) noexcept
     -> sequence_t<UTL_BINOP_RESULT(SYM, T, U), (Is SYM Js)...> {
     return {};
 }

--- a/include/utl/utility/utl_sequence.h
+++ b/include/utl/utility/utl_sequence.h
@@ -31,29 +31,35 @@ UTL_NAMESPACE_BEGIN
 
 using size_t = decltype(sizeof(0));
 
-template <typename T, T... Is> struct integer_sequence {};
+template <typename T, T... Is>
+struct integer_sequence {};
 
 namespace details {
 namespace sequence {
 
-template <typename, typename> struct combine;
+template <typename, typename>
+struct combine;
 
 template <typename T, T... Is, T... Js>
 struct combine<integer_sequence<T, Is...>, integer_sequence<T, Js...>> {
     using type = integer_sequence<T, Is..., (sizeof...(Is) + Js)...>;
 };
 
-template <typename T> struct combine<integer_sequence<T>, integer_sequence<T>> {
+template <typename T>
+struct combine<integer_sequence<T>, integer_sequence<T>> {
     using type = integer_sequence<T>;
 };
 
-template <typename T, size_t N> struct generate;
+template <typename T, size_t N>
+struct generate;
 
-template <typename T> struct generate<T, 0> {
+template <typename T>
+struct generate<T, 0> {
     using type = integer_sequence<T>;
 };
 
-template <typename T> struct generate<T, 1> {
+template <typename T>
+struct generate<T, 1> {
     using type = integer_sequence<T, 0>;
 };
 
@@ -61,9 +67,11 @@ template <typename T, size_t N>
 struct generate :
     combine<typename generate<T, N / 2>::type, typename generate<T, N - N / 2>::type> {};
 
-template <typename T, T N, bool = (N >= 0)> struct safe_generate;
+template <typename T, T N, bool = (N >= 0)>
+struct safe_generate;
 
-template <typename T, T N> struct safe_generate<T, N, true> : generate<T, (size_t)N> {};
+template <typename T, T N>
+struct safe_generate<T, N, true> : generate<T, (size_t)N> {};
 
 } // namespace sequence
 } // namespace details
@@ -71,11 +79,14 @@ template <typename T, T N> struct safe_generate<T, N, true> : generate<T, (size_
 template <typename T, T N>
 using make_integer_sequence = typename details::sequence::safe_generate<T, N>::type;
 
-template <size_t... Is> using index_sequence = integer_sequence<size_t, Is...>;
+template <size_t... Is>
+using index_sequence = integer_sequence<size_t, Is...>;
 
-template <size_t N> using make_index_sequence = make_integer_sequence<size_t, N>;
+template <size_t N>
+using make_index_sequence = make_integer_sequence<size_t, N>;
 
-template <typename... Ts> using index_sequence_for = make_index_sequence<sizeof...(Ts)>;
+template <typename... Ts>
+using index_sequence_for = make_index_sequence<sizeof...(Ts)>;
 
 UTL_NAMESPACE_END
 

--- a/include/utl/utility/utl_swap.h
+++ b/include/utl/utility/utl_swap.h
@@ -33,13 +33,15 @@ UTL_NAMESPACE_BEGIN
 
 namespace utility {
 namespace details {
-template <typename T> using noop_swap = is_empty<T>;
+template <typename T>
+using noop_swap = is_empty<T>;
 template <typename T>
 using can_swap_by_move = conjunction<is_move_constructible<T>, is_move_assignable<T>>;
 template <typename T>
 using can_swap_by_copy = conjunction<is_copy_constructible<T>, is_copy_assignable<T>>;
 
-template <typename T> using noop_swap_t = enable_if_t<noop_swap<T>::value>;
+template <typename T>
+using noop_swap_t = enable_if_t<noop_swap<T>::value>;
 template <typename T>
 using only_swap_by_move_t = enable_if_t<!noop_swap<T>::value && can_swap_by_move<T>::value>;
 template <typename T>
@@ -92,7 +94,7 @@ struct swap_cpo_t {
         typename U UTL_REQUIRES_CXX11(
             decltype(swap(declval<T&>(), declval<U&>()), true_type{})::value)>
     UTL_REQUIRES_CXX20(requires { swap(declval<T&>(), declval<U&>()); })
-    UTL_ATTRIBUTES(FLATTEN) inline UTL_CONSTEXPR_CXX14 void operator() (T& l, U& r) const
+    UTL_ATTRIBUTES(FLATTEN) inline UTL_CONSTEXPR_CXX14 void operator()(T& l, U& r) const
         noexcept(noexcept(swap(declval<T&>(), declval<U&>()))) {
         swap(l, r);
     }
@@ -108,27 +110,34 @@ namespace details {
 template <typename T, typename U,
     typename R = decltype(utility::swap(declval<T>(), declval<U>()),
         utility::swap(declval<U>(), declval<T>()), true_type{})>
-auto                               swap_test(int) -> R;
-template <typename, typename> auto swap_test(float) -> false_type;
+auto swap_test(int) -> R;
+template <typename, typename>
+auto swap_test(float) -> false_type;
 
 template <typename T, typename U,
     bool R = noexcept(swap(declval<T>(), declval<U>())) && noexcept(
         swap(declval<U>(), declval<T>()))>
-auto                               nothrow_swap_test(int) -> bool_constant<R>;
-template <typename, typename> auto nothrow_swap_test(float) -> false_type;
+auto nothrow_swap_test(int) -> bool_constant<R>;
+template <typename, typename>
+auto nothrow_swap_test(float) -> false_type;
 
-template <typename T, typename U> using swap_result = decltype(swap_test<T, U>(0));
-template <typename T, typename U> using nothrow_swap_result = decltype(nothrow_swap_test<T, U>(0));
+template <typename T, typename U>
+using swap_result = decltype(swap_test<T, U>(0));
+template <typename T, typename U>
+using nothrow_swap_result = decltype(nothrow_swap_test<T, U>(0));
 
 } // namespace details
 } // namespace utility
 
-template <typename T, typename U> struct is_swappable_with : utility::details::swap_result<T, U> {};
+template <typename T, typename U>
+struct is_swappable_with : utility::details::swap_result<T, U> {};
 template <typename T, typename U>
 struct is_nothrow_swappable_with : utility::details::nothrow_swap_result<T, U> {};
 
-template <typename T> struct is_swappable : is_swappable_with<T&, T&> {};
-template <typename T> struct is_nothrow_swappable : is_nothrow_swappable_with<T&, T&> {};
+template <typename T>
+struct is_swappable : is_swappable_with<T&, T&> {};
+template <typename T>
+struct is_nothrow_swappable : is_nothrow_swappable_with<T&, T&> {};
 
 #  define UTL_TRAIT_SUPPORTED_is_swappable 1
 #  define UTL_TRAIT_SUPPORTED_is_swappable_with 1


### PR DESCRIPTION
* Break after template keyword
* No space after operator overload