### PR TITLE
Explicitly call address of to prevent adl

### DIFF
--- a/src/utl/public/utl/memory/utl_atomic_reference_count.h
+++ b/src/utl/public/utl/memory/utl_atomic_reference_count.h
@@ -66,7 +66,7 @@ private:
         int const result = obj.count_.fetch_sub(1, memory_order_acq_rel);
         if (result <= 1) {
             UTL_ASSERT(result > 0);
-            reference_counting::details::destroy(addressof(obj));
+            reference_counting::details::destroy(UTL_SCOPE addressof(obj));
         }
     }
 

--- a/src/utl/public/utl/memory/utl_intrusive_ptr.h
+++ b/src/utl/public/utl/memory/utl_intrusive_ptr.h
@@ -104,7 +104,7 @@ public:
      * Copy assignment
      */
     UTL_CONSTEXPR_CXX14 intrusive_ptr& operator=(intrusive_ptr const& other) noexcept {
-        if (addressof(other) != this) {
+        if (UTL_SCOPE addressof(other) != this) {
             reset();
             if (other) {
                 increment(*other.resource_);
@@ -125,7 +125,7 @@ public:
      * Move assignment
      */
     UTL_CONSTEXPR_CXX14 intrusive_ptr& operator=(intrusive_ptr&& other) noexcept {
-        if (addressof(other) != this) {
+        if (UTL_SCOPE addressof(other) != this) {
             reset();
             resource_ = exchange(other.resource_, nullptr);
         }

--- a/src/utl/public/utl/memory/utl_nonnull_ptr.h
+++ b/src/utl/public/utl/memory/utl_nonnull_ptr.h
@@ -49,7 +49,7 @@ public:
      *
      * @param ref A reference to the object.
      */
-    constexpr explicit nonnull_ptr(T& ref) noexcept : ptr_(addressof(ref)) {}
+    constexpr explicit nonnull_ptr(T& ref) noexcept : ptr_(UTL_SCOPE addressof(ref)) {}
 
     /**
      * Conversion operator to implicitly convert nonnull_ptr to the underlying raw pointer.

--- a/src/utl/public/utl/memory/utl_pointer_traits.h
+++ b/src/utl/public/utl/memory/utl_pointer_traits.h
@@ -112,7 +112,9 @@ struct pointer_traits<T*> {
     using element_type = T;
     using difference_type = typename details::pointer_traits::diff_type<T*>::type;
 
-    static constexpr pointer pointer_to(element_type& ref) noexcept { return addressof(ref); }
+    static constexpr pointer pointer_to(element_type& ref) noexcept {
+        return UTL_SCOPE addressof(ref);
+    }
 };
 
 namespace details {

--- a/src/utl/public/utl/memory/utl_reference_count.h
+++ b/src/utl/public/utl/memory/utl_reference_count.h
@@ -54,7 +54,7 @@ private:
     friend void decrement(reference_count& obj) noexcept {
         if (--obj.count_ < 1) {
             UTL_ASSERT(obj.count_ >= 0);
-            reference_counting::details::destroy(addressof(obj));
+            reference_counting::details::destroy(UTL_SCOPE addressof(obj));
         }
     }
 


### PR DESCRIPTION
Explicitly call `utl::addressof` to prevent adl resolving `addressof` calls to custom overloads.