### PR TITLE
Reimplement swap

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -80,12 +80,16 @@ IncludeBlocks:   Regroup
 IncludeCategories:
   - Regex:           '.*\.generated\.h'
     Priority:        100
+  - Regex:           '"utl/preprocessor/utl_config.h"'
+    Priority:        0
+  - Regex:           '"utl/preprocessor/.*"'
+    Priority:        5
   - Regex:           '".*"'
-    Priority:        1
+    Priority:        10
   - Regex:           '^<.*\.(h)>'
-    Priority:        3
+    Priority:        30
   - Regex:           '^<.*>'
-    Priority:        4
+    Priority:        40
 
 IfMacros: ['UTL_TRY']
 AttributeMacros: []
@@ -109,3 +113,4 @@ Macros:
 - UTL_REQUIRES_CXX20(X,Y,Z)=requires (X,Y,Z)
 - UTL_CONCEPT_CXX20(X)=typename
 - UTL_NODISCARD=[[nodiscard]]
+- UTL_ENABLE_IF_CXX11(X,Y)=void

--- a/NOTES
+++ b/NOTES
@@ -5,3 +5,5 @@
 * TODO: Maybe remove utl ordering and just use <compare>? the header is not particularly large
 # TODO: Fix for C++11 T.T
 # TODO: Shorten UTL_SCOPE to _UTL
+# TODO: Map APPLE Clang to LLVM
+# TODO: fix UTL_TRAIT_* for llvm < 18

--- a/src/utl/private/tests/iterator/syntax.cpp
+++ b/src/utl/private/tests/iterator/syntax.cpp
@@ -1,3 +1,4 @@
+// Copyright 2023-2024 Bryan Wong
 
 #include "utl/iterator/utl_bidirectional_iterator.h"
 #include "utl/iterator/utl_contiguous_iterator.h"

--- a/src/utl/private/tests/ranges/swap.cpp
+++ b/src/utl/private/tests/ranges/swap.cpp
@@ -1,0 +1,147 @@
+// Copyright 2023-2024 Bryan Wong
+
+#include "utl/ranges/utl_swap.h"
+#include "utl/utility/utl_swap.h"
+
+namespace {
+struct non_default_ctor {
+    non_default_ctor(int) {}
+    non_default_ctor(non_default_ctor const&) {}
+    non_default_ctor& operator=(non_default_ctor const&) = default;
+    non_default_ctor& operator++() { return *this; }
+};
+inline bool operator==(non_default_ctor const&, non_default_ctor const&) {
+    return false;
+}
+
+inline bool operator<(non_default_ctor const&, non_default_ctor const&) {
+    return false;
+}
+
+inline non_default_ctor operator+(non_default_ctor const&, non_default_ctor const&) {
+    return non_default_ctor(1);
+}
+
+inline non_default_ctor operator-(non_default_ctor const&, non_default_ctor const&) {
+    return non_default_ctor(1);
+}
+
+inline non_default_ctor operator*(non_default_ctor const&, non_default_ctor const&) {
+    return non_default_ctor(1);
+}
+
+struct pod {
+    int x;
+};
+} // namespace
+
+UTL_NAMESPACE_BEGIN
+template void swap(non_default_ctor&, non_default_ctor&);
+template void swap(pod&, pod&);
+UTL_NAMESPACE_END
+
+static_assert(noexcept(utl::swap(utl::declval<int&>(), utl::declval<int&>())), "Error");
+static_assert(noexcept(utl::swap(utl::declval<int (&)[5]>(), utl::declval<int (&)[5]>())), "Error");
+static_assert(noexcept(utl::ranges::swap(utl::declval<int&>(), utl::declval<int&>())), "Error");
+static_assert(
+    noexcept(utl::ranges::swap(utl::declval<int (&)[5]>(), utl::declval<int (&)[5]>())), "Error");
+
+void array_test() {
+    int x[2][3];
+    int y[2][3];
+    utl::ranges::swap(x, y);
+    utl::swap(x, y);
+
+    using utl::swap;
+    swap(x, y);
+}
+
+#if UTL_CXX14
+namespace {
+constexpr bool constexpr_test_utility() {
+    auto ok = true;
+
+    double asc = 3.1415;
+    double bsc = 2.7182;
+    utl::swap(asc, bsc);
+    ok = ok && asc == 2.7182 && bsc == 3.1415;
+
+    float arr[5]{0.0f, 1.0f, 2.0f, 3.0f, 4.0f};
+    float brr[5]{5.0f, 6.0f, 7.0f, 8.0f, 9.0f};
+    utl::swap(arr, brr);
+    ok = ok && arr[2] == 7.0f && brr[2] == 2.0f;
+
+    return ok;
+}
+
+constexpr bool constexpr_test_ranges() {
+    auto ok = true;
+
+    double asc = 3.1415;
+    double bsc = 2.7182;
+    utl::ranges::swap(asc, bsc);
+    ok = ok && asc == 2.7182 && bsc == 3.1415;
+
+    float arr[5]{0.0f, 1.0f, 2.0f, 3.0f, 4.0f};
+    float brr[5]{5.0f, 6.0f, 7.0f, 8.0f, 9.0f};
+    utl::ranges::swap(arr, brr);
+    ok = ok && arr[2] == 7.0f && brr[2] == 2.0f;
+
+    return ok;
+}
+} // namespace
+
+static_assert(constexpr_test_utility(), "");
+static_assert(constexpr_test_ranges(), "");
+#endif
+
+#include <string>
+
+namespace {
+template <typename T>
+class utility_W {
+public:
+    T data;
+};
+
+template <typename T>
+class ranges_W {
+public:
+    T data;
+};
+
+template <typename T>
+class adl_W {
+public:
+    T data;
+    friend void swap(adl_W& l, adl_W& r) { utl::ranges::swap(l.data, r.data); }
+};
+
+template <class T>
+void swap(utility_W<T>& x, utility_W<T>& y) {
+    using utl::swap;
+    swap(x.data, y.data);
+}
+
+template <class T>
+void swap(ranges_W<T>& x, ranges_W<T>& y) {
+    utl::ranges::swap(x.data, y.data);
+}
+
+// DR 809. std::swap should be overloaded for array types.
+void dr809() {
+    utility_W<std::string[8]> w1, w2; // Two objects of a Swappable type.
+    using utl::swap;
+    swap(w1, w2);
+}
+
+void dr809_ranges() {
+    ranges_W<std::string[8]> w1, w2;
+    utl::ranges::swap(w1, w2);
+}
+
+void adl_test() {
+    adl_W<std::string[8]> w1, w2;
+    utl::ranges::swap(w1, w2);
+}
+} // namespace

--- a/src/utl/private/tests/ranges/swap.cpp
+++ b/src/utl/private/tests/ranges/swap.cpp
@@ -1,5 +1,7 @@
-// Copyright 2023-2024 Bryan Wong
-// Credit: This file contains code derived from the GCC test suite.
+/**
+ * Copyright 2023-2024 Bryan Wong
+ * Credit: This file contains code derived from the GCC test suite.
+ */
 
 #include "utl/ranges/utl_swap.h"
 #include "utl/utility/utl_swap.h"

--- a/src/utl/private/tests/ranges/swap.cpp
+++ b/src/utl/private/tests/ranges/swap.cpp
@@ -1,4 +1,5 @@
 // Copyright 2023-2024 Bryan Wong
+// Credit: This file contains code derived from the GCC test suite.
 
 #include "utl/ranges/utl_swap.h"
 #include "utl/utility/utl_swap.h"
@@ -128,14 +129,14 @@ void swap(ranges_W<T>& x, ranges_W<T>& y) {
     utl::ranges::swap(x.data, y.data);
 }
 
