### PR TITLE
Implemented reference_constructs_from_temporary

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,11 +1,8 @@
 # Untitled Library (UTL)
 
-This essentially started out as a simple exercise with 3 simple goals:
- * Learn how to use concepts in C++20
- * Find out if there are noticable differences between SFINAE and Concepts
- * Implement a custom tuple that maintains triviality and "standard layout"-ness if all its elements meet those requirements
-
-Eventually, it spiraled into learning more about how all the common compilers (Clang, GCC, MSVC, etc.) implement certain things and wondering what newer features could be brought into the older standards, e.g. constexpr things in C++11 that were only constexpr in C++17, etc.
+Incredibly pointless library.
 
 # Disclaimer
 This project contains undefined behaviours.
+ * Including pre-C++17 optional and variant (Limitations in pre-C++ object lifetime will result in strange behaviours fro certain types)
+ * Forward declared std types

--- a/src/utl/private/tests/type_traits/reference_constructs.cpp
+++ b/src/utl/private/tests/type_traits/reference_constructs.cpp
@@ -1,0 +1,238 @@
+// Copyright 2023-2024 Bryan Wong
+
+#include "utl/preprocessor/utl_traits_check.h"
+#include "utl/type_traits/utl_reference_constructs_from_temporary.h"
+
+#if UTL_SUPPORTS_TRAIT(reference_constructs_from_temporary)
+
+/**
+ * Test lifted from GCC's test suite
+ */
+
+#  define SA(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
+
+struct A {
+    A();
+};
+struct B {
+    operator A();
+};
+struct C {
+    explicit C();
+};
+struct D {
+    explicit operator A();
+};
+struct E {
+    explicit operator A&();
+};
+struct F {
+    explicit operator A&&();
+};
+// Could use a class template with explicit(bool), but then this would need
+// C++20.
+struct G {
+    operator int();
+    explicit operator int&&();
+};
+struct G2 {
+    explicit operator int();
+    operator int&&();
+};
+struct H {
+    operator int();
+    explicit operator int&();
+};
+struct H2 {
+    explicit operator int();
+    operator int&();
+};
+
+struct Base {};
+struct Der : Base {};
+
+template <typename T, typename RT>
+struct morph {
+    mutable T val{};
+    operator RT() const { return static_cast<RT>(val); }
+};
+
+template <typename T>
+using id = T;
+
+// Built-in types.
+SA(!utl::reference_constructs_from_temporary<int, int>::value);
+SA(!utl::reference_constructs_from_temporary<int&, void>::value);
+SA(!utl::reference_constructs_from_temporary<int&, void const>::value);
+SA(!utl::reference_constructs_from_temporary<int&, void volatile>::value);
+SA(!utl::reference_constructs_from_temporary<int&, void const volatile>::value);
+SA(!utl::reference_constructs_from_temporary<void, void>::value);
+SA(!utl::reference_constructs_from_temporary<void, int>::value);
+SA(!utl::reference_constructs_from_temporary<int&, int>::value);
+SA(!utl::reference_constructs_from_temporary<int&, int&>::value);
+SA(!utl::reference_constructs_from_temporary<int&, int&&>::value);
+SA(!utl::reference_constructs_from_temporary<int&, long>::value);
+
+// static_assert(!utl::details::dangling::constructs_from_temp<int&, long&>::value, "");
+// non-const lvalue reference to type 'int' cannot bind to a value of unrelated type 'long'
+SA(!utl::reference_constructs_from_temporary<int&, long&>::value);
+SA(!utl::reference_constructs_from_temporary<int&, long&&>::value);
+SA(utl::reference_constructs_from_temporary<int const&, int>::value);
+SA(!utl::reference_constructs_from_temporary<int const&, int&>::value);
+SA(!utl::reference_constructs_from_temporary<int const&, int const&>::value);
+SA(!utl::reference_constructs_from_temporary<int const&, int&&>::value);
+SA(utl::reference_constructs_from_temporary<int const&, long>::value);
+SA(utl::reference_constructs_from_temporary<int const&, long&>::value);
+SA(utl::reference_constructs_from_temporary<int const&, long&&>::value);
+SA(utl::reference_constructs_from_temporary<int&&, int>::value);
+SA(!utl::reference_constructs_from_temporary<int&&, int&>::value);
+SA(!utl::reference_constructs_from_temporary<int&&, int&&>::value);
+SA(utl::reference_constructs_from_temporary<int&&, long>::value);
+SA(utl::reference_constructs_from_temporary<int&&, long&>::value);
+SA(utl::reference_constructs_from_temporary<int&&, long&&>::value);
+SA(!utl::reference_constructs_from_temporary<unsigned int&, double>::value);
+SA(!utl::reference_constructs_from_temporary<int volatile&, int>::value);
+SA(!utl::reference_constructs_from_temporary<int const volatile&, int>::value);
+SA(!utl::reference_constructs_from_temporary<int volatile&, int&>::value);
+SA(!utl::reference_constructs_from_temporary<int const volatile&, int&>::value);
+SA(!utl::reference_constructs_from_temporary<int volatile&, int&&>::value);
+SA(!utl::reference_constructs_from_temporary<int const volatile&, int&&>::value);
+
+// Classes.
+SA(!utl::reference_constructs_from_temporary<A, A>::value);
+// A& r(A{}); doesn't construct.
+SA(!utl::reference_constructs_from_temporary<A&, A>::value);
+SA(!utl::reference_constructs_from_temporary<A&, A&>::value);
+SA(!utl::reference_constructs_from_temporary<A&, A&&>::value);
+// Here we get const struct A & r = (const struct A &) &D.2414;
+SA(utl::reference_constructs_from_temporary<A const&, A>::value);
+SA(!utl::reference_constructs_from_temporary<A const&, A&>::value);
+SA(!utl::reference_constructs_from_temporary<A const&, A const&>::value);
+SA(!utl::reference_constructs_from_temporary<A const&, A&&>::value);
+// Here we get struct A & r = (struct A &) &D.2439;
+SA(utl::reference_constructs_from_temporary<A&&, A>::value);
+SA(!utl::reference_constructs_from_temporary<A&&, A&>::value);
+SA(!utl::reference_constructs_from_temporary<A&&, A const&>::value);
+SA(!utl::reference_constructs_from_temporary<A&&, A&&>::value);
+
+SA(!utl::reference_constructs_from_temporary<A, B>::value);
+SA(!utl::reference_constructs_from_temporary<A&, B>::value);
+SA(!utl::reference_constructs_from_temporary<A&, B&>::value);
+SA(!utl::reference_constructs_from_temporary<A&, B const&>::value);
+SA(!utl::reference_constructs_from_temporary<A&, B&&>::value);
+SA(utl::reference_constructs_from_temporary<A const&, B>::value);
+SA(utl::reference_constructs_from_temporary<A const&, B&>::value);
+// Doesn't construct, so it's false.
+SA(!utl::reference_constructs_from_temporary<A const&, B const&>::value);
+SA(utl::reference_constructs_from_temporary<A const&, B&&>::value);
+SA(utl::reference_constructs_from_temporary<A&&, B>::value);
+SA(utl::reference_constructs_from_temporary<A&&, B&>::value);
+SA(!utl::reference_constructs_from_temporary<A&&, B const&>::value);
+SA(utl::reference_constructs_from_temporary<A&&, B&&>::value);
+
+SA(!utl::reference_constructs_from_temporary<A const&, C>::value);
+SA(!utl::reference_constructs_from_temporary<A const&, C&>::value);
+
+// Doesn't construct, so it's false.
+SA(!utl::reference_constructs_from_temporary<int&, morph<int, int>>::value);
+// Here we get
+//   const int & r2 = D.2580 = morph<int, int>::operator int
+//     (&TARGET_EXPR <D.2578, {.val=0}>); (const int &) &D.2580;
+SA(utl::reference_constructs_from_temporary<int const&, morph<int, int>>::value);
+SA(!utl::reference_constructs_from_temporary<int&, morph<int, int&>>::value);
+SA(!utl::reference_constructs_from_temporary<int&, morph<int, int const&>>::value);
+SA(!utl::reference_constructs_from_temporary<int&, morph<int, int&&>>::value);
+SA(utl::reference_constructs_from_temporary<int const&, morph<long, long&>>::value);
+
+// These are like const C& c(cref); so the explicit ctor C isn't a problem
+// even in copy-init context.  const C& r = {}; would be a different story.
+SA(!utl::reference_constructs_from_temporary<C, C>::value);
+SA(!utl::reference_constructs_from_temporary<C&, C>::value);
+SA(!utl::reference_constructs_from_temporary<C&, C&>::value);
+SA(!utl::reference_constructs_from_temporary<C&, C&&>::value);
+SA(utl::reference_constructs_from_temporary<C const&, C>::value);
+SA(!utl::reference_constructs_from_temporary<C const&, C&>::value);
+SA(!utl::reference_constructs_from_temporary<C const&, C const&>::value);
+SA(!utl::reference_constructs_from_temporary<C const&, C&&>::value);
+SA(utl::reference_constructs_from_temporary<C&&, C>::value);
+SA(!utl::reference_constructs_from_temporary<C&&, C&>::value);
+SA(!utl::reference_constructs_from_temporary<C&&, C const&>::value);
+SA(!utl::reference_constructs_from_temporary<C&&, C&&>::value);
+
+// These are all false ultimately because of CWG 2267, which we implement.
+SA(!utl::reference_constructs_from_temporary<A, D>::value);
+SA(!utl::reference_constructs_from_temporary<A&, D>::value);
+SA(!utl::reference_constructs_from_temporary<A&, D&>::value);
+SA(!utl::reference_constructs_from_temporary<A&, D const&>::value);
+SA(!utl::reference_constructs_from_temporary<A&, D&&>::value);
+SA(!utl::reference_constructs_from_temporary<A const&, D>::value);
+SA(!utl::reference_constructs_from_temporary<A const&, D&>::value);
+SA(!utl::reference_constructs_from_temporary<A const&, D const&>::value);
+SA(!utl::reference_constructs_from_temporary<A const&, D&&>::value);
+SA(!utl::reference_constructs_from_temporary<A&&, D>::value);
+SA(!utl::reference_constructs_from_temporary<A&&, D&>::value);
+SA(!utl::reference_constructs_from_temporary<A&&, D const&>::value);
+SA(!utl::reference_constructs_from_temporary<A&&, D&&>::value);
+
+SA(!utl::reference_constructs_from_temporary<A, E>::value);
+/* A& a1(E{}); compiles, but A& a2 = E{}; doesn't.
+   With the former, we get A& a = E::operator A& (&TARGET_EXPR <D.2715, {}>)
+   so we're not binding the reference to a temporary, although there is
+   a temporary involved.  So the result is false in both copy- and direct-
+   init, albeit for different reasons!  */
+SA(!utl::reference_constructs_from_temporary<A&, E>::value);
+// A& a = E::operator A& ((struct E *) r)); copy-init doesn't compile.
+SA(!utl::reference_constructs_from_temporary<A&, E&>::value);
+SA(!utl::reference_constructs_from_temporary<A&, E const&>::value);
+SA(!utl::reference_constructs_from_temporary<A&, E&&>::value);
+// direct-init:
+// const A& a = (const struct A &) E::operator A& (&TARGET_EXPR <D.2720, {}>)
+SA(!utl::reference_constructs_from_temporary<A const&, E>::value);
+SA(!utl::reference_constructs_from_temporary<A const&, E&>::value);
+SA(!utl::reference_constructs_from_temporary<A const&, E const&>::value);
+SA(!utl::reference_constructs_from_temporary<A const&, E&&>::value);
+SA(!utl::reference_constructs_from_temporary<A&&, E>::value);
+SA(!utl::reference_constructs_from_temporary<A&&, E&>::value);
+SA(!utl::reference_constructs_from_temporary<A&&, E const&>::value);
+SA(!utl::reference_constructs_from_temporary<A&&, E&&>::value);
+
+SA(!utl::reference_constructs_from_temporary<A, F>::value);
+// A& a1(F{}); and A& a2 = F{}; both invalid.
+SA(!utl::reference_constructs_from_temporary<A&, F>::value);
+SA(!utl::reference_constructs_from_temporary<A&, F&>::value);
+SA(!utl::reference_constructs_from_temporary<A&, F const&>::value);
+SA(!utl::reference_constructs_from_temporary<A&, F&&>::value);
+SA(!utl::reference_constructs_from_temporary<A const&, F>::value);
+SA(!utl::reference_constructs_from_temporary<A const&, F&>::value);
+SA(!utl::reference_constructs_from_temporary<A const&, F const&>::value);
+SA(!utl::reference_constructs_from_temporary<A const&, F&&>::value);
+SA(!utl::reference_constructs_from_temporary<A&&, F>::value);
+SA(!utl::reference_constructs_from_temporary<A&&, F&>::value);
+SA(!utl::reference_constructs_from_temporary<A&&, F const&>::value);
+SA(!utl::reference_constructs_from_temporary<A&&, F&&>::value);
+
+/* This is where _converts_ and _constructs_ will differ:
+   in direct-init we use G::operator int&& (no temporary),
+   but in copy-init we use G::operator int, where a temporary is created
+   to be bound to int&&.  */
+SA(!utl::reference_constructs_from_temporary<int&&, G>::value);
+// Similar to the previous one.
+SA(!utl::reference_constructs_from_temporary<int const&, H>::value);
+/* And here I've switched the explicit-ness.  In both copy- and direct-init
+   we call operator int&, so no temporary.  */
+SA(!utl::reference_constructs_from_temporary<int&&, G2>::value);
+SA(!utl::reference_constructs_from_temporary<int const&, H2>::value);
+
+SA(utl::reference_constructs_from_temporary<Base const&, Der>::value);
+
+// This fails because std::is_constructible_v<int&&, id<int[3]>> is false.
+SA(!utl::reference_constructs_from_temporary<int&&, id<int[3]>>::value);
+
+// Arrays.
+SA(!utl::reference_constructs_from_temporary<int, int[]>::value);
+SA(!utl::reference_constructs_from_temporary<int[], int[]>::value);
+SA(!utl::reference_constructs_from_temporary<int&, int[]>::value);
+SA(!utl::reference_constructs_from_temporary<int&&, int[]>::value);
+SA(!utl::reference_constructs_from_temporary<int const&, int[]>::value);
+
+#endif

