### PR TITLE
Update scope macros and names

### DIFF
--- a/src/utl/public/utl/scope/utl_scope_exit.h
+++ b/src/utl/public/utl/scope/utl_scope_exit.h
@@ -51,7 +51,7 @@ struct exit_proxy_t {
 } // namespace scope
 } // namespace details
 
-#define UTL_ON_SCOPE_FAIL() \
-    auto UTL_UNIQUE_VAR(ScopeFail) = UTL_SCOPE details::scope::exit_proxy->*[&]()
+#define UTL_ON_SCOPE_EXIT \
+    const auto UTL_UNIQUE_VAR(ScopeFail) = UTL_SCOPE details::scope::exit_proxy->*[&]()
 
 UTL_NAMESPACE_END

--- a/src/utl/public/utl/scope/utl_scope_exit.h
+++ b/src/utl/public/utl/scope/utl_scope_exit.h
@@ -13,16 +13,15 @@ class scope_exit : private details::scope::impl<scope_exit<F>, F> {
     using move_t = conditional_t<is_movable::value, scope_exit, details::scope::invalid_t>;
 
 public:
-    template <typename Fn, typename = enable_if_t<is_constructible<F, Fn&&>::value>>
-    scope_exit(Fn&& func) noexcept(is_nothrow_constructible<F, Fn&&>::value)
+    template <typename Fn, typename = enable_if_t<UTL_TRAIT_VALUE(is_constructible, F, Fn&&)>>
+    explicit scope_exit(Fn&& func) noexcept(UTL_TRAIT_VALUE(is_nothrow_constructible, F, Fn&&))
         : base_type(forward<Fn>(func)) {}
-    scope_exit(move_t&& other) noexcept(is_nothrow_move_constructible<F>::value)
+    scope_exit(move_t&& other) noexcept(UTL_TRAIT_VALUE(is_nothrow_move_constructible, F))
         : base_type(move(other)) {}
 
     using base_type::release;
 
 private:
-    static constexpr bool should_invoke() noexcept { return true; }
 };
 
 #ifdef UTL_CXX17
@@ -32,22 +31,25 @@ explicit scope_exit(Fn&& f) -> scope_exit<decay_t<Fn>>;
 
 #endif
 
