### PR TITLE
implemented scope exits

### DIFF
--- a/src/utl/public/utl/exception.h
+++ b/src/utl/public/utl/exception.h
@@ -8,12 +8,29 @@
 #include "utl/preprocessor/utl_namespace.h"
 
 #ifdef UTL_WITH_EXCEPTIONS
+#  include <exception>
 #  define UTL_THROW(...) throw(__VA_ARGS__)
 #  define UTL_RETHROW throw
 #  define UTL_TRY try
 #  define UTL_CATCH(...) catch (__VA_ARGS__)
-#else // UTL_WITH_EXCEPTIONS
 
+UTL_NAMESPACE_BEGIN
+using std::exception;
+using std::exception_ptr;
+#  ifdef UTL_CXX17
+using std::uncaught_exceptions;
+#  else
+using std::uncaught_exception;
+#  endif
+using std::current_exception;
+using std::get_terminate;
+using std::make_exception_ptr;
+using std::rethrow_exception;
+using std::set_terminate;
+using std::terminate;
+UTL_NAMESPACE_END
+
+#else // UTL_WITH_EXCEPTIONS
 UTL_NAMESPACE_BEGIN
 
 namespace details {

--- a/src/utl/public/utl/scope/utl_scope_exit.h
+++ b/src/utl/public/utl/scope/utl_scope_exit.h
@@ -1,0 +1,54 @@
+// Copyright 2023-2024 Bryan Wong
+
+#pragma once
+
+#include "utl/scope/utl_scope_impl.h"
+
+UTL_NAMESPACE_BEGIN
+
+template <typename F>
+class scope_exit : private details::scope::impl<scope_exit<F>, F> {
+    using base_type = details::scope::impl<scope_exit<F>, F>;
+    using base_type::is_movable;
+    using move_t = conditional_t<is_movable::value, scope_exit, details::scope::invalid_t>;
+
+public:
+    template <typename Fn, typename = enable_if_t<is_constructible<F, Fn&&>::value>>
+    scope_exit(Fn&& func) noexcept(is_nothrow_constructible<F, Fn&&>::value)
+        : base_type(forward<Fn>(func)) {}
+    scope_exit(move_t&& other) noexcept(is_nothrow_move_constructible<F>::value)
+        : base_type(move(other)) {}
+
+    using base_type::release;
+
+private:
+    static constexpr bool should_invoke() noexcept { return true; }
+};
+
+#ifdef UTL_CXX17
+
+template <typename Fn>
+explicit scope_exit(Fn&& f) -> scope_exit<decay_t<Fn>>;
+
+#endif
+
+template <typename Fn, typename = enable_if_t<is_constructible<scope_exit<decay_t<Fn>>, Fn>::value>>
+scope_exit<decay_t<Fn>> make_scope_exit(Fn&& f) noexcept(
+    is_nothrow_constructible<scope_exit<decay_t<Fn>>, declval<Fn>()>) {
+    return scope_exit<decay_t<Fn>>{forward<Fn>(f)};
+}
+
+namespace details {
+struct scope_exit_proxy_t {
+    template <typename Fn,
+        typename = enable_if_t<is_constructible<scope_exit<decay_t<Fn>>, Fn>::value>>
+    scope_exit<decay_t<Fn>> operator->*(Fn&& f) const
+        noexcept(is_nothrow_constructible<scope_exit<decay_t<Fn>>, declval<Fn>()>) {
+        return scope_exit<decay_t<Fn>>{forward<Fn>(f)};
+    }
+} scope_exit_proxy;
+} // namespace details
+
+#define UTL_ON_SCOPE_FAIL() auto UTL_UNIQUE_VAR(ScopeFail) = scope_exit_proxy->*[&]()
+
+UTL_NAMESPACE_END

--- a/src/utl/public/utl/scope/utl_scope_exit.h
+++ b/src/utl/public/utl/scope/utl_scope_exit.h
@@ -39,16 +39,19 @@ scope_exit<decay_t<Fn>> make_scope_exit(Fn&& f) noexcept(
 }
 
 namespace details {
-struct scope_exit_proxy_t {
+namespace scope {
+struct exit_proxy_t {
     template <typename Fn,
         typename = enable_if_t<is_constructible<scope_exit<decay_t<Fn>>, Fn>::value>>
     scope_exit<decay_t<Fn>> operator->*(Fn&& f) const
         noexcept(is_nothrow_constructible<scope_exit<decay_t<Fn>>, declval<Fn>()>) {
         return scope_exit<decay_t<Fn>>{forward<Fn>(f)};
     }
-} scope_exit_proxy;
+} exit_proxy;
+} // namespace scope
 } // namespace details
 
-#define UTL_ON_SCOPE_FAIL() auto UTL_UNIQUE_VAR(ScopeFail) = scope_exit_proxy->*[&]()
+#define UTL_ON_SCOPE_FAIL() \
+    auto UTL_UNIQUE_VAR(ScopeFail) = UTL_SCOPE details::scope::exit_proxy->*[&]()
 
 UTL_NAMESPACE_END

--- a/src/utl/public/utl/scope/utl_scope_fail.h
+++ b/src/utl/public/utl/scope/utl_scope_fail.h
@@ -1,0 +1,62 @@
+// Copyright 2023-2024 Bryan Wong
+
+#pragma once
+
+#include "utl/exception.h"
+#include "utl/scope/utl_scope_impl.h"
+
+UTL_NAMESPACE_BEGIN
+
+#ifdef UTL_CXX17
+template <typename F>
+class scope_fail : private details::scope::impl<scope_fail<F>, F> {
+    using base_type = details::scope::impl<scope_fail<F>, F>;
+    using is_movable = typename base_type::is_movable;
+    using move_t = conditional_t<is_movable::value, scope_fail, details::scope::invalid_t>;
+    friend base_type;
+
+public:
+    template <typename Fn, typename = enable_if_t<is_constructible<F, Fn&&>::value>>
+    scope_fail(Fn&& func) noexcept(is_nothrow_constructible<F, Fn&&>::value)
+        : base_type(forward<Fn>(func))
+        , exceptions_(uncaught_exceptions()) {}
+    scope_fail(move_t&& other) noexcept(is_nothrow_move_constructible<F>::value)
+        : base_type(move(other))
+        , exceptions_(other.exceptions_) {}
+
+    using base_type::release;
+
+private:
+    bool should_invoke() const noexcept { return exceptions_ < uncaught_exceptions(); }
+    int exceptions_;
+};
+
+template <typename Fn>
+explicit scope_fail(Fn&& f) -> scope_fail<decay_t<Fn>>;
+
+template <typename Fn, typename = enable_if_t<is_constructible<scope_fail<decay_t<Fn>>, Fn>::value>>
+scope_fail<decay_t<Fn>> make_scope_fail(Fn&& f) noexcept(
+    is_nothrow_constructible<scope_fail<decay_t<Fn>>, declval<Fn>()>) {
+    return scope_fail<decay_t<Fn>>{forward<Fn>(f)};
+}
+
+namespace details {
+struct scope_fail_proxy_t {
+    template <typename Fn,
+        typename = enable_if_t<is_constructible<scope_fail<decay_t<Fn>>, Fn>::value>>
+    scope_fail<decay_t<Fn>> operator->*(Fn&& f) const
+        noexcept(is_nothrow_constructible<scope_fail<decay_t<Fn>>, declval<Fn>()>) {
+        return scope_fail<decay_t<Fn>>{forward<Fn>(f)};
+    }
+} scope_fail_proxy;
+} // namespace details
+
+#  define UTL_ON_SCOPE_FAIL() auto UTL_UNIQUE_VAR(ScopeFail) = scope_fail_proxy->*[&]()
+#else
+template <typename F>
+class scope_fail {
+    static_assert(sizeof(F) == 0, "scope_fail is unsupported prior to C++17");
+};
+#endif
+
+UTL_NAMESPACE_END

--- a/src/utl/public/utl/scope/utl_scope_fail.h
+++ b/src/utl/public/utl/scope/utl_scope_fail.h
@@ -41,17 +41,20 @@ scope_fail<decay_t<Fn>> make_scope_fail(Fn&& f) noexcept(
 }
 
 namespace details {
-struct scope_fail_proxy_t {
+namespace scope {
+struct fail_proxy_t {
     template <typename Fn,
         typename = enable_if_t<is_constructible<scope_fail<decay_t<Fn>>, Fn>::value>>
     scope_fail<decay_t<Fn>> operator->*(Fn&& f) const
         noexcept(is_nothrow_constructible<scope_fail<decay_t<Fn>>, declval<Fn>()>) {
         return scope_fail<decay_t<Fn>>{forward<Fn>(f)};
     }
-} scope_fail_proxy;
+} fail_proxy;
+} // namespace scope
 } // namespace details
 
-#  define UTL_ON_SCOPE_FAIL() auto UTL_UNIQUE_VAR(ScopeFail) = scope_fail_proxy->*[&]()
+#  define UTL_ON_SCOPE_FAIL() \
+      auto UTL_UNIQUE_VAR(ScopeFail) = UTL_SCOPE details::scope::fail_proxy->*[&]()
 #else
 template <typename F>
 class scope_fail {

--- a/src/utl/public/utl/scope/utl_scope_impl.h
+++ b/src/utl/public/utl/scope/utl_scope_impl.h
@@ -1,0 +1,67 @@
+// Copyright 2023-2024 Bryan Wong
+
+#pragma once
+
+#include "utl/preprocessor/utl_config.h"
+#include "utl/type_traits/utl_is_same.h"
+#include "utl/type_traits/utl_logical_traits.h"
+#include "utl/type_traits/utl_std_traits.h" // TODO replace
+#include "utl/utility/utl_forward.h"
+
+UTL_NAMESPACE_BEGIN
+namespace details {
+namespace scope {
+class invalid_t {
+private:
+    constexpr invalid_t() noexcept = default;
+    ~invalid_t() noexcept = default;
+};
+
+template <typename Impl, typename F>
+class impl {
+    // TODO static assert that F is callable
+protected:
+    using is_movable = is_move_constructible<F>;
+
+private:
+    using move_t = conditional_t<is_movable::value, impl, details::scope::invalid_t>;
+    using not_move_t = conditional_t<is_movable::value, details::scope::invalid_t, impl>;
+
+protected:
+    template <typename Fn, typename = enable_if_t<is_constructible<F, Fn&&>::value>>
+    impl(Fn&& func) noexcept(is_nothrow_constructible<F, Fn&&>::value)
+        : callable(forward<Fn>(func))
+        , released_(false) {}
+    impl(impl const& other) = delete;
+    impl& operator=(impl const& other) = delete;
+    impl(not_move_t&& other) = delete;
+    impl& operator=(impl&& other) = delete;
+    constexpr impl(move_t&& other) noexcept(is_nothrow_move_constructible<F>::value)
+        : impl(is_movable{}, move(other)) {}
+
+    void release() noexcept { released_ = true; }
+
+    ~impl() noexcept(noexcept(callable())) {
+        if (!released_ && static_cast<Impl*>(this)->should_invoke()) {
+            callable();
+        }
+    }
+
+private:
+    // TODO ignore warning
+    constexpr impl(false_type, details::scope::invalid_t&&) noexcept;
+    template <typename T = impl,
+        typename = enable_if_t<is_movable::value && is_same<T, impl>::value>>
+    constexpr impl(true_type, T&& other) noexcept
+        : callable(move(other.callable))
+        , released_(other.released_) {
+        other.release();
+    }
+
+    F callable;
+    bool released_;
+};
+} // namespace scope
+} // namespace details
+
+UTL_NAMESPACE_END

--- a/src/utl/public/utl/scope/utl_scope_success.h
+++ b/src/utl/public/utl/scope/utl_scope_success.h
@@ -42,17 +42,20 @@ scope_success<decay_t<Fn>> make_scope_success(Fn&& f) noexcept(
 }
 
 namespace details {
-struct scope_success_proxy_t {
+namespace scope {
+struct success_proxy_t {
     template <typename Fn,
         typename = enable_if_t<is_constructible<scope_success<decay_t<Fn>>, Fn>::value>>
     scope_success<decay_t<Fn>> operator->*(Fn&& f) const
         noexcept(is_nothrow_constructible<scope_success<decay_t<Fn>>, declval<Fn>()>) {
         return scope_success<decay_t<Fn>>{forward<Fn>(f)};
     }
-} scope_success_proxy;
+} success_proxy;
+} // namespace scope
 } // namespace details
 
-#  define UTL_ON_SCOPE_SUCCESS() auto UTL_UNIQUE_VAR(ScopeSuccess) = scope_success_proxy->*[&]()
+#  define UTL_ON_SCOPE_SUCCESS() \
+      auto UTL_UNIQUE_VAR(ScopeSuccess) = UTL_SCOPE details::scope::success_proxy->*[&]()
 
 #else
 template <typename F>

--- a/src/utl/public/utl/scope/utl_scope_success.h
+++ b/src/utl/public/utl/scope/utl_scope_success.h
@@ -1,0 +1,64 @@
+// Copyright 2023-2024 Bryan Wong
+
+#pragma once
+
+#include "utl/exception.h"
+#include "utl/scope/utl_scope_impl.h"
+
+UTL_NAMESPACE_BEGIN
+
+#ifdef UTL_CXX17
+template <typename F>
+class scope_success : private details::scope::impl<scope_success<F>, F> {
+    using base_type = details::scope::impl<scope_success<F>, F>;
+    using is_movable = typename base_type::is_movable;
+    using move_t = conditional_t<is_movable::value, scope_success, details::scope::invalid_t>;
+    friend base_type;
+
+public:
+    template <typename Fn, typename = enable_if_t<is_constructible<F, Fn&&>::value>>
+    explicit scope_success(Fn&& func) noexcept(is_nothrow_constructible<F, Fn&&>::value)
+        : base_type(forward<Fn>(func))
+        , exceptions_(uncaught_exceptions()) {}
+    scope_success(move_t&& other) noexcept(is_nothrow_move_constructible<F>::value)
+        : base_type(move(other))
+        , exceptions_(other.exceptions_) {}
+
+    using base_type::release;
+
+private:
+    bool should_invoke() const noexcept { return exceptions_ >= uncaught_exceptions(); }
+    int exceptions_;
+};
+
+template <typename Fn>
+explicit scope_success(Fn&& f) -> scope_success<decay_t<Fn>>;
+
+template <typename Fn,
+    typename = enable_if_t<is_constructible<scope_success<decay_t<Fn>>, Fn>::value>>
+scope_success<decay_t<Fn>> make_scope_success(Fn&& f) noexcept(
+    is_nothrow_constructible<scope_success<decay_t<Fn>>, declval<Fn>()>) {
+    return scope_success<decay_t<Fn>>{forward<Fn>(f)};
+}
+
+namespace details {
+struct scope_success_proxy_t {
+    template <typename Fn,
+        typename = enable_if_t<is_constructible<scope_success<decay_t<Fn>>, Fn>::value>>
+    scope_success<decay_t<Fn>> operator->*(Fn&& f) const
+        noexcept(is_nothrow_constructible<scope_success<decay_t<Fn>>, declval<Fn>()>) {
+        return scope_success<decay_t<Fn>>{forward<Fn>(f)};
+    }
+} scope_success_proxy;
+} // namespace details
+
+#  define UTL_ON_SCOPE_SUCCESS() auto UTL_UNIQUE_VAR(ScopeSuccess) = scope_success_proxy->*[&]()
+
+#else
+template <typename F>
+class scope_success {
+    static_assert(sizeof(F) == 0, "scope_success is unsupported prior to C++17");
+};
+#endif
+
+UTL_NAMESPACE_END


### PR DESCRIPTION
* Add scope_exit, scope_fail, scope_success
* Add exception aliases
* Exception classes have too much non-trivial compiler specific implementation, might revisit in future but for now, keep things simple by just including exception and adding aliases in UTL. The exception header is relatively small and so should not impact compile times overtly