--- a/src/utl/public/utl/type_traits.h
+++ b/src/utl/public/utl/type_traits.h
@@ -4,7 +4,6 @@
 
 #include "utl/type_traits/utl_constants.h"
 #include "utl/type_traits/utl_is_complete.h"
-#include "utl/type_traits/utl_is_x_constructible.h"
 #include "utl/type_traits/utl_std_traits.h"
 #include "utl/type_traits/utl_unwrap_reference.h"
 #include "utl/type_traits/utl_variadic_traits.h"

--- a/src/utl/public/utl/type_traits/utl_is_x_convertible.h
+++ b/src/utl/public/utl/type_traits/utl_is_x_convertible.h
@@ -103,6 +103,8 @@ using std::is_nothrow_convertible_v;
 
 #else // defined(UTL_USE_STD_TYPE_TRAITS) && defined(UTL_CXX20)
 
+#  include "utl/type_traits/utl_declval.h"
+
 UTL_NAMESPACE_BEGIN
 
 namespace details {

--- a/src/utl/public/utl/type_traits/utl_reference_binds_to_temporary.h
+++ b/src/utl/public/utl/type_traits/utl_reference_binds_to_temporary.h
@@ -1,0 +1,11 @@
+// Copyright 2023-2024 Bryan Wong
+
+#pragma once
+
+#ifndef UTL_DISABLE_BUILTIN_reference_binds_to_temporary
+#  define UTL_DISABLE_BUILTIN_reference_binds_to_temporary 0
+#endif
+
+#if UTL_SHOULD_USE_BUILTIN(reference_binds_to_temporary)
+#  define UTL_BUILTIN_reference_binds_to_temporary(...) __reference_binds_to_temporary(__VA_ARGS__)
+#endif // UTL_SHOULD_USE_BUILTIN(reference_constructs_from_temporary)

--- a/src/utl/public/utl/type_traits/utl_reference_constructs_from_temporary.h
+++ b/src/utl/public/utl/type_traits/utl_reference_constructs_from_temporary.h
@@ -1,0 +1,138 @@
+// Copyright 2023-2024 Bryan Wong
+
+#pragma once
+
+#include "utl/type_traits/utl_common.h"
+
+#if defined(UTL_USE_STD_TYPE_TRAITS) && defined(UTL_CXX23)
+
+#  include <type_traits>
+
+UTL_NAMESPACE_BEGIN
+
+using std::reference_constructs_from_temporary;
+
+using std::reference_constructs_from_temporary_v;
+
+UTL_NAMESPACE_END
+
+#  define UTL_TRAIT_SUPPORTED_reference_constructs_from_temporary 1
+
+#else // ifdef UTL_USE_STD_TYPE_TRAITS
+
+#  include "utl/type_traits/utl_constants.h"
+#  include "utl/type_traits/utl_reference_binds_to_temporary.h"
+
+#  ifndef UTL_DISABLE_BUILTIN_reference_constructs_from_temporary
+#    define UTL_DISABLE_BUILTIN_reference_constructs_from_temporary 0
+#  endif
+
+#  if UTL_SHOULD_USE_BUILTIN(reference_constructs_from_temporary)
+#    define UTL_BUILTIN_reference_constructs_from_temporary(...) \
+        __reference_constructs_from_temporary(__VA_ARGS__)
+#  endif // UTL_SHOULD_USE_BUILTIN(reference_constructs_from_temporary)
+
+#  ifdef UTL_BUILTIN_reference_constructs_from_temporary
+
+UTL_NAMESPACE_BEGIN
+
+template <typename T, typename U>
+struct reference_constructs_from_temporary :
+    bool_constant<UTL_BUILTIN_reference_constructs_from_temporary(T, U)> {};
+
+#    ifdef UTL_CXX14
+template <typename T, typename U>
+UTL_INLINE_CXX17 constexpr bool reference_constructs_from_temporary_v =
+    UTL_BUILTIN_reference_constructs_from_temporary(T, U);
+#    endif // UTL_CXX14
+
+UTL_NAMESPACE_END
+
+#  elif defined(UTL_BUILTIN_reference_binds_to_temporary)
+
+#    include "utl/type_traits/utl_is_same.h"
+#    include "utl/type_traits/utl_is_x_convertible.h"
+#    include "utl/type_traits/utl_remove_cv.h"
+#    include "utl/type_traits/utl_remove_cvref.h"
+
+#    ifdef UTL_CXX14
+#      define UTL_TRAIT_VALUE(TRAIT, ...) TRAIT##_v<__VA_ARGS__>
+#    else
+#      define UTL_TRAIT_VALUE(TRAIT, ...) TRAIT<__VA_ARGS__>::value
+#    endif
+
+UTL_NAMESPACE_BEGIN
+
+template <typename T, typename U>
+struct reference_constructs_from_temporary : false_type {};
+
+namespace details {
+namespace dangling {
+
+/**
+ * Checks valid conversion in unevaluated context
+ * @tparam T - reference only, first argument of reference_constructs_from_temporary
+ */
+template <typename T>
+void init_ref(T ref) noexcept;
+
+/**
+ * Creates a prvalue in unevaluated context
+ * @tparam U - any type
+ */
+template <typename U>
+remove_cv_t<U> make_type() noexcept;
+
+template <typename T, typename U>
+using constructs_from_impl = bool_constant<UTL_BUILTIN_reference_binds_to_temporary(T, U) ||
+    UTL_TRAIT_VALUE(is_convertible, remove_cvref_t<U>*, remove_cvref_t<T>*)>;
+
+template <typename T, typename U, typename = void>
+struct constructs_from : false_type {};
+
+template <typename T, typename U>
+struct constructs_from<T, U&, decltype(init_ref<T>(make_type<U&>()))> :
+    bool_constant<!UTL_TRAIT_VALUE(is_same, remove_cvref_t<T>, remove_cv_t<U>) &&
+        constructs_from_impl<T, U&>::value> {};
+
+template <typename T, typename U>
+struct constructs_from<T, U&&, decltype(init_ref<T>(make_type<U&&>()))> :
+    bool_constant<!UTL_TRAIT_VALUE(is_same, remove_cvref_t<T>, remove_cv_t<U>) &&
+        constructs_from_impl<T, U&&>::value> {};
+
+template <typename T, typename U>
+struct constructs_from<T, U, decltype(init_ref<T>(make_type<U>()))> : constructs_from_impl<T, U> {};
+
+} // namespace dangling
+} // namespace details
+
+template <typename T, typename U>
+struct reference_constructs_from_temporary<T&, U> : details::dangling::constructs_from<T&, U> {};
+
+template <typename T, typename U>
+struct reference_constructs_from_temporary<T&&, U> : details::dangling::constructs_from<T&&, U> {};
+
+#    ifdef UTL_CXX14
+template <typename T, typename U>
+UTL_INLINE_CXX17 constexpr bool reference_constructs_from_temporary_v =
+    reference_constructs_from_temporary<T, U>::value;
+#    endif // UTL_CXX14
+
+UTL_NAMESPACE_END
+
+#    undef UTL_TRAIT_VALUE
+
+#    define UTL_TRAIT_SUPPORTED_reference_constructs_from_temporary 1
+
+#  else // ifdef UTL_BUILTIN_reference_constructs_from_temporary
+
+UTL_NAMESPACE_BEGIN
+
+template <typename T, typename U>
+struct reference_constructs_from_temporary : false_type {};
+
+UTL_NAMESPACE_END
+
+#  endif
+
+#endif // ifdef UTL_USE_STD_TYPE_TRAITS

--- a/src/utl/public/utl/type_traits/utl_std_traits.h
+++ b/src/utl/public/utl/type_traits/utl_std_traits.h
@@ -158,32 +158,6 @@ UTL_INLINE_CXX17 constexpr bool is_pointer_interconvertible_base_of_v =
 #  define UTL_TRAIT_DEFINED_is_pointer_interconvertible_base_of 1
 #endif /* ifdef UTL_BUILTIN_is_pointer_interconvertible_base_of */
 
-#ifdef UTL_BUILTIN_reference_constructs_from_temporary
-template <typename T, typename U>
-struct reference_constructs_from_temporary :
-    bool_constant<UTL_BUILTIN_reference_constructs_from_temporary(T, U)> {};
-#  define UTL_TRAIT_SUPPORTED_reference_constructs_from_temporary 1
-
-#  ifdef UTL_CXX14
-template <typename T, typename U>
-UTL_INLINE_CXX17 constexpr bool reference_constructs_from_temporary_v =
-    UTL_BUILTIN_reference_constructs_from_temporary(T, U);
-#  endif
-
-#else /* ifdef UTL_BUILTIN_reference_constructs_from_temporary */
-template <typename, typename>
-struct reference_constructs_from_temporary : false_type {};
-
-#  ifdef UTL_CXX14
-template <typename T, typename U>
-UTL_INLINE_CXX17 constexpr bool reference_constructs_from_temporary_v =
-    reference_constructs_from_temporary<T, U>::value;
-#  endif
-
-#  define UTL_TRAIT_SUPPORTED_reference_constructs_from_temporary 0
-#  define UTL_TRAIT_DEFINED_reference_constructs_from_temporary 1
-#endif /* ifdef UTL_BUILTIN_reference_constructs_from_temporary */
-
 UTL_NAMESPACE_END
 
 #include "utl/type_traits/utl_traits_support.h"

--- a/src/utl/public/utl/type_traits/utl_variadic_traits.h
+++ b/src/utl/public/utl/type_traits/utl_variadic_traits.h
@@ -15,8 +15,7 @@
 #include "utl/type_traits/utl_is_nothrow_move_assignable.h"
 #include "utl/type_traits/utl_is_nothrow_move_constructible.h"
 #include "utl/type_traits/utl_logical_traits.h"
-// reference_constructs_from_temporary
-#include "utl/type_traits/utl_std_traits.h"
+#include "utl/type_traits/utl_reference_constructs_from_temporary.h"
 #include "utl/utility/utl_sequence.h"
 #include "utl/utility/utl_swap.h"
 


### PR DESCRIPTION
* Clang's intrinsic only has partial support, it was necessary to include additional logic to deal with cases where the intrinsic doesn't work
* Includes unit tests from GCC's test suite to ensure the correctness of Clang's implementation