### PR TITLE
Fix/constant p

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -91,7 +91,7 @@ IncludeCategories:
   - Regex:           '^<.*>'
     Priority:        40
 
-IfMacros: ['UTL_TRY']
+IfMacros: ['UTL_TRY','UTL_IF_CONSTEVAL']
 AttributeMacros: []
 StatementMacros: ['UTL_NAMESPACE_BEGIN', 'UTL_NAMESPACE_END']
 Macros:

--- a/src/utl/public/utl/preprocessor/utl_standard.h
+++ b/src/utl/public/utl/preprocessor/utl_standard.h
@@ -21,15 +21,15 @@
 #  define UTL_CXX11 1
 
 #  if UTL_CXX >= 201402L
-#    define UTL_CONSTEXPR_CXX14 constexpr
 #    define UTL_CXX14 1
+#    define UTL_CONSTEXPR_CXX14 constexpr
 #  else /* UTL_CXX >= 201402L */
 #    define UTL_CONSTEXPR_CXX14
 #  endif /* UTL_CXX >= 201402L */
 
 #  if UTL_CXX >= 201703L
-#    define UTL_CONSTEXPR_CXX17 constexpr
 #    define UTL_CXX17 1
+#    define UTL_CONSTEXPR_CXX17 constexpr
 #    define UTL_INLINE_CXX17 inline
 #  else /* UTL_CXX >= 201703L */
 #    define UTL_INLINE_CXX17
@@ -40,7 +40,6 @@
 #    define UTL_CXX20 1
 #    define UTL_CONSTEXPR_CXX20 constexpr
 #    define UTL_CONSTEVAL consteval
-#    define UTL_CONSTEVAL_CXX14 consteval
 #    define UTL_EXPLICIT_IF(...) explicit(__VA_ARGS__)
 #    define UTL_IMPLICIT_IF(...) explicit(!(__VA_ARGS__))
 
@@ -53,7 +52,6 @@
 
 #    define UTL_CONSTEXPR_CXX20
 #    define UTL_CONSTEVAL constexpr
-#    define UTL_CONSTEVAL_CXX14 UTL_CONSTEXPR_CXX14
 #    define UTL_EXPLICIT_IF(...)
 #    define UTL_IMPLICIT_IF(...) explicit
 #    define UTL_ENABLE_IF_CXX11(TYPE, ...) UTL_SCOPE enable_if_t<(__VA_ARGS__), TYPE>
@@ -65,11 +63,14 @@
 #  if UTL_CXX >= 202302L
 #    define UTL_CXX23 1
 #    define UTL_CONSTEXPR_CXX23 constexpr
+#    define UTL_CONSTEVAL_CXX23 consteval
 #    define UTL_IF_CONSTEVAL(...) if consteval
 #  else /* UTL_CXX >= 202302L */
 #    define UTL_CONSTEXPR_CXX23
-/* This requires including 'utl_constant_p.h' */
-#    define UTL_IF_CONSTEVAL(...) if (UTL_CONSTANT_P(__VA_ARGS__))
+#    define UTL_CONSTEVAL_CXX23 constexpr
+#    define UTL_IF_CONSTEVAL(...) \
+        if (UTL_CONSTANT_P(__VA_ARGS__)) /* This requires including 'utl_constant_p.h' */
+
 #  endif /* UTL_CXX >= 202302L */
 
 #else /* ifdef UTL_CXX */
@@ -81,6 +82,5 @@
 #  define UTL_CONSTEXPR_CXX20 const
 #  define UTL_CONSTEXPR_CXX23 const
 #  define UTL_CONSTEVAL
-#  define UTL_CONSTEVAL_CXX14
 
 #endif /* ifdef UTL_CXX */

--- a/src/utl/public/utl/preprocessor/utl_standard.h
+++ b/src/utl/public/utl/preprocessor/utl_standard.h
@@ -65,8 +65,11 @@
 #  if UTL_CXX >= 202302L
 #    define UTL_CXX23 1
 #    define UTL_CONSTEXPR_CXX23 constexpr
