### PR TITLE
Declval collision bugfix

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,6 @@ BasedOnStyle: LLVM
 ---
 Language: Cpp
 AlignAfterOpenBracket: DontAlign
-AlignConsecutiveDeclarations: true
 AlignEscapedNewlines: Left
 AlignOperands: DontAlign
 AlignTrailingComments: true
@@ -13,6 +12,12 @@ AllowShortEnumsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortLambdasOnASingleLine: All
 # AllowShortCompoundRequirementOnASingleLine: true
+AlignArrayOfStructures: Right
+AlignConsecutiveAssignments:
+  Enabled: false
+AlignConsecutiveDeclarations:
+  Enabled: false
+
 BraceWrapping:
   AfterCaseLabel: false
   AfterClass: false

--- a/include/utl/tuple/utl_tuple_cat.h
+++ b/include/utl/tuple/utl_tuple_cat.h
@@ -29,7 +29,7 @@ constexpr auto tuple_forward(Tuple&& tuple, index_sequence<Ns...>) noexcept(
     TT_SCOPE is_all_nothrow_gettable<Tuple>::value /* Only check the get expresions */
     /* We're constructing a tuple of references, so the construction should always be noexcept */
     ) -> UTL_SCOPE tuple<decltype(TT_SCOPE decl_element<Ns, Tuple>())...> {
-    return {TT_SCOPE get<Ns>(forward<Tuple>(tuple))...};
+    return {UTL_TUPLE_GET(Ns, forward<Tuple>(tuple))...};
 }
 
 template <typename Tuple>
@@ -60,12 +60,12 @@ constexpr auto tuple_cat_impl(UTL_SCOPE tuple<> const& tuple1, T0&& tuple0) noex
 template <typename T0, typename T1, size_t... I0, size_t... I1>
 constexpr auto tuple_cat_impl_idx(T0&& tuple0, T1&& tuple1, index_sequence<I0...>,
     index_sequence<I1...>) noexcept(TT_SCOPE is_all_nothrow_gettable<T0>::value &&
-    TT_SCOPE                                 is_all_nothrow_gettable<T1>::value &&
+    TT_SCOPE is_all_nothrow_gettable<T1>::value &&
     is_nothrow_constructible<TT_SCOPE concat_elements_t<T0, T1>,
-        decltype(TT_SCOPE get<I0>(declval<T0>()))...,
-        decltype(TT_SCOPE get<I1>(declval<T1>()))...>::value)
+        decltype(UTL_TUPLE_GET(I0, declval<T0>()))...,
+        decltype(UTL_TUPLE_GET(I1, declval<T1>()))...>::value)
     -> TT_SCOPE concat_elements_t<T0, T1> {
-    return {TT_SCOPE get<I0>(forward<T0>(tuple0))..., TT_SCOPE get<I1>(forward<T1>(tuple1))...};
+    return {UTL_TUPLE_GET(I0, forward<T0>(tuple0))..., UTL_TUPLE_GET(I1, forward<T1>(tuple1))...};
 }
 
 template <typename T0, typename T1>

--- a/include/utl/tuple/utl_tuple_compare_traits.h
+++ b/include/utl/tuple/utl_tuple_compare_traits.h
@@ -175,8 +175,8 @@ template <typename T, typename U, typename Cat, size_t... Is>
 auto all_three_way_comparable_with_test(int, index_sequence<Is...>)
     -> bool_constant<tuple_size<T>::value == tuple_size<U>::value &&
         conjunction<decltype(three_way_comparable_with_test<
-            remove_cvref_t<decltype(TT_SCOPE get<Is>(declval<T>()))>,
-            remove_cvref_t<decltype(TT_SCOPE get<Is>(declval<U>()))>, Cat>(0))...>::value>;
+            remove_cvref_t<decltype(UTL_TUPLE_GET(Is, declval<T>()))>,
+            remove_cvref_t<decltype(UTL_TUPLE_GET(Is, declval<U>()))>, Cat>(0))...>::value>;
 
 template <typename T, typename U, typename Cat, size_t... Is>
 auto all_nothrow_three_way_comparable_with_test(float, index_sequence<Is...>) -> false_type;