-// DR 809. std::swap should be overloaded for array types.
-void dr809() {
+// DR 809. swap should be overloaded for array types.
+void defect_809() {
     utility_W<std::string[8]> w1, w2; // Two objects of a Swappable type.
     using utl::swap;
     swap(w1, w2);
 }
 
-void dr809_ranges() {
+void defect_809_ranges() {
     ranges_W<std::string[8]> w1, w2;
     utl::ranges::swap(w1, w2);
 }

--- a/src/utl/public/utl/concepts/utl_allocator_type.h
+++ b/src/utl/public/utl/concepts/utl_allocator_type.h
@@ -9,8 +9,8 @@
 #include "utl/concepts/utl_move_constructible.h"
 #include "utl/concepts/utl_swappable.h"
 #include "utl/preprocessor/utl_config.h"
+#include "utl/type_traits/utl_is_swappable.h"
 #include "utl/utility/utl_move.h"
-#include "utl/utility/utl_swap.h"
 
 #if UTL_CXX20
 UTL_NAMESPACE_BEGIN
@@ -52,7 +52,8 @@ concept move_assignability =
     });
 
 template <typename T>
-concept swappability = !swap_propogation<T> || (swappable<T> && is_nothrow_swappable_v<T>);
+concept swappability =
+    !swap_propogation<T> || (UTL_SCOPE swappable<T> && UTL_SCOPE is_nothrow_swappable_v<T>);
 
 } // namespace allocator
 } // namespace details

--- a/src/utl/public/utl/concepts/utl_swappable.h
+++ b/src/utl/public/utl/concepts/utl_swappable.h
@@ -5,21 +5,18 @@
 #include "utl/preprocessor/utl_config.h"
 
 #if UTL_CXX20
-#  include "utl/utility/utl_forward.h"
-#  include "utl/utility/utl_swap.h"
+
+#  include "utl/concepts/utl_common_reference_with.h"
+#  include "utl/ranges/utl_swap.h"
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T>
-concept swappable = requires(T& l, T& r) { UTL_SCOPE utility::swap(l, r); };
-
 template <typename T, typename U>
-concept swappable_with = requires(T&& t, U&& u) {
-    UTL_SCOPE utility::swap(UTL_SCOPE forward<T>(t), UTL_SCOPE forward<T>(t));
-    UTL_SCOPE utility::swap(UTL_SCOPE forward<U>(u), UTL_SCOPE forward<U>(u));
-    UTL_SCOPE utility::swap(UTL_SCOPE forward<T>(t), UTL_SCOPE forward<U>(u));
-    UTL_SCOPE utility::swap(UTL_SCOPE forward<U>(u), UTL_SCOPE forward<T>(t));
-};
+concept swappable_with = common_reference_with<T, U> && ranges::details::swap::invocable<T, U> &&
+    ranges::details::swap::invocable<U, U> && ranges::details::swap::invocable<T, T>;
+
+template <typename T>
+concept swappable = swappable_with<T&, T&>;
 
 UTL_NAMESPACE_END
 

--- a/src/utl/public/utl/exception/utl_exception_base.h
+++ b/src/utl/public/utl/exception/utl_exception_base.h
@@ -2,10 +2,11 @@
 
 #pragma once
 
-#include "utl/preprocessor/utl_assertion.h"
-#include "utl/preprocessor/utl_attributes.h"
 #include "utl/preprocessor/utl_config.h"
-#include "utl/preprocessor/utl_namespace.h"
+
+#include "utl/preprocessor/utl_assertion.h"
+
+#include "utl/type_traits/utl_constants.h"
 
 #if UTL_WITH_EXCEPTIONS
 
@@ -59,17 +60,13 @@ public:
     virtual char const* what() const noexcept { return nullptr; }
 };
 UTL_INLINE_CXX17 constexpr bool with_exceptions = false;