+#    define UTL_IF_CONSTEVAL(...) if consteval
 #  else /* UTL_CXX >= 202302L */
 #    define UTL_CONSTEXPR_CXX23
+/* This requires including 'utl_constant_p.h' */
+#    define UTL_IF_CONSTEVAL(...) if (UTL_CONSTANT_P(__VA_ARGS__))
 #  endif /* UTL_CXX >= 202302L */
 
 #else /* ifdef UTL_CXX */

--- a/src/utl/public/utl/string/utl_libc.h
+++ b/src/utl/public/utl/string/utl_libc.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "utl/preprocessor/utl_config.h"
+
 #include "utl/string/utl_libc_compile_time.h"
 #include "utl/string/utl_libc_runtime.h"
 #include "utl/utility/utl_constant_p.h"
@@ -13,6 +14,42 @@ UTL_NAMESPACE_BEGIN
 namespace libc {
 
 namespace unsafe {
+/* consteval needs to be evaluated in a consteval scope */
+#if UTL_CXX20
+template <typename T>
+constexpr T* memcpy(
+    T* UTL_RESTRICT dst, T const* UTL_RESTRICT src, element_count_t count) noexcept {
+    UTL_IF_CONSTEVAL(*dst == *src && src + count != dst) {
+        return compile_time::memcpy(dst, src, count);
+    }
+    return runtime::memcpy(dst, src, count);
+}
+
+template <typename T>
+constexpr T* memmove(T* dst, T const* src, element_count_t count) noexcept {
+    UTL_IF_CONSTEVAL(*dst == *src && src + count != dst) {
+        return compile_time::memmove(dst, src, count);
+    }
+    return runtime::memmove(dst, src, count);
+}
+
+template <typename T>
+constexpr T* memset(T* dst, T const src, element_count_t count) noexcept {
+    UTL_IF_CONSTEVAL(*dst == *src && src + count != dst) {
+        return compile_time::memset(dst, src, count);
+    }
+    return runtime::memset(dst, src, count);
+}
+
+template <typename T, typename U>
+UTL_LIBC_PURE constexpr int memcmp(T const* lhs, U const* rhs, element_count_t count) noexcept {
+    UTL_IF_CONSTEVAL(*dst == *src && src + count != dst) {
+        return compile_time::memcmp(lhs, rhs, count);
+    }
+    return runtime::memcmp(lhs, rhs, count);
+}
+
+#else
 template <typename T>
 constexpr T* memcpy(
     T* UTL_RESTRICT dst, T const* UTL_RESTRICT src, element_count_t count) noexcept {
@@ -37,6 +74,7 @@ constexpr T* memset(T* dst, T const src, element_count_t count) noexcept {
     return UTL_CONSTANT_P(src != *(dst + count - 1)) ? compile_time::memset(dst, src, count)
                                                      : runtime::memset(dst, src, count);
 }
+#endif
 } // namespace unsafe
 
 template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_REQUIRES_CXX11(
@@ -50,13 +88,6 @@ template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_REQUIRES_CXX11(
     is_trivially_copyable<T>::value)>
 constexpr T* memmove(T* dst, T const* src, element_count_t count) noexcept {
     return unsafe::memmove(dst, src, count);
-}
-
-template <UTL_CONCEPT_CXX20(exact_size<1>) T, UTL_CONCEPT_CXX20(exact_size<1>) U UTL_REQUIRES_CXX11(
-    exact_size<T, 1>::value && exact_size<U, 1>::value)>
-UTL_LIBC_PURE constexpr T* memchr(T const* str, U value, size_t bytes) noexcept {
-    return UTL_CONSTANT_P((value, str + bytes)) ? compile_time::memchr(str, value, bytes)
-                                                : runtime::memchr(str, value, bytes);
 }
 
 template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_REQUIRES_CXX11(
@@ -73,26 +104,95 @@ UTL_LIBC_PURE constexpr int memcmp(T const* lhs, U const* rhs, element_count_t c
     return unsafe::memcmp(lhs, rhs, count);
 }
 
+#if UTL_CXX20
+
+template <UTL_CONCEPT_CXX20(exact_size<1>) T, UTL_CONCEPT_CXX20(exact_size<1>) U
+    UTL_REQUIRES_CXX11( exact_size<T, 1>::value && exact_size<U, 1>::value)>
+UTL_LIBC_PURE constexpr T* memchr(T const* str, U value, size_t bytes) noexcept {
+    UTL_IF_CONSTEVAL(str + (*str != value) + bytes) {
+        return compile_time::memchr(str, value, bytes);
+    }
+    return runtime::memchr(str, value, bytes);
+}
+
 template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
 UTL_LIBC_PURE constexpr size_t strlen(T const* str) noexcept {
-    return UTL_CONSTANT_P(str) ? compile_time::strlen(str) : runtime::strlen(str);
+    UTL_IF_CONSTEVAL(str && *str > 0) {
+        return compile_time::strlen(str);
+    }
+    return runtime::strlen(str);
 }
 
 template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
 UTL_LIBC_PURE constexpr T* strchr(T const* str, T const ch) noexcept {
-    return UTL_CONSTANT_P((ch, str)) ? compile_time::strchr(str, ch) : runtime::strchr(str, ch);
+    UTL_IF_CONSTEVAL(*str != ch) {
+        return compile_time::strchr(str, ch);
+    }
+    return runtime::strchr(str, ch);
 }
 
 template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
 UTL_LIBC_PURE constexpr int strcmp(T const* left, T const* right) noexcept {
-    return UTL_CONSTANT_P(left != right) ? compile_time::strcmp(left, right)
-                                         : runtime::strcmp(left, right);
+    UTL_IF_CONSTEVAL(*left != *right && left != right) {
+        return compile_time::strcmp(left, right);
+    }
+    return runtime::strcmp(left, right);
 }
 
 template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
 UTL_LIBC_PURE constexpr int strncmp(
     T const* left, T const* right, element_count_t max_len) noexcept {
-    return UTL_CONSTANT_P(left + max_len != right + max_len)
+    UTL_IF_CONSTEVAL(*left != *right && left + max_len != right + max_len) {
+        return compile_time::strncmp(left, right, max_len);
+    }
+    return runtime::strncmp(left, right, max_len);
+}
+
+template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+UTL_LIBC_PURE constexpr T* strnset(T* dst, T const val, element_count_t max_len) noexcept {
+    UTL_IF_CONSTEVAL(dst + max_len + (*dst != val)) {
+        return compile_time::strnset(dst, val, max_len);
+    }
+    return runtime::strnset(dst, val, max_len);
+}
+
+template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+UTL_LIBC_PURE constexpr T* strnchr(T const* str, T const ch, element_count_t max_len) noexcept {
+    UTL_IF_CONSTEVAL(str + max_len + (*str == ch)) {
+        return compile_time::strnchr(str, ch, max_len);
+    }
+    return runtime::strnchr(str, ch, max_len);
+}
+
+#else
+
+template <UTL_CONCEPT_CXX20(exact_size<1>) T, UTL_CONCEPT_CXX20(exact_size<1>) U UTL_REQUIRES_CXX11(
+    exact_size<T, 1>::value && exact_size<U, 1>::value)>
+UTL_LIBC_PURE constexpr T* memchr(T const* str, U value, size_t bytes) noexcept {
+    return UTL_CONSTANT_P((value, str + bytes)) ? compile_time::memchr(str, value, bytes)
+                                                : runtime::memchr(str, value, bytes);
+}
+
+template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+UTL_LIBC_PURE constexpr size_t strlen(T const* str) noexcept {
+    return UTL_CONSTANT_P(str && *str > 0) ? compile_time::strlen(str) : runtime::strlen(str);
+}
+
+template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+UTL_LIBC_PURE constexpr T* strchr(T const* str, T const ch) noexcept {
+    return UTL_CONSTANT_P(*str != ch) ? compile_time::strchr(str, ch) : runtime::strchr(str, ch);
+}
+
+template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+UTL_LIBC_PURE constexpr int strcmp(T const* left, T const* right) noexcept {
+    return UTL_CONSTANT_P(*left != *right && left != right) ? compile_time::strcmp(left, right)
+                                                            : runtime::strcmp(left, right);
+}
+
+template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+UTL_LIBC_PURE constexpr int strncmp(
+    T const* left, T const* right, element_count_t max_len) noexcept {
+    return UTL_CONSTANT_P(*left != *right && left + max_len != right + max_len)
         ? compile_time::strncmp(left, right, max_len)
         : runtime::strncmp(left, right, max_len);
 }
@@ -108,6 +208,8 @@ UTL_LIBC_PURE constexpr T* strnchr(T const* str, T const ch, element_count_t max
     return UTL_CONSTANT_P((str + max_len, ch)) ? compile_time::strnchr(str, ch, max_len)
                                                : runtime::strnchr(str, ch, max_len);
 }
+
+#endif
 } // namespace libc
 
 #undef UTL_LIBC_PURE

--- a/src/utl/public/utl/string/utl_libc_compile_time.h
+++ b/src/utl/public/utl/string/utl_libc_compile_time.h
@@ -13,29 +13,29 @@ namespace compile_time {
 namespace recursive {
 
 template <typename T>
-UTL_CONSTEVAL T* memcpy(T* dst, T const* src, element_count_t count, T* org) noexcept {
+constexpr T* memcpy(T* dst, T const* src, element_count_t count, T* org) noexcept {
     return count == 0 ? org : ((*dst = *src), memcpy(dst + 1, src + 1, count - 1, org));
 }
 
 template <typename T>
-UTL_CONSTEVAL T* reverse_memcpy(T* dst, T const* src, element_count_t count, T* org) noexcept {
+constexpr T* reverse_memcpy(T* dst, T const* src, element_count_t count, T* org) noexcept {
     return count == 0 ? org : ((*--dst = *--src), memcpy(dst, src, count - 1, org));
 }
 
 template <typename T>
-UTL_CONSTEVAL T* memset(T* dst, T const src, element_count_t count, T* org) noexcept {
+constexpr T* memset(T* dst, T const src, element_count_t count, T* org) noexcept {
     return count == 0 ? org : ((*dst = src), memset(dst + 1, src, count - 1, org));
 }
 
 template <typename T>
-UTL_CONSTEVAL T* memmove(T* dst, T const* src, element_count_t count) noexcept {
+constexpr T* memmove(T* dst, T const* src, element_count_t count) noexcept {
     return is_pointer_in_range(src, src + count, dst)
         ? reverse_memcpy(dst + count, src + count, count, dst)
         : memcpy(dst, src, count, dst);
 }
 
 template <typename T, typename U>
-UTL_CONSTEVAL int memcmp(T const* left, U const* right, element_count_t count) noexcept {
+constexpr int memcmp(T const* left, U const* right, element_count_t count) noexcept {
     static_assert(is_trivially_lexicographically_comparable<T, U>::value,
         "Types must be lexicographically comparable");
     return count == 0      ? 0
@@ -46,24 +46,24 @@ UTL_CONSTEVAL int memcmp(T const* left, U const* right, element_count_t count) n
 
 template <UTL_CONCEPT_CXX20(exact_size<1>) T, UTL_CONCEPT_CXX20(exact_size<1>) U UTL_REQUIRES_CXX11(
     exact_size<T, 1>::value && exact_size<U, 1>::value)>
-UTL_CONSTEVAL T* memchr(T const* str, U value, size_t bytes) noexcept {
+constexpr T* memchr(T const* str, U value, size_t bytes) noexcept {
     return bytes == 0   ? nullptr
         : *str == value ? const_cast<T*>(str)
                         : memchr(str + 1, value, bytes - 1);
 }
 
 template <typename T>
-UTL_CONSTEVAL size_t strlen(T const* str, size_t r = 0) noexcept {
+constexpr size_t strlen(T const* str, size_t r = 0) noexcept {
     return !*str ? r : strlen(str, r + 1);
 }
 
 template <typename T>
-UTL_CONSTEVAL T* strchr(T const* str, T const ch) noexcept {
+constexpr T* strchr(T const* str, T const ch) noexcept {
     return *str == ch ? const_cast<T*>(str) : !*str ? nullptr : strchr(str + 1, ch);
 }
 
 template <typename T>
-UTL_CONSTEVAL int strcmp(T const* left, T const* right) noexcept {
+constexpr int strcmp(T const* left, T const* right) noexcept {
     return !*left && !*right ? 0
         : (*left < *right)   ? -1
         : (*right < *left)   ? 1
@@ -71,7 +71,7 @@ UTL_CONSTEVAL int strcmp(T const* left, T const* right) noexcept {
 }
 
 template <typename T>
-UTL_CONSTEVAL int strncmp(T const* left, T const* right, element_count_t len) noexcept {
+constexpr int strncmp(T const* left, T const* right, element_count_t len) noexcept {
     return len == 0 || (!*left && !*right) ? 0
         : (*left < *right)                 ? -1
         : (*right < *left)                 ? 1
@@ -79,7 +79,7 @@ UTL_CONSTEVAL int strncmp(T const* left, T const* right, element_count_t len) no
 }
 
 template <typename T>
-UTL_CONSTEVAL T* strnchr(T const* str, T const ch, element_count_t len) noexcept {
+constexpr T* strnchr(T const* str, T const ch, element_count_t len) noexcept {
     return len == 0    ? nullptr
         : (*str == ch) ? const_cast<T*>(str)
         : (!*str)      ? nullptr
@@ -87,7 +87,7 @@ UTL_CONSTEVAL T* strnchr(T const* str, T const ch, element_count_t len) noexcept
 }
 
 template <typename T>
-UTL_CONSTEVAL T* strnset(T* dst, T const val, element_count_t count, T* org) noexcept {
+constexpr T* strnset(T* dst, T const val, element_count_t count, T* org) noexcept {
     return count == 0 ? org : ((*dst = val), strnset(dst + 1, val, count - 1, org));
 }
 
@@ -157,7 +157,7 @@ constexpr size_t strlen(char const* str) noexcept {
 #endif
 }
 
-UTL_CONSTEVAL size_t strlen(wchar_t const* str) noexcept {
+constexpr size_t strlen(wchar_t const* str) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_wcslen)
     return __builtin_wcslen(str);
 #else
@@ -166,11 +166,11 @@ UTL_CONSTEVAL size_t strlen(wchar_t const* str) noexcept {
 }
 
 template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
-UTL_CONSTEVAL size_t strlen(T const* str) noexcept {
+constexpr size_t strlen(T const* str) noexcept {
     return recursive::strlen(str);
 }
 
-UTL_CONSTEVAL char* strchr(char const* str, char const ch) noexcept {
+constexpr char* strchr(char const* str, char const ch) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_strchr)
     return __builtin_strchr(str, (int)ch);
 #else
@@ -178,7 +178,7 @@ UTL_CONSTEVAL char* strchr(char const* str, char const ch) noexcept {
 #endif
 }
 
-UTL_CONSTEVAL wchar_t* strchr(wchar_t const* str, wchar_t const ch) noexcept {
+constexpr wchar_t* strchr(wchar_t const* str, wchar_t const ch) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_wcschr)
     return __builtin_wcschr(str, ch);
 #else
@@ -187,11 +187,11 @@ UTL_CONSTEVAL wchar_t* strchr(wchar_t const* str, wchar_t const ch) noexcept {
 }
 
 template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
-UTL_CONSTEVAL T* strchr(T const* str, T const ch) noexcept {
+constexpr T* strchr(T const* str, T const ch) noexcept {
     return recursive::strchr(str, ch);
 }
 
-UTL_CONSTEVAL int strcmp(char const* left, char const* right) noexcept {
+constexpr int strcmp(char const* left, char const* right) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_strcmp)
     return __builtin_strcmp(left, right);
 #else
@@ -199,7 +199,7 @@ UTL_CONSTEVAL int strcmp(char const* left, char const* right) noexcept {
 #endif
 }
 
-UTL_CONSTEVAL int strcmp(wchar_t const* left, wchar_t const* right) noexcept {
+constexpr int strcmp(wchar_t const* left, wchar_t const* right) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_wcscmp)
     return __builtin_wcscmp(left, right);
 #else
@@ -208,11 +208,11 @@ UTL_CONSTEVAL int strcmp(wchar_t const* left, wchar_t const* right) noexcept {
 }
 
 template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
-UTL_CONSTEVAL int strcmp(T const* left, T const* right) noexcept {
+constexpr int strcmp(T const* left, T const* right) noexcept {
     return recursive::strcmp(left, right);
 }
 
-UTL_CONSTEVAL int strncmp(char const* left, char const* right, element_count_t len) noexcept {
+constexpr int strncmp(char const* left, char const* right, element_count_t len) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_strncmp)
     return __builtin_strncmp(left, right, (size_t)len);
 #else
@@ -220,7 +220,7 @@ UTL_CONSTEVAL int strncmp(char const* left, char const* right, element_count_t l
 #endif
 }
 
-UTL_CONSTEVAL int strncmp(wchar_t const* left, wchar_t const* right, element_count_t len) noexcept {
+constexpr int strncmp(wchar_t const* left, wchar_t const* right, element_count_t len) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_wcsncmp)
     return __builtin_wcsncmp(left, right, (size_t)len);
 #else
@@ -229,17 +229,17 @@ UTL_CONSTEVAL int strncmp(wchar_t const* left, wchar_t const* right, element_cou
 }
 
 template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
-UTL_CONSTEVAL int strncmp(T const* left, T const* right, element_count_t len) noexcept {
+constexpr int strncmp(T const* left, T const* right, element_count_t len) noexcept {
     return recursive::strncmp(left, right, len);
 }
 
 template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
-UTL_CONSTEVAL T* strnset(T* dst, T const val, element_count_t max_len) noexcept {
+constexpr T* strnset(T* dst, T const val, element_count_t max_len) noexcept {
     return recursive::strnset(dst, val, max_len, dst);
 }
 
 template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
-UTL_CONSTEVAL T* strnchr(T const* str, T const val, element_count_t max_len) noexcept {
+constexpr T* strnchr(T const* str, T const val, element_count_t max_len) noexcept {
     return recursive::strnchr(str, val, max_len);
 }
 

--- a/src/utl/public/utl/string/utl_libc_compile_time.h
+++ b/src/utl/public/utl/string/utl_libc_compile_time.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "utl/preprocessor/utl_config.h"
+
 #include "utl/string/utl_libc_common.h"
 
 UTL_NAMESPACE_BEGIN
@@ -43,9 +44,8 @@ UTL_CONSTEVAL int memcmp(T const* left, U const* right, element_count_t count) n
                            : memcmp(left + 1, right + 1, count - 1);
 }
 
-template <UTL_CONCEPT_CXX20(exact_size<1>) T,
-    UTL_CONCEPT_CXX20(exact_size<1>)
-        U UTL_REQUIRES_CXX11(exact_size<T, 1>::value&& exact_size<U, 1>::value)>
+template <UTL_CONCEPT_CXX20(exact_size<1>) T, UTL_CONCEPT_CXX20(exact_size<1>) U UTL_REQUIRES_CXX11(
+    exact_size<T, 1>::value && exact_size<U, 1>::value)>
 UTL_CONSTEVAL T* memchr(T const* str, U value, size_t bytes) noexcept {
     return bytes == 0   ? nullptr
         : *str == value ? const_cast<T*>(str)
@@ -93,9 +93,9 @@ UTL_CONSTEVAL T* strnset(T* dst, T const val, element_count_t count, T* org) noe
 
 } // namespace recursive
 
-template <UTL_CONCEPT_CXX20(trivially_copyable)
-        T UTL_REQUIRES_CXX11(is_trivially_copyable<T>::value)>
-UTL_CONSTEVAL T* memcpy(T* dst, T const* src, element_count_t count) noexcept {
+template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_REQUIRES_CXX11(
+    is_trivially_copyable<T>::value)>
+constexpr T* memcpy(T* dst, T const* src, element_count_t count) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_memcpy)
     return __builtin_memcpy(dst, src, byte_count<T>(count)), dst;
 #else
@@ -103,10 +103,10 @@ UTL_CONSTEVAL T* memcpy(T* dst, T const* src, element_count_t count) noexcept {
 #endif
 }
 
-template <UTL_CONCEPT_CXX20(trivially_copyable)
-        T UTL_REQUIRES_CXX11(is_trivially_copyable<T>::value&& exact_size<T, 1>::value)>
+template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_REQUIRES_CXX11(
+    is_trivially_copyable<T>::value && exact_size<T, 1>::value)>
 UTL_REQUIRES_CXX20(exact_size<T, 1>)
-UTL_CONSTEVAL T* memset(T* dst, T const src, element_count_t count) noexcept {
+constexpr T* memset(T* dst, T const src, element_count_t count) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_memset)
     return __builtin_memset(dst, as_byte(src), byte_count<T>(count)), dst;
 #else
@@ -114,9 +114,9 @@ UTL_CONSTEVAL T* memset(T* dst, T const src, element_count_t count) noexcept {
 #endif
 }
 
-template <UTL_CONCEPT_CXX20(trivially_copyable)
-        T UTL_REQUIRES_CXX11(is_trivially_copyable<T>::value)>
-UTL_CONSTEVAL T* memmove(T* dst, T const* src, element_count_t count) noexcept {
+template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_REQUIRES_CXX11(
+    is_trivially_copyable<T>::value)>
+constexpr T* memmove(T* dst, T const* src, element_count_t count) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_memmove)
     return __builtin_memmove(dst, src, byte_count<T>(count)), dst;
 #else
@@ -125,7 +125,7 @@ UTL_CONSTEVAL T* memmove(T* dst, T const* src, element_count_t count) noexcept {
 }
 
 template <typename T, typename U>
-UTL_CONSTEVAL int memcmp(T const* left, U const* right, element_count_t count) noexcept {
+constexpr int memcmp(T const* left, U const* right, element_count_t count) noexcept {
     static_assert(is_trivially_lexicographically_comparable<T, U>::value,
         "Types must be lexicographically comparable");
 #if UTL_HAS_BUILTIN(__builtin_char_memcmp)
@@ -135,7 +135,7 @@ UTL_CONSTEVAL int memcmp(T const* left, U const* right, element_count_t count) n
 #endif
 }
 
-UTL_CONSTEVAL char* memchr(char const* str, char value, size_t bytes) noexcept {
+constexpr char* memchr(char const* str, char value, size_t bytes) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_char_memchr)
     return __builtin_char_memchr(str, (int)value, bytes);
 #else
@@ -143,14 +143,13 @@ UTL_CONSTEVAL char* memchr(char const* str, char value, size_t bytes) noexcept {
 #endif
 }
 
-template <UTL_CONCEPT_CXX20(exact_size<1>) T,
-    UTL_CONCEPT_CXX20(exact_size<1>)
-        U UTL_REQUIRES_CXX11(exact_size<T, 1>::value&& exact_size<U, 1>::value)>
-UTL_CONSTEVAL T* memchr(T const* str, U value, size_t bytes) noexcept {
+template <UTL_CONCEPT_CXX20(exact_size<1>) T, UTL_CONCEPT_CXX20(exact_size<1>) U UTL_REQUIRES_CXX11(
+    exact_size<T, 1>::value && exact_size<U, 1>::value)>
+constexpr T* memchr(T const* str, U value, size_t bytes) noexcept {
     return recursive::memchr(str, as_byte(value), bytes);
 }
 
-UTL_CONSTEVAL size_t strlen(char const* str) noexcept {
+constexpr size_t strlen(char const* str) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_strlen)
     return __builtin_strlen(str);
 #else


### PR DESCRIPTION
There is a restriction for `consteval` functions that renders it useless in `is_constant_evaluated` branches, it may be possible to use `if consteval` in C++23 but there seems to be a compiler bug on GCC that fails to compile it even with `if consteval`. For now, it is just easier to set all functions to constexpr.