@@ -186,8 +186,8 @@ auto all_nothrow_three_way_comparable_with_test(int, index_sequence<Is...>)
     -> bool_constant<tuple_size<T>::value == tuple_size<U>::value &&
         TT_SCOPE is_all_nothrow_gettable<T>::value && TT_SCOPE is_all_nothrow_gettable<U>::value &&
         conjunction<decltype(nothrow_three_way_comparable_with_test<
-            remove_cvref_t<decltype(TT_SCOPE get<Is>(declval<T>()))>,
-            remove_cvref_t<decltype(TT_SCOPE get<Is>(declval<U>()))>, Cat>(0))...>::value>;
+            remove_cvref_t<decltype(UTL_TUPLE_GET(Is, declval<T>()))>,
+            remove_cvref_t<decltype(UTL_TUPLE_GET(Is, declval<U>()))>, Cat>(0))...>::value>;
 
 template <typename T, typename U, typename Cat, size_t N = tuple_size<T>::value>
 using all_three_way_comparable_with_test_t =

--- a/include/utl/tuple/utl_tuple_cpp17.h
+++ b/include/utl/tuple/utl_tuple_cpp17.h
@@ -99,8 +99,8 @@ private:
 template <>
 struct storage<> {
     constexpr storage() noexcept = default;
-    constexpr storage&       operator=(storage const&) noexcept = default;
-    constexpr storage&       operator=(storage&&) noexcept = default;
+    constexpr storage& operator=(storage const&) noexcept = default;
+    constexpr storage& operator=(storage&&) noexcept = default;
     UTL_CONSTEXPR_CXX14 void swap(storage<>& other) noexcept {}
 };
 
@@ -458,7 +458,7 @@ class tuple<> : private details::tuple::storage<> {
 public:
     using storage::storage;
     using storage::operator=;
-    UTL_CONSTEXPR_CXX14 void               swap(tuple const& other) const noexcept {}
+    UTL_CONSTEXPR_CXX14 void swap(tuple const& other) const noexcept {}
     friend inline UTL_CONSTEXPR_CXX14 void swap(tuple const&, tuple const&) noexcept {}
 };
 
@@ -487,24 +487,24 @@ private:
         conjunction<TT_SCOPE is_all_nothrow_gettable<TupleLike, sizeof...(Is)>,
             TT_SCOPE rebind_references_t<traits::template is_nothrow_constructible, TupleLike,
                 sizeof...(Is)>>::value)
-        : base_type(TT_SCOPE get<Is>(forward<TupleLike>(other))...) {}
+        : base_type(UTL_TUPLE_GET(Is, forward<TupleLike>(other))...) {}
 
     template <typename Alloc, typename TupleLike, size_t... Is>
     constexpr tuple(allocator_arg_t, Alloc const& alloc, TupleLike&& other,
         index_sequence<
             Is...>) noexcept(conjunction<TT_SCOPE is_all_nothrow_gettable<TupleLike, sizeof...(Is)>,
-        TT_SCOPE                                  rebind_references_t<
+        TT_SCOPE rebind_references_t<
             variadic_proxy<traits::template is_nothrow_constructible_with_allocator,
                 Alloc>::template apply,
             TupleLike, sizeof...(Types)>>::value)
-        : base_type(allocator_arg, alloc, TT_SCOPE get<Is>(forward<TupleLike>(other))...) {}
+        : base_type(allocator_arg, alloc, UTL_TUPLE_GET(Is, forward<TupleLike>(other))...) {}
 
     template <typename TupleLike, size_t... Is>
     UTL_CONSTEXPR_CXX14 tuple& assign(TupleLike&& other, index_sequence<Is...>) noexcept(
         conjunction<TT_SCOPE is_all_nothrow_gettable<TupleLike, sizeof...(Is)>,
-            TT_SCOPE         rebind_references_t<traits::template is_nothrow_assignable, TupleLike,
+            TT_SCOPE rebind_references_t<traits::template is_nothrow_assignable, TupleLike,
                 sizeof...(Is)>>::value) {
-        return (tuple&)base_type::assign(TT_SCOPE get<Is>(forward<TupleLike>(other))...);
+        return (tuple&)base_type::assign(UTL_TUPLE_GET(Is, forward<TupleLike>(other))...);
     }
 
     template <typename TupleLike, size_t... Is>
@@ -512,7 +512,7 @@ private:
         noexcept(conjunction<TT_SCOPE is_all_nothrow_gettable<TupleLike, sizeof...(Is)>,
             TT_SCOPE rebind_references_t<traits::template is_nothrow_const_assignable, TupleLike,
                 sizeof...(Is)>>::value) {
-        return (tuple const&)base_type::assign(TT_SCOPE get<Is>(forward<TupleLike>(other))...);
+        return (tuple const&)base_type::assign(UTL_TUPLE_GET(Is, forward<TupleLike>(other))...);
     }
 
 public:
@@ -552,7 +552,7 @@ public:
     template <typename... Us>
     UTL_CONSTEXPR_CXX14 enable_if_t<conjunction<typename traits::template matches<Us...>,
         typename traits::template is_swappable_with<Us const&...>>::value>
