### PR TITLE
moved UTL_TRAIT_VALUE to common header

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,5 +4,5 @@ Incredibly pointless library.
 
 # Disclaimer
 This project contains undefined behaviours.
- * Including pre-C++17 optional and variant (Limitations in pre-C++ object lifetime will result in strange behaviours for certain types)
+ * Including pre-C++17 optional and variant (Limitations in pre-C++17 object lifetime will result in strange behaviours for certain types)
  * Forward declared std types

--- a/src/utl/public/utl/memory/utl_addressof.h
+++ b/src/utl/public/utl/memory/utl_addressof.h
@@ -18,14 +18,14 @@ constexpr T* addressof(T&&) = delete;
 
 template <typename T>
 UTL_ATTRIBUTES(NODISCARD, CONST)
-constexpr enable_if_t<is_object<remove_reference_t<T>>::value, T*> addressof(
+constexpr enable_if_t<UTL_TRAIT_VALUE(is_object, remove_reference_t<T>), T*> addressof(
     T& arg UTL_ATTRIBUTE(LIFETIMEBOUND)) noexcept {
     return UTL_BUILTIN_addressof(arg);
 }
 
 template <typename T>
 UTL_ATTRIBUTES(NODISCARD, CONST)
-constexpr enable_if_t<!is_object<remove_reference_t<T>>::value, T*> addressof(
+constexpr enable_if_t<!UTL_TRAIT_VALUE(is_object, remove_reference_t<T>), T*> addressof(
     T& arg UTL_ATTRIBUTE(LIFETIMEBOUND)) noexcept {
     return &arg;
 }
@@ -58,8 +58,8 @@ struct natively_invocable<T, void_t<decltype(&declval<add_lvalue_reference_t<T>>
     true_type {};
 
 template <typename T>
-struct has_overload :
-    disjunction<negation<natively_invocable<T>>, has_adl_overload<T>, has_member_overload<T>> {};
+using has_overload =
+    disjunction<negation<natively_invocable<T>>, has_adl_overload<T>, has_member_overload<T>>{};
 } // namespace addressof
 } // namespace details
 

--- a/src/utl/public/utl/memory/utl_uses_allocator.h
+++ b/src/utl/public/utl/memory/utl_uses_allocator.h
@@ -43,10 +43,10 @@ using impl = R;
 
 struct allocator_arg_t {
     explicit constexpr allocator_arg_t() noexcept = default;
-    template <typename T UTL_REQUIRES_CXX11(is_same<T, ::std::allocator_arg_t>::value)>
+    template <typename T UTL_REQUIRES_CXX11(UTL_TRAIT_VALUE(is_same, T, ::std::allocator_arg_t))>
     UTL_REQUIRES_CXX20(same_as<T, ::std::allocator_arg_t>)
     constexpr allocator_arg_t(T) noexcept {}
-    template <typename T UTL_REQUIRES_CXX11(is_same<T, ::std::allocator_arg_t>::value)>
+    template <typename T UTL_REQUIRES_CXX11(UTL_TRAIT_VALUE(is_same, T, ::std::allocator_arg_t))>
     UTL_REQUIRES_CXX20(same_as<T, ::std::allocator_arg_t>)
     constexpr operator T() const noexcept {
         return {};

--- a/src/utl/public/utl/meta/function_info.h
+++ b/src/utl/public/utl/meta/function_info.h
@@ -19,9 +19,11 @@ namespace function_info {
 template <typename F, typename = void>
 struct function_type;
 template <typename F>
-struct function_type<F*, enable_if_t<is_function<F>::value>> : UTL_SCOPE function_type<F> {};
+struct function_type<F*, enable_if_t<UTL_TRAIT_VALUE(is_function, F)>> :
+    UTL_SCOPE function_type<F> {};
 template <typename F>
-struct function_type<F&, enable_if_t<is_function<F>::value>> : UTL_SCOPE function_type<F> {};
+struct function_type<F&, enable_if_t<UTL_TRAIT_VALUE(is_function, F)>> :
+    UTL_SCOPE function_type<F> {};
 } // namespace function_info
 } // namespace details
 

--- a/src/utl/public/utl/type_traits/utl_common.h
+++ b/src/utl/public/utl/type_traits/utl_common.h
@@ -7,3 +7,9 @@
 UTL_NAMESPACE_BEGIN
 using size_t = decltype(sizeof(0));
 UTL_NAMESPACE_END
+
+#ifdef UTL_CXX14
+#  define UTL_TRAIT_VALUE(TRAIT, ...) TRAIT##_v<__VA_ARGS__>
+#else
+#  define UTL_TRAIT_VALUE(TRAIT, ...) TRAIT<__VA_ARGS__>::value
+#endif

--- a/src/utl/public/utl/type_traits/utl_is_bounded_array.h
+++ b/src/utl/public/utl/type_traits/utl_is_bounded_array.h
@@ -12,16 +12,7 @@ UTL_NAMESPACE_BEGIN
 
 using std::is_bounded_array;
 
-#  ifdef UTL_CXX17
-
 using std::is_bounded_array_v;
-
-#  elif defined(UTL_CXX14) // ifdef UTL_CXX17
-
-template <typename T>
-UTL_INLINE_CXX17 constexpr bool is_bounded_array_v = is_bounded_array<T>::value;
-
-#  endif // ifdef UTL_CXX17
 
 UTL_NAMESPACE_END
 

--- a/src/utl/public/utl/type_traits/utl_is_member_object_pointer.h
+++ b/src/utl/public/utl/type_traits/utl_is_member_object_pointer.h
@@ -58,12 +58,6 @@ UTL_NAMESPACE_END
 
 #    include "utl/type_traits/utl_is_function.h"
 
-#    ifdef UTL_CXX14
-#      define UTL_TRAIT_VALUE(TRAIT, ...) TRAIT##_v<__VA_ARGS__>
-#    else
-#      define UTL_TRAIT_VALUE(TRAIT, ...) TRAIT<__VA_ARGS__>::value
-#    endif
-
 UTL_NAMESPACE_BEGIN
 
 template <typename T>
@@ -71,8 +65,6 @@ struct is_member_object_pointer : false_type {};
 
 template <typename T, typename U>
 struct is_member_object_pointer<T U::*> : bool_constant<!UTL_TRAIT_VALUE(is_function, T)> {};
-
-#    undef UTL_TRAIT_VALUE
 
 #    ifdef UTL_CXX14
 template <typename T>

--- a/src/utl/public/utl/type_traits/utl_is_nothrow_assignable.h
+++ b/src/utl/public/utl/type_traits/utl_is_nothrow_assignable.h
@@ -84,17 +84,10 @@ auto nothrow_impl(nothrow_branch_t<false, false>) noexcept -> false_type;
 template <typename T, typename U>
 auto nothrow_impl(nothrow_branch_t<false, true>) noexcept -> false_type;
 
-#    ifdef UTL_CXX14
-#      define UTL_TRAIT_VALUE(TRAIT, ...) TRAIT##_v<__VA_ARGS__>
-#    else
-#      define UTL_TRAIT_VALUE(TRAIT, ...) TRAIT<__VA_ARGS__>::value
-#    endif
-
 template <typename T, typename U>
 using nothrow_impl_t = decltype(nothrow_impl<T, U>(
     nothrow_branch_t<UTL_TRAIT_VALUE(is_assignable, T, Args), UTL_TRAIT_VALUE(is_reference, T)>{}));
 
-#    undef UTL_TRAIT_VALUE
 } // namespace assignable
 } // namespace details
 