+
 namespace details {
 namespace exception {
-template <typename... A>
-UTL_ATTRIBUTES(NODISCARD, CONST)
-constexpr bool always_false(A&&...) noexcept {
+template <typename F>
+UTL_ATTRIBUTES(NODISCARD)
+constexpr bool catch_statement(F&&) noexcept {
     return false;
-}
-template <typename... A>
-UTL_ATTRIBUTES(NODISCARD, CONST)
-constexpr bool always_true(A&&...) noexcept {
-    return true;
 }
 } // namespace exception
 } // namespace details
@@ -84,18 +81,20 @@ UTL_NAMESPACE_END
 #    define UTL_NOEXCEPT(...) noexcept(__VA_ARGS__)
 #  endif
 
-#  define UTL_THROW(...)                                                   \
-      UTL_ASSERT(UTL_SCOPE details::exception::always_false(__VA_ARGS__)); \
+#  define UTL_THROW(...)                                                \
+      UTL_ASSERT(UTL_SCOPE always_false<decltype(__VA_ARGS__)>::value); \
       UTL_BUILTIN_unreachable()
 #  define UTL_RETHROW(...)            \
       UTL_ASSERT(false, __VA_ARGS__); \
       UTL_BUILTIN_unreachable()
 #  define UTL_TRY if UTL_CONSTEXPR_CXX17 (1)
 
-#  define UTL_THROW_IF(CONDITION, ...)                                                     \
-      UTL_ASSERT(!(CONDITION) && UTL_SCOPE details::exception::always_false(__VA_ARGS__)); \
+#  define UTL_THROW_IF(CONDITION, ...)                                                  \
+      UTL_ASSERT(!(CONDITION) && UTL_SCOPE always_false<decltype(__VA_ARGS__)>::value); \
       UTL_BUILTIN_unreachable()
 
-#  define UTL_CATCH(...) else if (UTL_SCOPE always_false([](__VA_ARGS__) -> void {}))
+#  define UTL_CATCH(...)                                                          \
+      else if UTL_CONSTEXPR_CXX17 (UTL_SCOPE details::exception::catch_statement( \
+                                       [](__VA_ARGS__) -> void {}))
 
 #endif // UTL_WITH_EXCEPTIONS

--- a/src/utl/public/utl/memory/utl_allocator.h
+++ b/src/utl/public/utl/memory/utl_allocator.h
@@ -5,11 +5,11 @@
 #include "utl/exception/utl_program_exception.h"
 #include "utl/memory/utl_allocator_fwd.h"
 #include "utl/preprocessor/utl_config.h"
-#include "utl/string/utl_constant_p.h"
 #include "utl/type_traits/utl_enable_if.h"
 #include "utl/type_traits/utl_is_complete.h"
 #include "utl/type_traits/utl_is_void.h"
 #include "utl/type_traits/utl_type_identity.h"
+#include "utl/utility/utl_constant_p.h"
 
 #include <cstddef>
 #include <new>

--- a/src/utl/public/utl/ranges/utl_swap.h
+++ b/src/utl/public/utl/ranges/utl_swap.h
@@ -1,0 +1,212 @@
+// Copyright 2023-2024 Bryan Wong
+
+#pragma once
+
+#include "utl/preprocessor/utl_config.h"
+
+#if UTL_USE_STD_ranges_swap && UTL_CXX20
+
+#  include <ranges>
+
+UTL_NAMESPACE_BEGIN
+using ::std::ranges::swap;
+UTL_NAMESPACE_END
+
+#else
+
+#  if UTL_USE_STD_ranges_swap
+UTL_PRAGMA_WARN(
+    "ranges::swap is only available in C++20, ignoring `UTL_USE_STD_ranges_swap` defintion");
+#  endif
+
+#  include "utl/type_traits/utl_extent.h"
+#  include "utl/type_traits/utl_is_nothrow_move_assignable.h"
+#  include "utl/type_traits/utl_is_nothrow_move_constructible.h"
+#  include "utl/utility/utl_customization_point.h"
+#  include "utl/utility/utl_exchange.h"
+#  include "utl/utility/utl_forward.h"
+
+#  if UTL_CXX20
+
+#    include "utl/concepts/utl_assignable_from.h"
+#    include "utl/concepts/utl_move_constructible.h"
+
+UTL_NAMESPACE_BEGIN
+
+namespace ranges {
+namespace details {
+namespace swap {
+
+struct function_t;
+template <typename T>
+void swap(T&, T&) = delete;
+
+template <typename L, typename R>
+concept unqualified_swappable =
+    requires(L&& l, R&& r) { swap(UTL_SCOPE forward<L>(l), UTL_SCOPE forward<R>(r)); };
+
+template <typename L, typename R>
+concept nothrow_unqualified_swappable = unqualified_swappable<L, R> && requires(L&& l, R&& r) {
+    { swap(UTL_SCOPE forward<L>(l), UTL_SCOPE forward<R>(r)) } noexcept;
+};
+
+template <typename L, typename R, size_t N>
+concept unqualified_swappable_array =
+    (!unqualified_swappable<L (&)[N], R (&)[N]> && UTL_SCOPE extent_v<L> == UTL_SCOPE extent_v<R> &&
+        requires(L (&l)[N], R (&r)[N], function_t const& func) { func(*l, *r); });
+
+template <typename T>
+concept exchangable = !unqualified_swappable<T&, T&> && UTL_SCOPE move_constructible<T> &&
+    UTL_SCOPE assignable_from<T&, T>;
+
+struct function_t {
+    template <typename L, typename R>
+    requires unqualified_swappable<L, R>
+    UTL_ATTRIBUTE(ALWAYS_INLINE) UTL_CONSTEXPR_CXX14 void operator()(L&& l, R&& r) const
+        noexcept(nothrow_unqualified_swappable<L, R>) {
+        swap(l, r);
+    }
+
+    template <typename L, typename R, size_t N>
+    requires unqualified_swappable_array<L, R, N>
+    UTL_CONSTEXPR_CXX14 void operator()(L (&l)[N], R (&r)[N]) const noexcept(noexcept((*this)(*l, *r))) {
+        for (decltype(N) i = 0; i < N; ++i) {
+            (*this)(l[i], r[i]);
+        }
+    }
+
+    template <exchangable T>
+    UTL_CONSTEXPR_CXX14 void operator()(T& l, T& r) const noexcept(
+        UTL_TRAIT_is_nothrow_move_constructible(T) && UTL_TRAIT_is_nothrow_move_assignable(T)) {
+        r = UTL_SCOPE exchange(l, UTL_SCOPE move(r));
+    }
+};
+} // namespace swap
+} // namespace details
+
+inline namespace cpo {
+UTL_DEFINE_CUSTOMIZATION_POINT(UTL_SCOPE ranges::details::swap::function_t, swap);
+} // namespace cpo
+
+namespace details {
+namespace swap {
+template <typename L, typename R>
+concept invocable = requires(L&& l, R&& r) {
+    UTL_SCOPE ranges::swap(UTL_SCOPE forward<L>(l), UTL_SCOPE forward<R>(r));
+    UTL_SCOPE ranges::swap(UTL_SCOPE forward<R>(r), UTL_SCOPE forward<L>(l));
+};
+
+template <typename L, typename R>
+concept nothrow_invocable = invocable<L, R> && requires(L&& l, R&& r) {
+    { UTL_SCOPE ranges::swap(UTL_SCOPE forward<L>(l), UTL_SCOPE forward<R>(r)) } noexcept;
+    { UTL_SCOPE ranges::swap(UTL_SCOPE forward<R>(r), UTL_SCOPE forward<L>(l)) } noexcept;
+};
+} // namespace swap
+} // namespace details
+
+} // namespace ranges
+
+UTL_NAMESPACE_END
+
+#  else
+
+#    include "utl/type_traits/utl_constants.h"
+#    include "utl/type_traits/utl_declval.h"
+#    include "utl/type_traits/utl_enable_if.h"
+#    include "utl/type_traits/utl_is_move_assignable.h"
+#    include "utl/type_traits/utl_is_move_constructible.h"
+#    include "utl/type_traits/utl_logical_traits.h"
+#    include "utl/type_traits/utl_void_t.h"
+
+UTL_NAMESPACE_BEGIN
+
+namespace ranges {
+namespace details {
+namespace swap {
+
+struct function_t;
+template <typename T>
+void swap(T&, T&) = delete;
+
+template <typename L, typename R>
+auto unqualified_swappable_impl(float) noexcept -> UTL_SCOPE false_type;
+template <typename L, typename R>
+auto unqualified_swappable_impl(int) noexcept
+    -> UTL_SCOPE always_true<decltype(swap(UTL_SCOPE declval<L>(), UTL_SCOPE declval<R>()))>;
+
+template <typename L, typename R>
+auto nothrow_unqualified_swappable_impl(float) noexcept -> UTL_SCOPE false_type;
+template <typename L, typename R>
+auto nothrow_unqualified_swappable_impl(int) noexcept
+    -> UTL_SCOPE bool_constant<noexcept(swap(UTL_SCOPE declval<L>(), UTL_SCOPE declval<R>()))>;
+
+template <typename L, typename R, size_t N>
+auto unqualified_swappable_array_impl(float) noexcept -> UTL_SCOPE false_type;
+
+template <typename L, typename R, size_t N, typename F = function_t const&>
+auto unqualified_swappable_array_impl(int) noexcept -> UTL_SCOPE
+    conjunction<UTL_SCOPE bool_constant<(UTL_SCOPE extent_v<L> == UTL_SCOPE extent_v<R>)>,
+        UTL_SCOPE always_true<decltype(UTL_SCOPE declval<F>()(
+            UTL_SCOPE declval<L&>(), UTL_SCOPE declval<R&>()))>>;
+
+template <typename L, typename R>
+using unqualified_swappable = decltype(unqualified_swappable_impl<L, R>(0));
+template <typename L, typename R>
+using nothrow_unqualified_swappable = decltype(nothrow_unqualified_swappable_impl<L, R>(0));
+template <typename L, typename R, size_t N>
+using unqualified_swappable_array = decltype(unqualified_swappable_array_impl<L, R>(0));
+
+struct function_t {
+private:
+    static constexpr struct third_t {
+    } third = {};
+    static constexpr struct second_t : third_t {
+    } second = {};
+    static constexpr struct first_t : second_t {
+    } first = {};
+
+    template <typename L, typename R>
+    UTL_ATTRIBUTE(ALWAYS_INLINE)
+    UTL_CONSTEXPR_CXX14 UTL_SCOPE enable_if_t<unqualified_swappable<L, R>::value> operator()(
+        L&& l, R&& r, first_t) const noexcept(nothrow_unqualified_swappable<L, R>::value) {
+        swap(UTL_SCOPE forward<L>(l), UTL_SCOPE forward<R>(r));
+    }
+
+    template <typename L, typename R, size_t N>
+    UTL_ATTRIBUTE(ALWAYS_INLINE)
+    UTL_CONSTEXPR_CXX14 UTL_SCOPE enable_if_t<unqualified_swappable_array<L, R, N>::value> operator()(
+        L (&l)[N], R (&r)[N], second_t) const noexcept(noexcept((*this)(*l, *r))) {
+        for (decltype(N) i = 0; i < N; ++i) {
+            (*this)(l[i], r[i]);
+        }
+    }
+
+    template <typename T>
+    UTL_ATTRIBUTE(ALWAYS_INLINE)
+    UTL_CONSTEXPR_CXX14 UTL_SCOPE
+        enable_if_t<UTL_TRAIT_is_move_constructible(T) && UTL_TRAIT_is_move_assignable(T)>
+        operator()(T& l, T& r, third_t) const noexcept(
+            UTL_TRAIT_is_nothrow_move_constructible(T) && UTL_TRAIT_is_nothrow_move_assignable(T)) {
+        r = UTL_SCOPE exchange(l, UTL_SCOPE move(r));
+    }
+
+public:
+    template <typename L, typename R>
+    UTL_CONSTEXPR_CXX14 auto operator()(L& l, R& r) const noexcept(noexcept((*this)(l, r, function_t::first)))
+        -> decltype((*this)(l, r, function_t::first)) {
+        (*this)(l, r, function_t::first);
+    }
+};
+} // namespace swap
+} // namespace details
+
+inline namespace cpo {
+UTL_DEFINE_CUSTOMIZATION_POINT(UTL_SCOPE ranges::details::swap::function_t, swap);
+} // namespace cpo
+} // namespace ranges
+
+UTL_NAMESPACE_END
+
+#  endif
+
+#endif

--- a/src/utl/public/utl/string/utl_libc.h
+++ b/src/utl/public/utl/string/utl_libc.h
@@ -3,9 +3,9 @@
 #pragma once
 
 #include "utl/preprocessor/utl_config.h"
-#include "utl/string/utl_constant_p.h"
 #include "utl/string/utl_libc_compile_time.h"
 #include "utl/string/utl_libc_runtime.h"
+#include "utl/utility/utl_constant_p.h"
 
 UTL_NAMESPACE_BEGIN
 #define UTL_LIBC_PURE UTL_ATTRIBUTES(NODISCARD, PURE)

--- a/src/utl/public/utl/tuple/utl_tuple_cpp17.h
+++ b/src/utl/public/utl/tuple/utl_tuple_cpp17.h
@@ -6,16 +6,14 @@
  * Standard Tuple implementation up to and including C++17
  */
 
-#include "utl/preprocessor/utl_pragma.h"
-
 #if !defined(UTL_TUPLE_PRIVATE_HEADER_GUARD)
 #  error "Private header accessed"
 #endif
 
+#include "utl/preprocessor/utl_config.h"
+
 #include "utl/memory/utl_uses_allocator.h"
-#include "utl/preprocessor/utl_attributes.h"
-#include "utl/preprocessor/utl_namespace.h"
-#include "utl/preprocessor/utl_standard.h"
+#include "utl/ranges/utl_swap.h"
 #include "utl/tuple/utl_tuple_compare_traits.h"
 #include "utl/tuple/utl_tuple_fwd.h"
 #include "utl/tuple/utl_tuple_traits.h"
@@ -26,6 +24,7 @@
 #include "utl/type_traits/utl_is_copy_constructible.h"
 #include "utl/type_traits/utl_is_default_constructible.h"
 #include "utl/type_traits/utl_is_explicit_constructible.h"
+#include "utl/type_traits/utl_is_move_assignable.h"
 #include "utl/type_traits/utl_is_move_constructible.h"
 #include "utl/type_traits/utl_is_nothrow_copy_constructible.h"
 #include "utl/type_traits/utl_is_nothrow_default_constructible.h"
@@ -39,7 +38,6 @@
 #include "utl/utility/utl_ignore.h"
 #include "utl/utility/utl_move.h"
 #include "utl/utility/utl_sequence.h"
-#include "utl/utility/utl_swap.h"
 
 UTL_NAMESPACE_BEGIN
 
@@ -187,25 +185,25 @@ public:
     template <typename U = T>
     UTL_CONSTEXPR_CXX14 void swap(storage<U>& other) noexcept(
         traits::template is_nothrow_swappable_with<U&>::value) {
-        UTL_SCOPE utility::swap(head, other.head);
+        UTL_SCOPE ranges::swap(head, other.head);
     }
 
     template <typename U = T>
     UTL_CONSTEXPR_CXX14 void swap(storage<U> const& other) noexcept(
         traits::template is_nothrow_swappable_with<U const&>::value) {
-        UTL_SCOPE utility::swap(head, other.head);
+        UTL_SCOPE ranges::swap(head, other.head);
     }
 
     template <typename U = T>
     UTL_CONSTEXPR_CXX14 void swap(storage<U>& other) const
         noexcept(traits::template is_nothrow_const_swappable_with<U&>::value) {
-        UTL_SCOPE utility::swap(head, other.head);
+        UTL_SCOPE ranges::swap(head, other.head);
     }
 
     template <typename U = T>
     UTL_CONSTEXPR_CXX14 void swap(storage<U> const& other) const
         noexcept(traits::template is_nothrow_const_swappable_with<U const&>::value) {
-        UTL_SCOPE utility::swap(head, other.head);
+        UTL_SCOPE ranges::swap(head, other.head);
     }
 
     template <typename U>
@@ -345,7 +343,7 @@ struct storage<T, Tail...> : variadic_traits<T, Tail...> {
     UTL_ATTRIBUTE(ALWAYS_INLINE)
     UTL_CONSTEXPR_CXX14 void swap(storage<Us&...>& other) noexcept(
         traits::template is_nothrow_swappable_with<Us&...>::value) {
-        UTL_SCOPE utility::swap(head, other.head);
+        UTL_SCOPE ranges::swap(head, other.head);
         tail.swap(other.tail);
     }
 
@@ -353,7 +351,7 @@ struct storage<T, Tail...> : variadic_traits<T, Tail...> {
     UTL_ATTRIBUTE(ALWAYS_INLINE)
     UTL_CONSTEXPR_CXX14 void swap(storage<Us...> const& other) const
         noexcept(traits::template is_nothrow_const_swappable_with<Us const&...>::value) {
-        UTL_SCOPE utility::swap(head, other.head);
+        UTL_SCOPE ranges::swap(head, other.head);
         tail.swap(other.tail);
     }
 
@@ -361,7 +359,7 @@ struct storage<T, Tail...> : variadic_traits<T, Tail...> {
     UTL_ATTRIBUTE(ALWAYS_INLINE)
     UTL_CONSTEXPR_CXX14 void swap(storage<Us...>& other) const
         noexcept(traits::template is_nothrow_const_swappable_with<Us&...>::value) {
-        UTL_SCOPE utility::swap(head, other.head);
+        UTL_SCOPE ranges::swap(head, other.head);
         tail.swap(other.tail);
     }
 

--- a/src/utl/public/utl/tuple/utl_tuple_latest.h
+++ b/src/utl/public/utl/tuple/utl_tuple_latest.h
@@ -14,6 +14,8 @@
 #  error "Header compiled with invalid standard"
 #endif
 
+#include "utl/preprocessor/utl_config.h"
+
 #include "utl/compare/utl_compare_traits.h"
 #include "utl/compare/utl_strong_ordering.h"
 #include "utl/concepts/utl_allocator_type.h"
@@ -29,7 +31,7 @@
 #include "utl/concepts/utl_three_way_comparable.h"
 #include "utl/concepts/utl_variadic_match.h"
 #include "utl/memory/utl_uses_allocator.h"
-#include "utl/preprocessor/utl_config.h"
+#include "utl/ranges/utl_swap.h"
 #include "utl/tuple/utl_tuple_compare_traits.h"
 #include "utl/tuple/utl_tuple_concepts.h"
 #include "utl/type_traits/utl_common_comparison_category.h"
@@ -39,7 +41,10 @@
 #include "utl/type_traits/utl_is_base_of.h"
 #include "utl/type_traits/utl_is_explicit_constructible.h"
 #include "utl/type_traits/utl_is_implicit_constructible.h"
+#include "utl/type_traits/utl_is_move_assignable.h"
+#include "utl/type_traits/utl_is_move_constructible.h"
 #include "utl/type_traits/utl_is_nothrow_constructible.h"
+#include "utl/type_traits/utl_is_nothrow_copy_assignable.h"
 #include "utl/type_traits/utl_is_nothrow_copy_constructible.h"
 #include "utl/type_traits/utl_is_nothrow_default_constructible.h"
 #include "utl/type_traits/utl_is_standard_layout.h"
@@ -50,7 +55,6 @@
 #include "utl/utility/utl_ignore.h"
 #include "utl/utility/utl_move.h"
 #include "utl/utility/utl_sequence.h"
-#include "utl/utility/utl_swap.h"
 
 #define TT_SCOPE UTL_SCOPE tuple_traits::
 
@@ -130,8 +134,10 @@ template <typename T>
 struct storage<T> {
 public:
     using head_type = T;
-    using move_assign_t = conditional_t<is_move_assignable_v<T>, invalid_t, storage>;
-    using move_construct_t = conditional_t<is_move_constructible_v<T>, invalid_t, storage>;
+    using move_assign_t =
+        UTL_SCOPE conditional_t<UTL_SCOPE is_move_assignable_v<T>, invalid_t, storage>;
+    using move_construct_t =
+        UTL_SCOPE conditional_t<UTL_SCOPE is_move_constructible_v<T>, invalid_t, storage>;
 
     constexpr storage() noexcept(is_nothrow_default_constructible_v<T>) = default;
     constexpr storage(storage const&) noexcept(is_nothrow_copy_constructible_v<T>) = default;
@@ -191,25 +197,25 @@ public:
 
     template <typename U>
     constexpr void swap(storage<U>& other) noexcept(is_nothrow_swappable_with_v<T&, U&>) {
-        UTL_SCOPE utility::swap(head, other.head);
+        UTL_SCOPE ranges::swap(head, other.head);
     }
 
     template <typename U>
     constexpr void swap(storage<U> const& other) noexcept(
         is_nothrow_swappable_with_v<T&, U const&>) {
-        UTL_SCOPE utility::swap(head, other.head);
+        UTL_SCOPE ranges::swap(head, other.head);
     }
 
     template <typename U>
     constexpr void swap(storage<U>& other) const
         noexcept(is_nothrow_swappable_with_v<T const&, U&>) {
-        UTL_SCOPE utility::swap(head, other.head);
+        UTL_SCOPE ranges::swap(head, other.head);
     }
 
     template <typename U>
     constexpr void swap(storage<U> const& other) const
         noexcept(is_nothrow_swappable_with_v<T const&, U const&>) {
-        UTL_SCOPE utility::swap(head, other.head);
+        UTL_SCOPE ranges::swap(head, other.head);
     }
 
     template <typename U>
@@ -347,7 +353,7 @@ public:
     template <typename U, typename... Us>
     constexpr void swap(storage<U, Us...>& other) noexcept(
         (is_nothrow_swappable_with_v<T&, U&> && ... && is_nothrow_swappable_with_v<Tail&, Us&>)) {
-        UTL_SCOPE utility::swap(head, other.head);
+        UTL_SCOPE ranges::swap(head, other.head);
         tail.swap(other.tail);
     }
 
@@ -355,7 +361,7 @@ public:
     constexpr void swap(storage<U, Us...>& other) const
         noexcept((is_nothrow_swappable_with_v<T const&, U&> && ... &&
             is_nothrow_swappable_with_v<Tail const&, Us&>)) {
-        UTL_SCOPE utility::swap(head, other.head);
+        UTL_SCOPE ranges::swap(head, other.head);
         tail.swap(other.tail);
     }
 
@@ -363,7 +369,7 @@ public:
     constexpr void swap(storage<U, Us...> const& other) noexcept(
         (is_nothrow_swappable_with_v<T&, U const&> && ... &&
             is_nothrow_swappable_with_v<Tail&, Us const&>)) {
-        UTL_SCOPE utility::swap(head, other.head);
+        UTL_SCOPE ranges::swap(head, other.head);
         tail.swap(other.tail);
     }
 
@@ -371,7 +377,7 @@ public:
     constexpr void swap(storage<U, Us...> const& other) const
         noexcept((is_nothrow_swappable_with_v<T const&, U const&> && ... &&
             is_nothrow_swappable_with_v<Tail const&, Us const&>)) {
-        UTL_SCOPE utility::swap(head, other.head);
+        UTL_SCOPE ranges::swap(head, other.head);
         tail.swap(other.tail);
     }
 

--- a/src/utl/public/utl/type_traits/utl_constants.h
+++ b/src/utl/public/utl/type_traits/utl_constants.h
@@ -14,7 +14,7 @@ struct integral_constant {
     static constexpr T value = N;
     using value_type = T;
     using type = integral_constant;
-    constexpr            operator value_type() const noexcept { return N; }
+    constexpr operator value_type() const noexcept { return N; }
     constexpr value_type operator()() const noexcept { return N; }
 };
 
@@ -30,13 +30,20 @@ template <bool B>
 using bool_constant = integral_constant<bool, B>;
 using true_type = bool_constant<true>;
 using false_type = bool_constant<false>;
+template <typename...>
+using always_true = true_type;
+template <typename...>
+using always_false = false_type;
 
 #if UTL_CXX14
 template <typename T, T N>
 UTL_INLINE_CXX17 constexpr T integral_constant_v = N;
-
 template <typename T, T N>
 UTL_INLINE_CXX17 constexpr T value_constant_v = N;
+template <typename...>
+UTL_INLINE_CXX17 constexpr bool always_true_v = true;
+template <typename...>
+UTL_INLINE_CXX17 constexpr bool always_false_v = false;
 #endif
 
 UTL_NAMESPACE_END

--- a/src/utl/public/utl/type_traits/utl_extent.h
+++ b/src/utl/public/utl/type_traits/utl_extent.h
@@ -33,11 +33,11 @@ UTL_NAMESPACE_END
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T, size_t Dim>
+template <typename T, size_t Dim = 0>
 struct extent : size_constant<UTL_BUILTIN_array_extent(T, Dim)> {};
 
 #    if UTL_CXX14
-template <typename T, size_t Dim>
+template <typename T, size_t Dim = 0>
 UTL_INLINE_CXX17 constexpr size_t extent_v = UTL_BUILTIN_array_extent(T, Dim);
 #    endif // UTL_CXX14
 

--- a/src/utl/public/utl/type_traits/utl_is_copyable.h
+++ b/src/utl/public/utl/type_traits/utl_is_copyable.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "utl/type_traits/utl_common.h"
+#include "utl/type_traits/utl_is_copy_assignable.h"
 #include "utl/type_traits/utl_is_copy_constructible.h"
 #include "utl/type_traits/utl_is_movable.h"
 

--- a/src/utl/public/utl/type_traits/utl_is_movable.h
+++ b/src/utl/public/utl/type_traits/utl_is_movable.h
@@ -7,7 +7,7 @@
 #include "utl/type_traits/utl_is_assignable.h"
 #include "utl/type_traits/utl_is_move_constructible.h"
 #include "utl/type_traits/utl_is_object.h"
-#include "utl/utility/utl_swap.h"
+#include "utl/type_traits/utl_is_swappable.h"
 
 UTL_NAMESPACE_BEGIN
 

--- a/src/utl/public/utl/type_traits/utl_is_swappable.h
+++ b/src/utl/public/utl/type_traits/utl_is_swappable.h
@@ -1,0 +1,146 @@
+// Copyright 2023-2024 Bryan Wong
+
+#pragma once
+
+#include "utl/type_traits/utl_common.h"
+
+#if UTL_USE_STD_TYPE_TRAITS && UTL_USE_STD_swap && UTL_CXX20
+
+#  include <type_traits>
+
+UTL_NAMESPACE_BEGIN
+
+using std::is_nothrow_swappable;
+using std::is_nothrow_swappable_v;
+using std::is_nothrow_swappable_with;
+using std::is_nothrow_swappable_with_v;
+using std::is_swappable;
+using std::is_swappable_v;
+using std::is_swappable_with;
+using std::is_swappable_with_v;
+
+UTL_NAMESPACE_END
+
+#else // if UTL_USE_STD_TYPE_TRAITS && UTL_USE_STD_swap && UTL_CXX20
+
+#  include "utl/type_traits/utl_constants.h"
+#  include "utl/utility/utl_swap.h"
+
+#  if UTL_CXX20
+
+#    include "utl/concepts/utl_referenceable.h"
+
+UTL_NAMESPACE_BEGIN
+
+template <typename L, typename R>
+struct is_swappable_with : bool_constant<ranges::details::swap::invocable<L, R>> {};
+template <typename L, typename R>
+struct is_nothrow_swappable_with : bool_constant<ranges::details::swap::nothrow_invocable<L, R>> {};
+
+template <typename T>
+struct is_swappable : false_type {};
+template <typename T>
+struct is_nothrow_swappable : false_type {};
+
+template <referenceable T>
+struct is_swappable<T> : bool_constant<ranges::details::swap::invocable<T&, T&>> {};
+template <referenceable T>
+struct is_nothrow_swappable<T> : bool_constant<ranges::details::swap::nothrow_invocable<T&, T&>> {};
+
+template <typename L, typename R>
+inline constexpr bool is_swappable_with_v = ranges::details::swap::invocable<L, R>;
+template <typename L, typename R>
+inline constexpr bool is_nothrow_swappable_with_v = ranges::details::swap::nothrow_invocable<L, R>;
+template <typename T>
+inline constexpr bool is_swappable_v = referenceable<T> && ranges::details::swap::invocable<T&, T&>;
+template <typename T>
+inline constexpr bool is_nothrow_swappable_v =
+    referenceable<T> && ranges::details::swap::nothrow_invocable<T&, T&>;
+
+UTL_NAMESPACE_END
+
+#  else // if UTL_CXX20
+
+#    include "utl/type_traits/utl_declval.h"
+#    include "utl/type_traits/utl_is_referenceable.h"
+
+UTL_NAMESPACE_BEGIN
+
+namespace details {
+namespace swappable {
+template <typename L, typename R>
+auto trait_impl(float) noexcept -> UTL_SCOPE false_type;
+template <typename L, typename R>
+auto trait_impl(int) noexcept -> UTL_SCOPE
+    always_true<decltype(UTL_SCOPE ranges::swap(UTL_SCOPE declval<L>(), UTL_SCOPE declval<R>())),
+        decltype(UTL_SCOPE ranges::swap(UTL_SCOPE declval<R>(), UTL_SCOPE declval<L>()))>;
+
+template <typename L, typename R>
+auto nothrow_impl(float) noexcept -> UTL_SCOPE false_type;
+template <typename L, typename R>
+auto nothrow_impl(int) noexcept
+    -> UTL_SCOPE bool_constant<noexcept(UTL_SCOPE ranges::swap(
+                                   UTL_SCOPE declval<L>(), UTL_SCOPE declval<R>())) &&
+        noexcept(UTL_SCOPE ranges::swap(UTL_SCOPE declval<R>(), UTL_SCOPE declval<L>()))>;
+
+template <typename L, typename R>
+using trait = decltype(trait_impl<L, R>(0));
+template <typename L, typename R>
+using is_nothrow = decltype(nothrow_impl<L, R>(0));
+} // namespace swappable
+} // namespace details
+
+template <typename L, typename R>
+struct is_swappable_with : details::swappable::trait<L, R> {};
+template <typename L, typename R>
+struct is_nothrow_swappable_with : details::swappable::is_nothrow<L, R> {};
+
+template <typename T>
+struct is_swappable : conjunction<is_referenceable<T>, is_swappable_with<T&, T&>> {};
+template <typename T>
+struct is_nothrow_swappable :
+    conjunction<is_referenceable<T>, is_nothrow_swappable_with<T&, T&>> {};
+
+#    if UTL_CXX14
+
+template <typename L, typename R>
+UTL_INLINE_CXX17 constexpr bool is_swappable_with_v = details::swappable::trait<L, R>::value;
+template <typename L, typename R>
+UTL_INLINE_CXX17 constexpr bool is_nothrow_swappable_with_v = details::swappable::is_nothrow<L, R>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_swappable_v = is_swappable<T>::value;
+template <typename T>
+UTL_INLINE_CXX17 constexpr bool is_nothrow_swappable_v = is_nothrow_swappable<T>::value;
+
+#    endif // if UTL_CXX14
+
+UTL_NAMESPACE_END
+
+#  endif // if UTL_CXX20
+
+#endif // if UTL_USE_STD_TYPE_TRAITS && UTL_USE_STD_swap
+
+#if UTL_CXX20
+#  define UTL_TRAIT_is_swappable_with(...) UTL_SCOPE details::swappable::swap_invocable<__VA_ARGS__>
+#  define UTL_TRAIT_is_nothrow_swappable_with(...) \
+      UTL_SCOPE details::swappable::nothrow_swap_invocable<__VA_ARGS__>
+#  define UTL_TRAIT_is_swappable(...) UTL_SCOPE is_swappable_v<__VA_ARGS__>
+#  define UTL_TRAIT_is_nothrow_swappable(...) UTL_SCOPE is_nothrow_swappable_v<__VA_ARGS__>
+#elif UTL_CXX14
+#  define UTL_TRAIT_is_swappable(...) UTL_SCOPE is_swappable_v<__VA_ARGS__>
+#  define UTL_TRAIT_is_nothrow_swappable(...) UTL_SCOPE is_nothrow_swappable_v<__VA_ARGS__>
+#  define UTL_TRAIT_is_swappable_with(...) UTL_SCOPE is_swappable_with_v<__VA_ARGS__>
+#  define UTL_TRAIT_is_nothrow_swappable_with(...) \
+      UTL_SCOPE is_nothrow_swappable_with_v<__VA_ARGS__>
+#else
+#  define UTL_TRAIT_is_swappable(...) UTL_SCOPE is_swappable<__VA_ARGS__>::value
+#  define UTL_TRAIT_is_nothrow_swappable(...) UTL_SCOPE is_nothrow_swappable<__VA_ARGS__>::value
+#  define UTL_TRAIT_is_swappable_with(...) UTL_SCOPE is_swappable_with<__VA_ARGS__>::value
+#  define UTL_TRAIT_is_nothrow_swappable_with(...) \
+      UTL_SCOPE is_nothrow_swappable_with<__VA_ARGS__>::value
+#endif
+
+#define UTL_TRAIT_SUPPORTED_is_swappable 1
+#define UTL_TRAIT_SUPPORTED_is_nothrow_swappable 1
+#define UTL_TRAIT_SUPPORTED_is_swappable_with 1
+#define UTL_TRAIT_SUPPORTED_is_nothrow_swappable_with 1

--- a/src/utl/public/utl/utility/utl_constant_p.h
+++ b/src/utl/public/utl/utility/utl_constant_p.h
@@ -9,12 +9,12 @@
 #  define UTL_CONSTANT_P(...) UTL_BUILTIN_is_constant_evaluated()
 
 #elif UTL_HAS_BUILTIN(__builtin_constant_p)
-#  define UTL_CONSTANT_P(...) __builtin_constant_p(__VA_ARGS__)
+#  define UTL_CONSTANT_P(...) __builtin_constant_p((__VA_ARGS__))
 
 #elif UTL_COMPILER_MSVC
 UTL_NAMESPACE_BEGIN
 namespace details {
-UTL_ATTRIBUTES(NODISCARD, CONST, ALWAYS_INLINE)
+UTL_ATTRIBUTES(NODISCARD, CONST)
 constexpr bool is_constant_evaluated() noexcept {
     struct C {};
     struct M : C {

--- a/src/utl/public/utl/utility/utl_customization_point.h
+++ b/src/utl/public/utl/utility/utl_customization_point.h
@@ -1,0 +1,52 @@
+// Copyright 2023-2024 Bryan Wong
+
+#pragma once
+
+#include "utl/preprocessor/utl_config.h"
+
+#if UTL_CXX17
+
+#  define UTL_DEFINE_CUSTOMIZATION_POINT(TYPE, NAME) inline constexpr TYPE NAME = {}
+
+#elif UTL_CXX14
+
+UTL_NAMESPACE_BEGIN
+namespace details {
+namespace customization_point {
+template <typename T>
+constexpr T constant = {};
+} // namespace customization_point
+} // namespace details
+
+UTL_NAMESPACE_END
+
+#  define UTL_DEFINE_CUSTOMIZATION_POINT(TYPE, NAME)                                       \
+      namespace {                                                                          \
+      constexpr auto const& NAME = UTL_SCOPE details::customization_point::constant<TYPE>; \
+      }                                                                                    \
+      static_assert(true, "semi-colon required")
+
+#else
+UTL_NAMESPACE_BEGIN
+
+namespace details {
+namespace customization_point {
+template <typename T>
+struct constant {
+    static constexpr T value = {};
+};
+
+template <typename T>
+constexpr T constant<T>::value;
+} // namespace customization_point
+} // namespace details
+
+UTL_NAMESPACE_END
+
+#  define UTL_DEFINE_CUSTOMIZATION_POINT(TYPE, NAME)                                              \
+      namespace {                                                                                 \
+      constexpr auto const& NAME = UTL_SCOPE details::customization_point::constant<TYPE>::value; \
+      }                                                                                           \
+      static_assert(true, "semi-colon required")
+
+#endif

--- a/src/utl/public/utl/utility/utl_exchange.h
+++ b/src/utl/public/utl/utility/utl_exchange.h
@@ -35,8 +35,10 @@ UTL_PRAGMA_WARN(
 UTL_NAMESPACE_BEGIN
 
 template <UTL_CONCEPT_CXX20(move_constructible) T, UTL_CONCEPT_CXX20(assignable_to<T&>) U = T>
-constexpr UTL_ENABLE_IF_CXX11(T, UTL_TRAIT_is_move_constructible(T) && UTL_TRAIT_is_assignable(T&, U)) exchange(T& obj, U&& new_value) noexcept(
-    UTL_TRAIT_is_nothrow_move_constructible(T) && UTL_TRAIT_is_nothrow_assignable(T&, U)) {
+constexpr UTL_ENABLE_IF_CXX11(
+    T, UTL_TRAIT_is_move_constructible(T) && utl::is_assignable<T&, U>::value)
+    exchange(T& obj, U&& new_value) noexcept(
+        UTL_TRAIT_is_nothrow_move_constructible(T) && UTL_TRAIT_is_nothrow_assignable(T&, U)) {
     T previous(UTL_SCOPE move(obj));
     obj = UTL_SCOPE forward<U>(new_value);
     return previous;

--- a/src/utl/public/utl/utility/utl_exchange.h
+++ b/src/utl/public/utl/utility/utl_exchange.h
@@ -10,9 +10,9 @@
 
 UTL_NAMESPACE_BEGIN
 
-using std::exchange
+using std::exchange;
 
-    UTL_NAMESPACE_END
+UTL_NAMESPACE_END
 
 #else // UTL_CXX23 && UTL_USE_STD_exchange
 
@@ -22,6 +22,9 @@ UTL_PRAGMA_WARN(
 #    undef UTL_USE_STD_exchange
 #  endif // UTL_USE_STD_exchange
 
+#  include "utl/concepts/utl_assignable_to.h"
+#  include "utl/concepts/utl_move_constructible.h"
+#  include "utl/type_traits/utl_enable_if.h"
 #  include "utl/type_traits/utl_is_assignable.h"
 #  include "utl/type_traits/utl_is_move_constructible.h"
 #  include "utl/type_traits/utl_is_nothrow_assignable.h"
@@ -31,12 +34,11 @@ UTL_PRAGMA_WARN(
 
 UTL_NAMESPACE_BEGIN
 
-template <typename T, typename U = T>
-constexpr enable_if_t<conjunction<is_move_constructible<T>, is_assignable<T&, U>>::value, T>
-exchange(T& obj, U&& new_value) noexcept(
-    is_nothrow_move_constructible<T>::value && is_nothrow_assignable<T&, U>::value) {
-    T previous(move(obj));
-    obj = forward<U>(new_value);
+template <UTL_CONCEPT_CXX20(move_constructible) T, UTL_CONCEPT_CXX20(assignable_to<T&>) U = T>
+constexpr UTL_ENABLE_IF_CXX11(T, UTL_TRAIT_is_move_constructible(T) && UTL_TRAIT_is_assignable(T&, U)) exchange(T& obj, U&& new_value) noexcept(
+    UTL_TRAIT_is_nothrow_move_constructible(T) && UTL_TRAIT_is_nothrow_assignable(T&, U)) {
+    T previous(UTL_SCOPE move(obj));
+    obj = UTL_SCOPE forward<U>(new_value);
     return previous;
 }
 

--- a/src/utl/public/utl/utility/utl_exchange.h
+++ b/src/utl/public/utl/utility/utl_exchange.h
@@ -34,15 +34,25 @@ UTL_PRAGMA_WARN(
 
 UTL_NAMESPACE_BEGIN
 
+#  if UTL_COMPILER_CLANG_AT_LEAST(18, 0, 0)
+template <UTL_CONCEPT_CXX20(move_constructible) T, UTL_CONCEPT_CXX20(assignable_to<T&>) U = T>
+constexpr UTL_ENABLE_IF_CXX11(T, UTL_TRAIT_is_move_constructible(T) && UTL_TRAIT_is_assignable(T&, U)) exchange(T& obj, U&& new_value) noexcept(
+    UTL_TRAIT_is_nothrow_move_constructible(T) && UTL_TRAIT_is_nothrow_assignable(T&, U)) {
+    T previous(UTL_SCOPE move(obj));
+    obj = UTL_SCOPE forward<U>(new_value);
+    return previous;
+}
+#  else
 template <UTL_CONCEPT_CXX20(move_constructible) T, UTL_CONCEPT_CXX20(assignable_to<T&>) U = T>
 constexpr UTL_ENABLE_IF_CXX11(
-    T, UTL_TRAIT_is_move_constructible(T) && utl::is_assignable<T&, U>::value)
+    T, UTL_TRAIT_is_move_constructible(T) && UTL_SCOPE is_assignable<T&, U>::value)
     exchange(T& obj, U&& new_value) noexcept(
         UTL_TRAIT_is_nothrow_move_constructible(T) && UTL_TRAIT_is_nothrow_assignable(T&, U)) {
     T previous(UTL_SCOPE move(obj));
     obj = UTL_SCOPE forward<U>(new_value);
     return previous;
 }
+#  endif
 
 UTL_NAMESPACE_END
 

--- a/src/utl/public/utl/utility/utl_swap.h
+++ b/src/utl/public/utl/utility/utl_swap.h
@@ -4,180 +4,43 @@
 
 #include "utl/preprocessor/utl_config.h"
 
-#if UTL_CXX20 && UTL_USE_STD_swap
+#if UTL_USE_STD_swap
 
-#  include <type_traits>
 #  include <utility>
 
 UTL_NAMESPACE_BEGIN
 
-using std::is_nothrow_swappable;
-using std::is_swappable;
 using std::swap;
 
 UTL_NAMESPACE_END
 
-#else // UTL_CXX20 && UTL_USE_STD_swap
+#else // UTL_USE_STD_swap
 
-#  if UTL_USE_STD_swap
-UTL_PRAGMA_WARN("C++ < 20 does not implement a constexpr swap, `UTL_USE_STD_swap` ignored")
-#    undef UTL_USE_STD_swap
-#  endif // UTL_USE_STD_swap
+#  include "utl/ranges/utl_swap.h"
 
-#  include "utl/type_traits/utl_declval.h"
-#  include "utl/type_traits/utl_enable_if.h"
-#  include "utl/type_traits/utl_is_copy_assignable.h"
-#  include "utl/type_traits/utl_is_copy_constructible.h"
-#  include "utl/type_traits/utl_is_empty.h"
-#  include "utl/type_traits/utl_is_move_assignable.h"
-#  include "utl/type_traits/utl_is_move_constructible.h"
-#  include "utl/type_traits/utl_is_nothrow_copy_assignable.h"
-#  include "utl/type_traits/utl_is_nothrow_copy_constructible.h"
-#  include "utl/type_traits/utl_is_nothrow_move_assignable.h"
-#  include "utl/type_traits/utl_is_nothrow_move_constructible.h"
-#  include "utl/type_traits/utl_logical_traits.h"
-#  include "utl/type_traits/utl_void_t.h"
+#  if UTL_CXX20
 
 UTL_NAMESPACE_BEGIN
 
-namespace utility {
-namespace details {
 template <typename T>
-using noop_swap = is_empty<T>;
-template <typename T>
-using can_swap_by_move = conjunction<is_move_constructible<T>, is_move_assignable<T>>;
-template <typename T>
-using can_swap_by_copy = conjunction<is_copy_constructible<T>, is_copy_assignable<T>>;
-
-template <typename T>
-using noop_swap_t = enable_if_t<noop_swap<T>::value>;
-template <typename T>
-using only_swap_by_move_t = enable_if_t<!noop_swap<T>::value && can_swap_by_move<T>::value>;
-template <typename T>
-using only_swap_by_copy_t =
-    enable_if_t<!noop_swap<T>::value && !can_swap_by_move<T>::value && can_swap_by_copy<T>::value>;
-} // namespace details
-} // namespace utility
-
-/**
- * No reason to swap an empty class
- * Overload if such a swap is needed
- */
-template <typename T>
-inline UTL_CONSTEXPR_CXX14 utility::details::noop_swap_t<T> swap(T& a, T& b) noexcept {}
-
-template <typename T>
-inline UTL_CONSTEXPR_CXX14 utility::details::only_swap_by_move_t<T> swap(T& a, T& b) noexcept(
-    conjunction<is_nothrow_move_constructible<T>, is_nothrow_move_assignable<T>>::value) {
-
-    T tmp(move(a));
-    a = move(b);
-    b = move(tmp);
+requires requires(T& l, T& r) { ranges::swap(l, r); }
+inline constexpr void swap(T& l, T& r) noexcept(noexcept(ranges::swap(l, r))) {
+    ranges::swap(l, r);
 }
-
-template <typename T>
-inline UTL_CONSTEXPR_CXX14 utility::details::only_swap_by_copy_t<T> swap(T& a, T& b) noexcept(
-    conjunction<is_nothrow_copy_constructible<T>, is_nothrow_copy_assignable<T>>::value) {
-
-    T tmp(a);
-    a = b;
-    b = tmp;
-}
-
-template <typename T, size_t N>
-inline UTL_CONSTEXPR_CXX14 auto swap(T (&a)[N], T (&b)[N]) noexcept(noexcept(swap(*a, *b)))
-    -> void_t<decltype(swap(*a, *b))> {
-    for (T *i = a, *j = b, *end = a + N - 1;;) {
-        swap(*i, *j);
-        if (++i == end)
-            return;
-        ++j;
-    }
-}
-
-namespace utility {
-namespace details {
-using UTL_SCOPE swap;
-struct swap_cpo_t {
-    template <typename T, typename U UTL_REQUIRES_CXX11(
-            decltype(swap(declval<T&>(), declval<U&>()), true_type{})::value)>
-    UTL_REQUIRES_CXX20(requires { swap(declval<T&>(), declval<U&>()); })
-    UTL_ATTRIBUTES(FLATTEN) inline UTL_CONSTEXPR_CXX14 void operator()(T& l, U& r) const
-        noexcept(noexcept(swap(declval<T&>(), declval<U&>()))) {
-        swap(l, r);
-    }
-};
-} // namespace details
-
-UTL_INLINE_CXX17 constexpr details::swap_cpo_t swap = {};
-} // namespace utility
-
-namespace utility {
-namespace details {
-
-template <typename T, typename U,
-    typename R = decltype(utility::swap(declval<T>(), declval<U>()),
-        utility::swap(declval<U>(), declval<T>()), true_type{})>
-auto swap_test(int) -> R;
-template <typename, typename>
-auto swap_test(float) -> false_type;
-
-template <typename T, typename U,
-    bool R = noexcept(swap(declval<T>(), declval<U>())) && noexcept(
-        swap(declval<U>(), declval<T>()))>
-auto nothrow_swap_test(int) -> bool_constant<R>;
-template <typename, typename>
-auto nothrow_swap_test(float) -> false_type;
-
-template <typename T, typename U>
-using swap_result = decltype(swap_test<T, U>(0));
-template <typename T, typename U>
-using nothrow_swap_result = decltype(nothrow_swap_test<T, U>(0));
-
-} // namespace details
-} // namespace utility
-
-template <typename T, typename U>
-struct is_swappable_with : utility::details::swap_result<T, U> {};
-template <typename T, typename U>
-struct is_nothrow_swappable_with : utility::details::nothrow_swap_result<T, U> {};
-
-template <typename T>
-struct is_swappable : is_swappable_with<T&, T&> {};
-template <typename T>
-struct is_nothrow_swappable : is_nothrow_swappable_with<T&, T&> {};
-
-#  define UTL_TRAIT_SUPPORTED_is_swappable 1
-#  define UTL_TRAIT_SUPPORTED_is_swappable_with 1
-#  define UTL_TRAIT_SUPPORTED_is_nothrow_swappable 1
-#  define UTL_TRAIT_SUPPORTED_is_nothrow_swappable_with 1
 
 UTL_NAMESPACE_END
 
-#  if UTL_CXX14
-
-UTL_NAMESPACE_BEGIN
-template <typename T, typename U>
-UTL_INLINE_CXX17 constexpr bool is_swappable_with_v = is_swappable_with<T, U>::value;
-template <typename T, typename U>
-UTL_INLINE_CXX17 constexpr bool is_nothrow_swappable_with_v = is_nothrow_swappable_with<T, T>::value;
-template <typename T>
-UTL_INLINE_CXX17 constexpr bool is_swappable_v = is_swappable_with_v<T&, T&>;
-template <typename T>
-UTL_INLINE_CXX17 constexpr bool is_nothrow_swappable_v = is_nothrow_swappable_with_v<T&, T&>;
-UTL_NAMESPACE_END
-
-#    define UTL_TRAIT_is_swappable(...) UTL_SCOPE is_swappable_v<__VA_ARGS__>
-#    define UTL_TRAIT_is_swappable_with(...) UTL_SCOPE is_swappable_with_v<__VA_ARGS__>
-#    define UTL_TRAIT_is_nothrow_swappable(...) UTL_SCOPE is_nothrow_swappable_v<__VA_ARGS__>
-#    define UTL_TRAIT_is_nothrow_swappable_with(...) \
-        UTL_SCOPE is_nothrow_swappable_with_v<__VA_ARGS__>
 #  else
-#    define UTL_TRAIT_is_swappable(...) UTL_SCOPE is_swappable<__VA_ARGS__>::value
-#    define UTL_TRAIT_is_swappable_with(...) UTL_SCOPE is_swappable_with<__VA_ARGS__>::value
-#    define UTL_TRAIT_is_nothrow_swappable(...) UTL_SCOPE is_nothrow_swappable<__VA_ARGS__>::value
-#    define UTL_TRAIT_is_nothrow_swappable_with(...) \
-        UTL_SCOPE is_nothrow_swappable_with<__VA_ARGS__>::value
-#  endif
 
+UTL_NAMESPACE_BEGIN
+
+template <typename T>
+inline constexpr auto swap(T& l, T& r) noexcept(noexcept(ranges::swap(l, r)))
+    -> decltype(ranges::swap(l, r)) {
+    ranges::swap(l, r);
+}
+
+UTL_NAMESPACE_END
+
+#  endif
 #endif // UTL_CXX20 && UTL_USE_STD_swap


### PR DESCRIPTION
* Implement `ranges::swap`
* Rewrite `std::swap` to use `ranges::swap` internally to avoid duplication
* Replace all `utility::swap` to `ranges::swap`
* Rewrite `utl::swappable` concept to use `ranges::swap`
* Rewrite `utl::is_swappable` trait to use `ranges::swap`
* Add a temporary conditional compilation for `utl::exchange`, llvm version < 18 has a bug where intrinsic metafunctions cannot be used in `enable_if` directly due to name mangling failure see [details](https://github.com/llvm/llvm-project/issues/67031)
* Add TODO: Map APPLE Clang's version to LLVM version
* Add tests for `swap`