-                        swap(tuple<Us...> const& other) noexcept(
+    swap(tuple<Us...> const& other) noexcept(
         traits::template is_nothrow_swappable_with<Us const&...>::value) {
         static_assert(is_base_of<details::tuple::storage<Us...>, tuple<Us...>>::value,
             "tuple must inherit from storage");
@@ -1149,7 +1149,7 @@ public:
             int> = 0>
     constexpr tuple(allocator_arg_t, Alloc const& alloc, TupleLike&& other) noexcept(
         conjunction<TT_SCOPE is_all_nothrow_gettable<TupleLike, sizeof...(Types)>,
-            TT_SCOPE         rebind_references_t<
+            TT_SCOPE rebind_references_t<
                 variadic_proxy<traits::template is_nothrow_constructible_with_allocator,
                     Alloc>::template apply,
                 TupleLike, sizeof...(Types)>>::value)
@@ -1170,7 +1170,7 @@ public:
             int> = 1>
     explicit constexpr tuple(allocator_arg_t, Alloc const& alloc, TupleLike&& other) noexcept(
         conjunction<TT_SCOPE is_all_nothrow_gettable<TupleLike, sizeof...(Types)>,
-            TT_SCOPE         rebind_references_t<
+            TT_SCOPE rebind_references_t<
                 variadic_proxy<traits::template is_nothrow_constructible_with_allocator,
                     Alloc>::template apply,
                 TupleLike, sizeof...(Types)>>::value)
@@ -1191,7 +1191,7 @@ public:
             int> = 2>
     constexpr tuple(allocator_arg_t, Alloc const& alloc, TupleLike&& other) noexcept(
         conjunction<TT_SCOPE is_all_nothrow_gettable<TupleLike, sizeof...(Types)>,
-            TT_SCOPE         rebind_references_t<
+            TT_SCOPE rebind_references_t<
                 variadic_proxy<traits::template is_nothrow_constructible_with_allocator,
                     Alloc>::template apply,
                 TupleLike, sizeof...(Types)>>::value) = delete;
@@ -1211,7 +1211,7 @@ public:
             int> = 3>
     explicit constexpr tuple(allocator_arg_t, Alloc const& alloc, TupleLike&& other) noexcept(
         conjunction<TT_SCOPE is_all_nothrow_gettable<TupleLike, sizeof...(Types)>,
-            TT_SCOPE         rebind_references_t<
+            TT_SCOPE rebind_references_t<
                 variadic_proxy<traits::template is_nothrow_constructible_with_allocator,
                     Alloc>::template apply,
                 TupleLike, sizeof...(Types)>>::value) = delete;
@@ -1298,7 +1298,7 @@ public:
             int> = 0>
     UTL_CONSTEXPR_CXX14 tuple& operator=(TupleLike&& other) noexcept(
         conjunction<TT_SCOPE is_all_nothrow_gettable<TupleLike, sizeof...(Types)>,
-            TT_SCOPE         rebind_references_t<traits::template is_nothrow_assignable, TupleLike,
+            TT_SCOPE rebind_references_t<traits::template is_nothrow_assignable, TupleLike,
                 sizeof...(Types)>>::value) {
         return assign(forward<TupleLike>(other), index_sequence_for<Types...>{});
     }
@@ -1337,8 +1337,8 @@ template <size_t I, typename T, typename U>
 UTL_ATTRIBUTES(NODISCARD, CONST)
 constexpr enable_if_t<(I < tuple_size<T>::value), bool> less(T const& l, U const& r) noexcept(
     conjunction<compare_ops::has_nothrow_eq<T, U>, compare_ops::has_nothrow_lt<T, U>>::value) {
-    return (TT_SCOPE get<I - 1>(l) == TT_SCOPE get<I - 1>(r)) &&
-        ((TT_SCOPE get<I>(l) < TT_SCOPE get<I>(r)) || less<I + 1>(l, r));
+    return (UTL_TUPLE_GET(I - 1, l) == UTL_TUPLE_GET(I - 1, r)) &&
+        ((UTL_TUPLE_GET(I, l) < UTL_TUPLE_GET(I, r)) || less<I + 1>(l, r));
 }
 
 template <typename T, typename U>
@@ -1347,7 +1347,7 @@ constexpr bool less(T const& l, U const& r) noexcept(
     conjunction<compare_ops::has_nothrow_eq<T, U>, compare_ops::has_nothrow_lt<T, U>>::value) {
     static_assert(compare_ops::all_have_eq<T, U>::value, "All elements must be comparable");
     static_assert(compare_ops::all_have_lt<T, U>::value, "All elements must be comparable");
-    return (TT_SCOPE get<0>(l) < TT_SCOPE get<0>(r)) || less<1>(l, r);
+    return (UTL_TUPLE_GET(0, l) < UTL_TUPLE_GET(0, r)) || less<1>(l, r);
 }
 
 template <size_t I, typename T, typename U>
@@ -1360,7 +1360,7 @@ template <size_t I, typename T, typename U>
 UTL_ATTRIBUTES(NODISCARD, CONST)
 constexpr enable_if_t<(I < tuple_size<T>::value), bool> equals(T const& l, U const& r) noexcept(
     compare_ops::has_nothrow_eq<T, U>::value) {
-    return (TT_SCOPE get<I>(l) == TT_SCOPE get<I>(r)) && equals<I + 1>(l, r);
+    return (UTL_TUPLE_GET(I, l) == UTL_TUPLE_GET(I, r)) && equals<I + 1>(l, r);
 }
 
 template <typename T, typename U>

--- a/include/utl/tuple/utl_tuple_latest.h
+++ b/include/utl/tuple/utl_tuple_latest.h
@@ -105,7 +105,7 @@ struct storage<> {
     constexpr storage() noexcept = default;
     constexpr storage& operator=(storage const&) noexcept = default;
     constexpr storage& operator=(storage&&) noexcept = default;
-    constexpr void     swap(storage<>& other) noexcept {}
+    constexpr void swap(storage<>& other) noexcept {}
 };
 
 template <typename T>
@@ -482,7 +482,7 @@ class tuple<> : private details::tuple::storage<> {
 public:
     using storage::storage;
     using storage::operator=;
-    constexpr void               swap(tuple const& other) const noexcept {}
+    constexpr void swap(tuple const& other) const noexcept {}
     friend inline constexpr void swap(tuple const&, tuple const&) noexcept {}
 };
 
@@ -508,30 +508,30 @@ private:
 
     template <typename TupleLike, size_t... Is>
     constexpr tuple(TupleLike&& other, index_sequence<Is...>) noexcept(requires(TupleLike&& t) {
-        { base_type(TT_SCOPE get<Is>(forward<TupleLike>(t))...) } noexcept;
-    }) : base_type(TT_SCOPE get<Is>(forward<TupleLike>(other))...) {}
+        { base_type(UTL_TUPLE_GET(Is, forward<TupleLike>(t))...) } noexcept;
+    }) : base_type(UTL_TUPLE_GET(Is, forward<TupleLike>(other))...) {}
 
     template <typename Alloc, typename TupleLike, size_t... Is>
     constexpr tuple(allocator_arg_t, Alloc const& alloc, TupleLike&& other,
         index_sequence<Is...>) noexcept(requires(Alloc const& a, TupleLike&& t) {
-        { base_type(allocator_arg, a, TT_SCOPE get<Is>(forward<TupleLike>(t))...) } noexcept;
+        { base_type(allocator_arg, a, UTL_TUPLE_GET(Is, forward<TupleLike>(t))...) } noexcept;
     })