--- a/src/utl/public/utl/type_traits/utl_is_nothrow_constructible.h
+++ b/src/utl/public/utl/type_traits/utl_is_nothrow_constructible.h
@@ -87,18 +87,11 @@ auto nothrow_impl(nothrow_branch_t<false, false>) noexcept -> false_type;
 template <typename T, typename... Args>
 auto nothrow_impl(nothrow_branch_t<false, true>) noexcept -> false_type;
 
-#    ifdef UTL_CXX14
-#      define UTL_TRAIT_VALUE(TRAIT, ...) TRAIT##_v<__VA_ARGS__>
-#    else
-#      define UTL_TRAIT_VALUE(TRAIT, ...) TRAIT<__VA_ARGS__>::value
-#    endif
-
 template <typename T, typename... Args>
 using nothrow_impl_t = decltype(nothrow_impl<T, Args...>(
     nothrow_branch_t<UTL_TRAIT_VALUE(is_constructible, T, Args...),
         UTL_TRAIT_VALUE(is_reference, T)>{}));
 
-#    undef UTL_TRAIT_VALUE
 } // namespace constructible
 } // namespace details
 

--- a/src/utl/public/utl/type_traits/utl_reference_constructs_from_temporary.h
+++ b/src/utl/public/utl/type_traits/utl_reference_constructs_from_temporary.h
@@ -55,12 +55,6 @@ UTL_NAMESPACE_END
 #    include "utl/type_traits/utl_remove_cv.h"
 #    include "utl/type_traits/utl_remove_cvref.h"
 
-#    ifdef UTL_CXX14
-#      define UTL_TRAIT_VALUE(TRAIT, ...) TRAIT##_v<__VA_ARGS__>
-#    else
-#      define UTL_TRAIT_VALUE(TRAIT, ...) TRAIT<__VA_ARGS__>::value
-#    endif
-
 UTL_NAMESPACE_BEGIN
 
 template <typename T, typename U>
@@ -119,8 +113,6 @@ UTL_INLINE_CXX17 constexpr bool reference_constructs_from_temporary_v =
 #    endif // UTL_CXX14
 
 UTL_NAMESPACE_END
-
-#    undef UTL_TRAIT_VALUE
 
 #    define UTL_TRAIT_SUPPORTED_reference_constructs_from_temporary 1
 


### PR DESCRIPTION
The macro `UTL_TRAIT_VALUE` _may_ be useful to shave off some compile time as it is used to swap over to template variables post-C++14 which provides a potential (unproven) minor boost due to not requiring the trait struct instantiations.