-template <typename Fn, typename = enable_if_t<is_constructible<scope_exit<decay_t<Fn>>, Fn>::value>>
-scope_exit<decay_t<Fn>> make_scope_exit(Fn&& f) noexcept(
-    is_nothrow_constructible<scope_exit<decay_t<Fn>>, declval<Fn>()>) {
+template <typename Fn>
+auto make_scope_exit(Fn&& f) noexcept(
+    UTL_TRAIT_VALUE(is_nothrow_constructible, scope_exit<decay_t<Fn>>, Fn))
+    -> enable_if_t<UTL_TRAIT_VALUE(is_constructible, scope_exit<decay_t<Fn>>, Fn),
+        scope_exit<decay_t<Fn>>> {
     return scope_exit<decay_t<Fn>>{forward<Fn>(f)};
 }
 
 namespace details {
 namespace scope {
-struct exit_proxy_t {
-    template <typename Fn,
-        typename = enable_if_t<is_constructible<scope_exit<decay_t<Fn>>, Fn>::value>>
-    scope_exit<decay_t<Fn>> operator->*(Fn&& f) const
-        noexcept(is_nothrow_constructible<scope_exit<decay_t<Fn>>, declval<Fn>()>) {
+UTL_INLINE_CXX17 constexpr struct exit_proxy_t {
+    template <typename Fn>
+    auto operator->*(Fn&& f) const
+        noexcept(UTL_TRAIT_VALUE(is_nothrow_constructible, scope_exit<decay_t<Fn>>, Fn))
+            -> enable_if_t<UTL_TRAIT_VALUE(is_constructible, scope_exit<decay_t<Fn>>, Fn),
+                scope_exit<decay_t<Fn>>> {
         return scope_exit<decay_t<Fn>>{forward<Fn>(f)};
     }
-} exit_proxy;
+} exit_proxy = {};
 } // namespace scope
 } // namespace details
 

--- a/src/utl/public/utl/scope/utl_scope_fail.h
+++ b/src/utl/public/utl/scope/utl_scope_fail.h
@@ -53,8 +53,8 @@ struct fail_proxy_t {
 } // namespace scope
 } // namespace details
 
-#  define UTL_ON_SCOPE_FAIL() \
-      auto UTL_UNIQUE_VAR(ScopeFail) = UTL_SCOPE details::scope::fail_proxy->*[&]()
+#  define UTL_ON_SCOPE_FAIL \
+      const auto UTL_UNIQUE_VAR(ScopeFail) = UTL_SCOPE details::scope::fail_proxy->*[&]()
 #else
 template <typename F>
 class scope_fail {

--- a/src/utl/public/utl/scope/utl_scope_impl.h
+++ b/src/utl/public/utl/scope/utl_scope_impl.h
@@ -43,7 +43,7 @@ protected:
     void release() noexcept { released_ = true; }
 
     ~impl() noexcept(noexcept(callable())) {
-        if (!released_ && static_cast<Impl*>(this)->should_invoke()) {
+        if (!released_) {
             callable();
         }
     }

--- a/src/utl/public/utl/scope/utl_scope_success.h
+++ b/src/utl/public/utl/scope/utl_scope_success.h
@@ -16,15 +16,21 @@ class scope_success : private details::scope::impl<scope_success<F>, F> {
     friend base_type;
 
 public:
-    template <typename Fn, typename = enable_if_t<is_constructible<F, Fn&&>::value>>
-    explicit scope_success(Fn&& func) noexcept(is_nothrow_constructible<F, Fn&&>::value)
+    template <typename Fn, typename = enable_if_t<UTL_TRAIT_VALUE(is_constructible, F, Fn&&)>>
+    explicit scope_success(Fn&& func) noexcept(UTL_TRAIT_VALUE(is_nothrow_constructible, F, Fn&&))
         : base_type(forward<Fn>(func))
         , exceptions_(uncaught_exceptions()) {}
-    scope_success(move_t&& other) noexcept(is_nothrow_move_constructible<F>::value)
+    scope_success(move_t&& other) noexcept(UTL_TRAIT_VALUE(is_nothrow_move_constructible, F))
         : base_type(move(other))
         , exceptions_(other.exceptions_) {}
 
     using base_type::release;
+
+    ~scope_success() noexcept {
+        if (!should_invoke()) {
+            release();
+        }
+    }
 
 private:
     bool should_invoke() const noexcept { return exceptions_ >= uncaught_exceptions(); }
@@ -34,23 +40,25 @@ private:
 template <typename Fn>
 explicit scope_success(Fn&& f) -> scope_success<decay_t<Fn>>;
 
-template <typename Fn,
-    typename = enable_if_t<is_constructible<scope_success<decay_t<Fn>>, Fn>::value>>
-scope_success<decay_t<Fn>> make_scope_success(Fn&& f) noexcept(
-    is_nothrow_constructible<scope_success<decay_t<Fn>>, declval<Fn>()>) {
+template <typename Fn>
+auto make_scope_success(Fn&& f) noexcept(
+    UTL_TRAIT_VALUE(is_nothrow_constructible, scope_success<decay_t<Fn>>, Fn))
+    -> enable_if_t<UTL_TRAIT_VALUE(is_constructible, scope_success<decay_t<Fn>>, Fn),
+        scope_success<decay_t<Fn>>> {
     return scope_success<decay_t<Fn>>{forward<Fn>(f)};
 }
 
 namespace details {
 namespace scope {
-struct success_proxy_t {
-    template <typename Fn,
-        typename = enable_if_t<is_constructible<scope_success<decay_t<Fn>>, Fn>::value>>
-    scope_success<decay_t<Fn>> operator->*(Fn&& f) const
-        noexcept(is_nothrow_constructible<scope_success<decay_t<Fn>>, declval<Fn>()>) {
+UTL_INLINE_CXX17 constexpr struct success_proxy_t {
+    template <typename Fn>
+    auto operator->*(Fn&& f) const
+        noexcept(UTL_TRAIT_VALUE(is_nothrow_constructible, scope_success<decay_t<Fn>>, Fn))
+            -> enable_if_t<UTL_TRAIT_VALUE(is_constructible, scope_success<decay_t<Fn>>, Fn),
+                scope_success<decay_t<Fn>>> {
         return scope_success<decay_t<Fn>>{forward<Fn>(f)};
     }
-} success_proxy;
+} success_proxy = {};
 } // namespace scope
 } // namespace details
 

--- a/src/utl/public/utl/scope/utl_scope_success.h
+++ b/src/utl/public/utl/scope/utl_scope_success.h
@@ -54,8 +54,8 @@ struct success_proxy_t {
 } // namespace scope
 } // namespace details
 
-#  define UTL_ON_SCOPE_SUCCESS() \
-      auto UTL_UNIQUE_VAR(ScopeSuccess) = UTL_SCOPE details::scope::success_proxy->*[&]()
+#  define UTL_ON_SCOPE_SUCCESS \
+      const auto UTL_UNIQUE_VAR(ScopeSuccess) = UTL_SCOPE details::scope::success_proxy->*[&]()
 
 #else
 template <typename F>


### PR DESCRIPTION
* Scope macros should be declared as constants instead so that the declaration looks declarative:
```c++
UTL_ON_SCOPE_EXIT {
    Cleanup();
};
```
As opposed to looking like a function/lambda.

* `UTL_ON_SCOPE_EXIT` was incorrectly named `UTL_ON_SCOPE_FAILED`
* proxies were not declared constexpr