-        : base_type(allocator_arg, alloc, TT_SCOPE get<Is>(forward<TupleLike>(other))...) {}
+        : base_type(allocator_arg, alloc, UTL_TUPLE_GET(Is, forward<TupleLike>(other))...) {}
 
     template <typename TupleLike, size_t... Is>
     constexpr tuple& assign(TupleLike&& other, index_sequence<Is...>) noexcept(
         requires(base_type& b, TupleLike&& t) {
-            { b.assign(TT_SCOPE get<Is>(forward<TupleLike>(t))...) } noexcept;
+            { b.assign(UTL_TUPLE_GET(Is, forward<TupleLike>(t))...) } noexcept;
         }) {
-        return (tuple&)base_type::assign(TT_SCOPE get<Is>(forward<TupleLike>(other))...);
+        return (tuple&)base_type::assign(UTL_TUPLE_GET(Is, forward<TupleLike>(other))...);
     }
 
     template <typename TupleLike, size_t... Is>
     constexpr tuple const& assign(TupleLike&& other, index_sequence<Is...>) const
         noexcept(requires(base_type const& b, TupleLike&& t) {
-            { b.assign(TT_SCOPE get<Is>(forward<TupleLike>(t))...) } noexcept;
+            { b.assign(UTL_TUPLE_GET(Is, forward<TupleLike>(t))...) } noexcept;
         }) {
-        return (tuple const&)base_type::assign(TT_SCOPE get<Is>(forward<TupleLike>(other))...);
+        return (tuple const&)base_type::assign(UTL_TUPLE_GET(Is, forward<TupleLike>(other))...);
     }
 
 public:
