### PR TITLE
Fix lifetime codegen

### DIFF
--- a/src/utl/makefile
+++ b/src/utl/makefile
@@ -13,7 +13,7 @@ MODULE_INCLUDES := $(shell find $(PRIVATE_DIR) $(PUBLIC_DIR) -name '*.h')
 
 .PHONY = all clean print preprocess compile
 CXX := c++
-CXX_FLAGS := -std=c++17 -fPIC -I$(PUBLIC_DIR) -I$(PRIVATE_DIR) -DUTL_BUILD_TESTS
+CXX_FLAGS := -std=c++17 -fPIC -O1 -I$(PUBLIC_DIR) -I$(PRIVATE_DIR) -DUTL_BUILD_TESTS
 LINKER_FLAGS := -lm
 OBJECTS := $(addsuffix .o, $(basename $(MODULE_SRCS:$(MODULE_ROOT)/%=%)))
 OBJECT_PATHS := $(addprefix $(INTERMEDIATE_DIR)/,$(OBJECTS))

--- a/src/utl/public/utl/preprocessor/utl_compiler.h
+++ b/src/utl/public/utl/preprocessor/utl_compiler.h
@@ -2,20 +2,20 @@
 
 #pragma once
 
-#ifdef __clang__
-#  define UTL_COMPILER_CLANG 1
-#  define UTL_COMPILER_CLANG_AT_LEAST(MAJOR, MINOR, PATCH) \
-      __clang_major__ > MAJOR ||                           \
-          (__clang_major__ == MAJOR &&                     \
-              (__clang_minor__ > MINOR ||                  \
-                  (__clang_minor__ == MINOR && __clang_patchlevel__ > PATCH)))
-#elif defined(__INTEL_LLVM_COMPILER)
+#if defined(__INTEL_LLVM_COMPILER)
 #  define UTL_COMPILER_ICX 1
 #  if defined(SYCL_LANGUAGE_VERSION)
 #    define UTL_COMPILER_ICX_DPCPP 1
 #  endif
 #  define UTL_COMPILER_ICX_AT_LEAST(VERSION) __INTEL_LLVM_COMPILER >= VERSION
 #  define UTL_COMPILER_ICX_DPCPP_AT_LEAST(VERSION) SYCL_LANGUAGE_VERSION >= VERSION
+#elif defined(__clang__)
+#  define UTL_COMPILER_CLANG 1
+#  define UTL_COMPILER_CLANG_AT_LEAST(MAJOR, MINOR, PATCH) \
+      __clang_major__ > MAJOR ||                           \
+          (__clang_major__ == MAJOR &&                     \
+              (__clang_minor__ > MINOR ||                  \
+                  (__clang_minor__ == MINOR && __clang_patchlevel__ > PATCH)))
 #elif defined(__INTEL_COMPILER)
 #  define UTL_COMPILER_ICC 1
 #  define UTL_COMPILER_ICC_AT_LEAST(VERSION) __VERSION__ >= VERSION

--- a/src/utl/public/utl/preprocessor/utl_config.h
+++ b/src/utl/public/utl/preprocessor/utl_config.h
@@ -34,6 +34,10 @@
 #  endif
 #endif
 
+#if __OPTIMIZE__
+#  define UTL_OPTIMIZATIONS_ENABLED 1
+#endif
+
 #include "utl/preprocessor/utl_attributes.h"
 #include "utl/preprocessor/utl_builtins.h"
 #include "utl/preprocessor/utl_compiler.h"


### PR DESCRIPTION
* Improve non-optimized codegen for `start_lifetime_as`

Details:
Implementation is still somewhat undefined in certain cases:
* When const/volatile qualified automatic, static or thread_local data is passed into the `start_lifetime_as` functions
* The cases where placement new is used

Future:
* Wait for official compiler support and update if required