@@ -807,7 +807,7 @@ public:
     template <typename Alloc, typename... UTypes>
     requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
     is_constructible_with_allocator<Alloc, UTypes...>::value&&
-            traits::template is_explicit_constructible_with_allocator<Alloc, UTypes...>::value&&
+        traits::template is_explicit_constructible_with_allocator<Alloc, UTypes...>::value&&
             traits::template is_dangling_without_allocator<Alloc,
                 UTypes...>::value explicit constexpr tuple(allocator_arg_t, Alloc const& alloc,
                 UTypes&&... args) noexcept(requires(Alloc const& alloc, UTypes&&... args) {
@@ -817,7 +817,7 @@ public:
     template <typename Alloc, typename... UTypes>
     requires (sizeof...(Types) == sizeof...(UTypes)) && traits::template
     is_constructible_with_allocator<Alloc, UTypes...>::value&&
-            traits::template is_implicit_constructible_with_allocator<Alloc, UTypes...>::value&&
+        traits::template is_implicit_constructible_with_allocator<Alloc, UTypes...>::value&&
             traits::template is_dangling_without_allocator<Alloc, UTypes...>::value constexpr tuple(
                 allocator_arg_t, Alloc const& alloc,
                 UTypes&&... args) noexcept(requires(Alloc const& alloc, UTypes&&... args) {
@@ -832,7 +832,7 @@ public:
             traits::template is_explicit_constructible_with_allocator<Alloc,
                 UTypes&...>::value) constexpr tuple(allocator_arg_t, Alloc const& alloc,
             tuple<UTypes...>& other) noexcept(requires(Alloc const& alloc,
-            tuple<UTypes...>&                                       other) {
+            tuple<UTypes...>& other) {
             { tuple(allocator_arg, alloc, other, index_sequence_for<UTypes...>{}) } noexcept;
         })
         : tuple(allocator_arg, alloc, other, index_sequence_for<UTypes...>{}) {}
@@ -844,7 +844,7 @@ public:
             traits::template is_explicit_constructible_with_allocator<Alloc,
                 UTypes&...>::value) constexpr tuple(allocator_arg_t, Alloc const& alloc,
             tuple<UTypes...>& other) noexcept(requires(Alloc const& alloc,
-            tuple<UTypes...>&                                       other) {
+            tuple<UTypes...>& other) {
             { tuple(allocator_arg, alloc, other, index_sequence_for<UTypes...>{}) } noexcept;
         }) = delete;
 
@@ -856,7 +856,7 @@ public:
             traits::template is_explicit_constructible_with_allocator<Alloc,
                 UTypes const&...>::value) constexpr tuple(allocator_arg_t, Alloc const& alloc,
             tuple<UTypes...> const& other) noexcept(requires(Alloc const& alloc,
-            tuple<UTypes...> const&                                       other) {
+            tuple<UTypes...> const& other) {
             { tuple(allocator_arg, alloc, other, index_sequence_for<UTypes...>{}) } noexcept;
         })
         : tuple(allocator_arg, alloc, other, index_sequence_for<UTypes...>{}) {}
@@ -868,7 +868,7 @@ public:
             traits::template is_explicit_constructible_with_allocator<Alloc,
                 UTypes const&...>::value) constexpr tuple(allocator_arg_t, Alloc const& alloc,
             tuple<UTypes...> const& other) noexcept(requires(Alloc const& alloc,
-            tuple<UTypes...> const&                                       other) {
+            tuple<UTypes...> const& other) {
             { tuple(allocator_arg, alloc, other, index_sequence_for<UTypes...>{}) } noexcept;
         }) = delete;
 
@@ -880,7 +880,7 @@ public:
             traits::template is_explicit_constructible_with_allocator<Alloc,
                 UTypes&&...>::value) constexpr tuple(allocator_arg_t, Alloc const& alloc,
             tuple<UTypes...>&& other) noexcept(requires(Alloc const& alloc,
-            tuple<UTypes...>&&                                       other) {
+            tuple<UTypes...>&& other) {
             { tuple(allocator_arg, alloc, move(other), index_sequence_for<UTypes...>{}) } noexcept;
         })
         : tuple(allocator_arg, alloc, move(other), index_sequence_for<UTypes...>{}) {}
@@ -892,7 +892,7 @@ public:
             traits::template is_explicit_constructible_with_allocator<Alloc,
                 UTypes&&...>::value) constexpr tuple(allocator_arg_t, Alloc const& alloc,
             tuple<UTypes...>&& other) noexcept(requires(Alloc const& alloc,
-            tuple<UTypes...>&&                                       other) {
+            tuple<UTypes...>&& other) {
             { tuple(allocator_arg, alloc, move(other), index_sequence_for<UTypes...>{}) } noexcept;
         }) = delete;
 
@@ -914,7 +914,7 @@ public:
             traits::template is_explicit_constructible_with_allocator<Alloc,
                 UTypes const&&...>::value) constexpr tuple(allocator_arg_t, Alloc const& alloc,
             tuple<UTypes...> const&& other) noexcept(requires(Alloc const& alloc,
-            tuple<UTypes...> const&&                                       other) {
+            tuple<UTypes...> const&& other) {
             { tuple(allocator_arg, alloc, move(other), index_sequence_for<UTypes...>{}) } noexcept;
         })
         : tuple(allocator_arg, alloc, move(other), index_sequence_for<UTypes...>{}) {}
@@ -926,7 +926,7 @@ public:
             traits::template is_explicit_constructible_with_allocator<Alloc,
                 UTypes const&&...>::value) constexpr tuple(allocator_arg_t, Alloc const& alloc,
             tuple<UTypes...> const&& other) noexcept(requires(Alloc const& alloc,
-            tuple<UTypes...> const&&                                       other) {
+            tuple<UTypes...> const&& other) {
             { tuple(allocator_arg, alloc, move(other), index_sequence_for<UTypes...>{}) } noexcept;
         }) = delete;
 
@@ -1005,7 +1005,7 @@ public:
     template <typename Alloc>
     requires traits::template
     is_constructible_with_allocator<Alloc, Types const&&...>::value constexpr tuple(allocator_arg_t,
-        Alloc const&  alloc,
+        Alloc const& alloc,
         tuple const&& other) noexcept(requires(Alloc const& alloc, tuple const&& other) {
         { tuple(allocator_arg, alloc, move(other), index_sequence_for<Types...>{}) } noexcept;
     })
@@ -1092,7 +1092,7 @@ public:
     requires traits::template
     is_assignable<UTypes const&&...>::value constexpr tuple& operator=(
         tuple<UTypes...> const&& other) noexcept(requires(tuple& t,
-        tuple<UTypes...> const&&                                 other) {
+        tuple<UTypes...> const&& other) {
         { t.assign(move(other), index_sequence_for<Types...>{}) } noexcept;
     }) {
         return assign(move(other), index_sequence_for<Types...>{});

--- a/include/utl/tuple/utl_tuple_traits.h
+++ b/include/utl/tuple/utl_tuple_traits.h
@@ -126,7 +126,7 @@ struct get_cpo_t {
     template <typename T>
     UTL_ATTRIBUTES(NODISCARD, FLATTEN, CONST)
     constexpr enable_if_t<sizeof(get<I>(declval<T>())) && is_tuple<T>::value, result_t<I, T>>
-    operator()(T&& t UTL_ATTRIBUTE(LIFETIMEBOUND)) const noexcept(noexcept(get<I>(declval<T>()))) {
+    operator()(T&& t UTL_ATTRIBUTE(LIFETIMEBOUND)) const noexcept {
         return get<I>(forward<T>(t));
     }
 };
@@ -155,23 +155,24 @@ constexpr enable_if_t<!is_tuple<T>::value, result_t<I, T>> get(
 template <size_t I, typename T>
 UTL_ATTRIBUTES(NODISCARD, FLATTEN, CONST)
 constexpr enable_if_t<is_tuple<T>::value, result_t<I, T>> get(
-    T&& t UTL_ATTRIBUTES(LIFETIMEBOUND)) noexcept(noexcept(details::get_cpo_t<I>()(declval<T>()))) {
+    T&& t UTL_ATTRIBUTES(LIFETIMEBOUND)) noexcept {
     return details::get_cpo_t<I>()(forward<T>());
 }
 
 #endif // ifdef UTL_CXX14
 
+#define UTL_TUPLE_GET(I, tuple) UTL_SCOPE tuple_traits::get<I>(tuple)
+
 namespace details {
 template <size_t I, typename T>
-auto nothrow_test(int) -> bool_constant<noexcept(UTL_SCOPE tuple_traits::get<I>(declval<T>()))>;
+auto nothrow_test(int) -> bool_constant<noexcept(UTL_TUPLE_GET(I, declval<T>()))>;
 template <size_t I, typename>
 auto nothrow_test(float) -> false_type;
 
 template <size_t I, typename T, typename = void>
 struct is_callable : false_type {};
 template <size_t I, typename T>
-struct is_callable<I, T, void_t<decltype(UTL_SCOPE tuple_traits::get<I>(declval<T>()))>> :
-    true_type {};
+struct is_callable<I, T, void_t<decltype(UTL_TUPLE_GET(I, declval<T>()))>> : true_type {};
 
 template <size_t I, typename T>
 using is_nothrow = decltype(nothrow_test<I, T>(0));
@@ -234,8 +235,8 @@ Target<typename UTL_SCOPE tuple_element<Is, T>::type...> rebuild_target_elements
  *
  * @return `Target<Ref...>`
  *  where:
- *    `Ref` is `decltype(get<I>(declval<TupleLike>()))` or `decltype(declval<TupleLike>().get<I>())`
- * where I is in the interval [0, N)
+ *    `Ref` is `decltype(get<I>(declval<TupleLike>()))` or
+ * `decltype(declval<TupleLike>().get<I>())` where I is in the interval [0, N)
  */
 template <template <typename...> class Target, typename TupleLike,
     size_t N = tuple_size<TupleLike>::value>
@@ -257,8 +258,8 @@ struct rebind_references {
  *
  * @return `Target<Ref...>`
  *  where:
- *    `Ref` is `decltype(get<I>(declval<TupleLike>()))` or `decltype(declval<TupleLike>().get<I>())`
- * where I is in the interval [0, N)
+ *    `Ref` is `decltype(get<I>(declval<TupleLike>()))` or
+ * `decltype(declval<TupleLike>().get<I>())` where I is in the interval [0, N)
  */
 template <template <typename...> class Target, typename TupleLike,
     size_t N = tuple_size<TupleLike>::value>

--- a/include/utl/utility/utl_declval.h
+++ b/include/utl/utility/utl_declval.h
@@ -2,12 +2,4 @@
 
 #pragma once
 
-#include "utl/preprocessor/utl_namespace.h"
-
-#include <type_traits>
-
-UTL_NAMESPACE_BEGIN
-
-using std::declval;
-
-UTL_NAMESPACE_END
+#include "utl/type_traits/utl_declval.h"

--- a/include/utl/utility/utl_pair.h
+++ b/include/utl/utility/utl_pair.h
@@ -216,11 +216,11 @@ private:
         typename... Args1, size_t... Is, size_t... Js>
     constexpr pair(L0<Args0...>& l0, L1<Args1...>& l1, index_sequence<Is...>,
         index_sequence<Js...>) noexcept(conjunction<TT_SCOPE is_nothrow_gettable<Is, L0<Args0>&>...,
-        TT_SCOPE                                             is_nothrow_gettable<Js, L1<Args1>&>...,
-        UTL_SCOPE                                            is_nothrow_constructible<T0, Args0...>,
+        TT_SCOPE is_nothrow_gettable<Js, L1<Args1>&>...,
+        UTL_SCOPE is_nothrow_constructible<T0, Args0...>,
         UTL_SCOPE is_nothrow_constructible<T1, Args1...>>::value)
-        : first(forward<Args0>(TT_SCOPE get<Is>(l0))...)
-        , second(forward<Args1>(TT_SCOPE get<Js>(l1))...) {}
+        : first(forward<Args0>(UTL_TUPLE_GET(Is, l0))...)
+        , second(forward<Args1>(UTL_TUPLE_GET(Js, l1))...) {}
 
 public:
     using first_type = T0;
@@ -259,7 +259,7 @@ public:
     }
     template <typename U0 = T0, typename U1 = T1>
     UTL_CONSTEXPR_CXX14 enable_if_t<traits::template is_swappable_with<U0 const&, U1 const&>::value>
-                        swap(pair<U0, U1> const& other) noexcept(
+    swap(pair<U0, U1> const& other) noexcept(
         traits::template is_nothrow_swappable_with<U0 const&, U1 const&>::value) {
         using UTL_SCOPE swap;
         swap(first, other.first);
@@ -495,8 +495,8 @@ public:
             int> = 0>
     constexpr pair(P&& p) noexcept(TT_SCOPE is_all_nothrow_gettable<P, 2>::value &&
         TT_SCOPE rebind_references_t<traits::template is_nothrow_constructible, P, 2>::value)
-        : first(TT_SCOPE get<0>(forward<P>(p)))
-        , second(TT_SCOPE get<1>(forward<P>(p))) {}
+        : first(UTL_TUPLE_GET(0, forward<P>(p)))
+        , second(UTL_TUPLE_GET(1, forward<P>(p))) {}
 
     template <typename P,
         enable_if_t<TT_SCOPE is_all_gettable<P, 2>::value &&
@@ -506,8 +506,8 @@ public:
             int> = 1>
     explicit constexpr pair(P&& p) noexcept(TT_SCOPE is_all_nothrow_gettable<P, 2>::value &&
         TT_SCOPE rebind_references_t<traits::template is_nothrow_constructible, P, 2>::value)
-        : first(TT_SCOPE get<0>(forward<P>(p)))
-        , second(TT_SCOPE get<1>(forward<P>(p))) {}
+        : first(UTL_TUPLE_GET(0, forward<P>(p)))
+        , second(UTL_TUPLE_GET(1, forward<P>(p))) {}
 
     template <typename P,
         enable_if_t<TT_SCOPE is_all_gettable<P, 2>::value &&
@@ -534,7 +534,7 @@ public:
     template <template <typename...> class L0, template <typename...> class L1, typename... Args0,
         typename... Args1,
         typename = enable_if_t<UTL_SCOPE is_constructible<T0, Args0...>::value &&
-            UTL_SCOPE                    is_constructible<T1, Args1...>::value>>
+            UTL_SCOPE is_constructible<T1, Args1...>::value>>
     constexpr pair(piecewise_construct_t, L0<Args0...> l0, L1<Args1...> l1) noexcept(
         UTL_SCOPE is_nothrow_constructible<pair, L0<Args0...>&, L1<Args1...>&,
             index_sequence_for<Args0...>, index_sequence_for<Args1...>>::value)
@@ -542,7 +542,7 @@ public:
 
     template <typename... Args0, typename... Args1,
         typename = enable_if_t<UTL_SCOPE is_constructible<T0, Args0...>::value &&
-            UTL_SCOPE                    is_constructible<T1, Args1...>::value>>
+            UTL_SCOPE is_constructible<T1, Args1...>::value>>
     constexpr pair(piecewise_construct_t, tuple<Args0...> l0, tuple<Args1...> l1) noexcept(
         UTL_SCOPE is_nothrow_constructible<pair, tuple<Args0...>&, tuple<Args1...>&,
             index_sequence_for<Args0...>, index_sequence_for<Args1...>>::value);
@@ -567,7 +567,7 @@ public:
 public:
     template <typename U0, typename U1>
     UTL_CONSTEXPR_CXX14 enable_if_t<traits::template is_assignable<U0&&, U1&&>::value, pair&>
-                        operator=(pair<U0, U1>&& p) noexcept(
+    operator=(pair<U0, U1>&& p) noexcept(
         traits::template is_nothrow_assignable<U0&&, U1&&>::value) {
         return assign(move(p).first, move(p).second);
     }
@@ -584,11 +584,11 @@ public:
     template <typename P>
     UTL_CONSTEXPR_CXX14 enable_if_t<tuple_size<P>::value == 2 &&
             conjunction<TT_SCOPE is_all_gettable<P>,
-                TT_SCOPE         rebind_references_t<traits::template is_assignable, P>>::value,
+                TT_SCOPE rebind_references_t<traits::template is_assignable, P>>::value,
         pair&>
-                        operator=(P&& p) noexcept(TT_SCOPE is_all_nothrow_gettable<P>::value &&
+    operator=(P&& p) noexcept(TT_SCOPE is_all_nothrow_gettable<P>::value &&
         TT_SCOPE rebind_references_t<traits::template is_nothrow_assignable, P>::value) {
-        return assign(TT_SCOPE get<0>(forward<P>(p)), TT_SCOPE get<1>(forward<P>(p)));
+        return assign(UTL_TUPLE_GET(0, forward<P>(p)), UTL_TUPLE_GET(1, forward<P>(p)));
     }
 
     template <typename P>
@@ -598,7 +598,7 @@ public:
         pair const&>
     operator=(P&& p) const noexcept(TT_SCOPE is_all_nothrow_gettable<P, 2>::value &&
         TT_SCOPE rebind_references_t<traits::template is_nothrow_const_assignable, P, 2>::value) {
-        return assign(TT_SCOPE get<0>(forward<P>(p)), TT_SCOPE get<1>(forward<P>(p)));
+        return assign(UTL_TUPLE_GET(0, forward<P>(p)), UTL_TUPLE_GET(1, forward<P>(p)));
     }
 
     UTL_CONSTEXPR_CXX20 ~pair() = default;


### PR DESCRIPTION
**Description**
declval header file in utility was still using the std alias, which caused some collision issues on files including it and type_traits declval

**Fix**
* Replace std alias in utlity/utl_declval.h
* Define `UTL_TUPLE_GET` for better readability