### PR TITLE
Fix trait macros

### DIFF
--- a/NOTES
+++ b/NOTES
@@ -1,7 +1,5 @@
 * Supporting modules will probably be a massive PITA
 * TODO: Maybe move all the type_traits builtins to a single file?
-* TODO: Find stable impementation of type traits introduced in C++20 and remove support for buggy implementations
 * TODO: Maybe remove utl ordering and just use <compare>? the header is not particularly large
 # TODO: Fix for C++11 T.T
-# TODO: fix UTL_TRAIT_* for llvm < 18
 # TODO: define CONSTEXPR_ASSERT for C++11

--- a/src/utl/public/utl/bit/utl_bit_ceil.h
+++ b/src/utl/public/utl/bit/utl_bit_ceil.h
@@ -13,14 +13,13 @@ template <typename T>
 UTL_REQUIRES_CXX20(requires(T x) {
     { +x } -> same_as<T>;
 })
-UTL_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD) inline constexpr auto bit_ceil(T x) noexcept
-    -> UTL_ENABLE_IF_CXX11(T, __UTL is_same<T, decltype(+x)>::value) {
+UTL_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD) inline constexpr auto bit_ceil(T x) noexcept -> UTL_ENABLE_IF_CXX11(
+    T, UTL_TRAIT_is_same(T, decltype(+x))) {
     return T(1) << bit_width(T(x - 1));
 }
 
 template <typename T>
-UTL_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD) inline constexpr auto bit_ceil(T x) noexcept
-    -> UTL_ENABLE_IF_CXX11(T, !__UTL is_same<T, decltype(+x)>::value) {
+UTL_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD) inline constexpr auto bit_ceil(T x) noexcept -> UTL_ENABLE_IF_CXX11(T, !UTL_TRAIT_is_same(T, decltype(+x))) {
     return T(1u << (bit_width(T(x - 1)) + details::bit::unsigned_width_diff<T>()) >>
         details::bit::unsigned_width_diff<T>());
 }

--- a/src/utl/public/utl/iterator/utl_contiguous_iterator_base.h
+++ b/src/utl/public/utl/iterator/utl_contiguous_iterator_base.h
@@ -31,14 +31,12 @@ private:
 
     UTL_ATTRIBUTES(NODISCARD, PURE, _HIDE_FROM_ABI) static constexpr value_type* get_ptr(
         It const& it) noexcept {
-        static_assert(
-            __UTL is_base_of<contiguous_iterator_base, It>::value, "Invalid iterator type");
+        static_assert(UTL_TRAIT_is_base_of(contiguous_iterator_base, It), "Invalid iterator type");
         return ((contiguous_iterator_base const&)it).ptr_;
     }
 
     __UTL_HIDE_FROM_ABI static constexpr It& set_ptr(It& it, value_type* value) noexcept {
-        static_assert(
-            __UTL is_base_of<contiguous_iterator_base, It>::value, "Invalid iterator type");
+        static_assert(UTL_TRAIT_is_base_of(contiguous_iterator_base, It), "Invalid iterator type");
         return ((contiguous_iterator_base&)it).ptr_ = value, it;
     }
 

--- a/src/utl/public/utl/iterator/utl_iter_rvalue_reference_t.h
+++ b/src/utl/public/utl/iterator/utl_iter_rvalue_reference_t.h
@@ -41,7 +41,7 @@ namespace iter_rvalue_reference {
 
 template <UTL_CONCEPT_CXX20(dereferenceable) T UTL_REQUIRES_CXX11(UTL_TRAIT_is_dereferenceable(T))>
 __UTL_HIDE_FROM_ABI auto resolve(int) noexcept -> __UTL
-    enable_if_t<__UTL is_referenceable<decltype(ranges::iter_move(__UTL declval<T&>()))>::value,
+    enable_if_t<UTL_TRAIT_is_referenceable(decltype(ranges::iter_move(__UTL declval<T&>()))),
         decltype(ranges::iter_move(__UTL declval<T&>()))>;
 
 } // namespace iter_rvalue_reference

--- a/src/utl/public/utl/iterator/utl_iterator_concept_t.h
+++ b/src/utl/public/utl/iterator/utl_iterator_concept_t.h
@@ -19,11 +19,13 @@ namespace iterator_concept {
 
 template <typename T>
 struct trait_type {
-    using type UTL_NODEBUG = T;
-};
-template <__UTL details::iterator_traits::is_specialized T>
-struct trait_type<T> {
     using type UTL_NODEBUG = __UTL iterator_traits<T>;
+};
+
+template <typename T>
+requires (!__UTL details::iterator_traits::is_specialized<T>)
+struct trait_type<T> {
+    using type UTL_NODEBUG = T;
 };
 
 template <typename T>
@@ -33,9 +35,15 @@ template <typename T>
 struct tag_type {};
 
 template <typename T>
-concept with_iterator_concept = requires { typename trait_type_t<T>::iterator_concept; };
+concept with_iterator_concept = requires {
+    typename trait_type<T>::type;
+    typename trait_type_t<T>::iterator_concept;
+};
 template <typename T>
-concept with_iterator_category = requires { typename trait_type_t<T>::iterator_category; };
+concept with_iterator_category = requires {
+    typename trait_type<T>::type;
+    typename trait_type_t<T>::iterator_category;
+};
 
 template <with_iterator_concept T>
 struct tag_type<T> {
@@ -49,7 +57,7 @@ struct tag_type<T> {
 };
 
 template <typename T>
-requires (!with_iterator_category<T> && !with_iterator_concept<T> &&
+requires (!with_iterator_concept<T> && !with_iterator_category<T> &&
     !__UTL details::iterator_traits::is_specialized<T>)
 struct tag_type<T> {
     using type UTL_NODEBUG = __UTL random_access_iterator_tag;

--- a/src/utl/public/utl/iterator/utl_iterator_traits_fwd.h
+++ b/src/utl/public/utl/iterator/utl_iterator_traits_fwd.h
@@ -6,6 +6,8 @@
 
 #include "utl/type_traits/utl_constants.h"
 #include "utl/type_traits/utl_is_base_of.h"
+#include "utl/type_traits/utl_is_complete.h"
+#include "utl/type_traits/utl_logical_traits.h"
 
 UTL_NAMESPACE_BEGIN
 
@@ -20,12 +22,14 @@ struct impl_tag {};
 #if UTL_CXX20
 
 template <typename T>
-concept is_specialized = !UTL_TRAIT_is_base_of(impl_tag<T>, __UTL iterator_traits<T>);
+concept is_specialized = UTL_TRAIT_is_complete(__UTL iterator_traits<T>) &&
+    !UTL_TRAIT_is_base_of(impl_tag<T>, __UTL iterator_traits<T>);
 
 #else
 
-template <typename T>
-using is_specialized = bool_constant<!UTL_TRAIT_is_base_of(impl_tag<T>, __UTL iterator_traits<T>)>;
+template <typename T, typename R = decltype(__UTL details::complete_type::is_complete<T>(0))>
+using is_specialized =
+    __UTL conjunction<R, __UTL is_base_of<impl_tag<T>, __UTL iterator_traits<T>>>;
 
 #endif
 } // namespace iterator_traits

--- a/src/utl/public/utl/numeric/utl_saturation.h
+++ b/src/utl/public/utl/numeric/utl_saturation.h
@@ -36,8 +36,9 @@ template <typename T>
 __UTL_HIDE_FROM_ABI auto trait_impl(float) noexcept -> __UTL false_type;
 
 template <typename T>
-__UTL_HIDE_FROM_ABI auto trait_impl(int) noexcept -> __UTL bool_constant<UTL_TRAIT_is_integral(T) &&
-    !__UTL disjunction<__UTL is_string_char<T>, __UTL is_boolean<T>>::value>;
+__UTL_HIDE_FROM_ABI auto trait_impl(int) noexcept
+    -> __UTL bool_constant<__UTL is_integral<T>::value &&
+        !__UTL disjunction<__UTL is_string_char<T>, __UTL is_boolean<T>>::value>;
 
 template <typename T>
 using trait UTL_NODEBUG = decltype(__UTL details::saturation::trait_impl<T>(0));

--- a/src/utl/public/utl/numeric/utl_saturation.h
+++ b/src/utl/public/utl/numeric/utl_saturation.h
@@ -36,9 +36,8 @@ template <typename T>
 __UTL_HIDE_FROM_ABI auto trait_impl(float) noexcept -> __UTL false_type;
 
 template <typename T>
-__UTL_HIDE_FROM_ABI auto trait_impl(int) noexcept
-    -> __UTL bool_constant<__UTL is_integral<T>::value &&
-        !__UTL disjunction<__UTL is_string_char<T>, __UTL is_boolean<T>>::value>;
+__UTL_HIDE_FROM_ABI auto trait_impl(int) noexcept -> __UTL bool_constant<UTL_is_integral(T) &&
+    !UTL_TRAIT_disjunction(__UTL is_string_char<T>, __UTL is_boolean<T>)>;
 
 template <typename T>
 using trait UTL_NODEBUG = decltype(__UTL details::saturation::trait_impl<T>(0));

--- a/src/utl/public/utl/string/utl_basic_short_string.h
+++ b/src/utl/public/utl/string/utl_basic_short_string.h
@@ -15,6 +15,7 @@
 #include "utl/exception.h"
 #include "utl/iterator/utl_contiguous_iterator_base.h"
 #include "utl/iterator/utl_distance.h"
+#include "utl/iterator/utl_iterator_traits.h"
 #include "utl/iterator/utl_legacy_forward_iterator.h"
 #include "utl/iterator/utl_legacy_input_iterator.h"
 #include "utl/iterator/utl_reverse_iterator.h"

--- a/src/utl/public/utl/type_traits/utl_has_unique_object_representations.h
+++ b/src/utl/public/utl/type_traits/utl_has_unique_object_representations.h
@@ -47,3 +47,11 @@ UTL_NAMESPACE_END
 #  endif // ifdef UTL_BUILTIN_has_unique_object_representations
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
+
+#if UTL_CXX14
+#  define UTL_TRAIT_has_unique_object_representations(...) \
+      __UTL has_unique_object_representations_v<__VA_ARGS__>
+#else
+#  define UTL_TRAIT_has_unique_object_representations(...) \
+      __UTL has_unique_object_representations<__VA_ARGS__>::value
+#endif

--- a/src/utl/public/utl/type_traits/utl_has_virtual_destructor.h
+++ b/src/utl/public/utl/type_traits/utl_has_virtual_destructor.h
@@ -68,9 +68,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_has_virtual_destructor
-#  define UTL_TRAIT_has_virtual_destructor(...) UTL_BUILTIN_has_virtual_destructor(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_has_virtual_destructor(...) __UTL has_virtual_destructor_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_has_virtual_destructor(...) __UTL has_virtual_destructor<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_abstract.h
+++ b/src/utl/public/utl/type_traits/utl_is_abstract.h
@@ -67,9 +67,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_abstract
-#  define UTL_TRAIT_is_abstract(...) UTL_BUILTIN_is_abstract(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_abstract(...) __UTL is_abstract_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_abstract(...) __UTL is_abstract<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_aggregate.h
+++ b/src/utl/public/utl/type_traits/utl_is_aggregate.h
@@ -69,9 +69,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_aggregate
-#  define UTL_TRAIT_is_aggregate(...) UTL_BUILTIN_is_aggregate(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_aggregate(...) __UTL is_aggregate_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_aggregate(...) __UTL is_aggregate<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_array.h
+++ b/src/utl/public/utl/type_traits/utl_is_array.h
@@ -81,9 +81,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_array
-#  define UTL_TRAIT_is_array(...) UTL_BUILTIN_is_array(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_array(...) __UTL is_array_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_array(...) __UTL is_array<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_assignable.h
+++ b/src/utl/public/utl/type_traits/utl_is_assignable.h
@@ -86,9 +86,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_assignable
-#  define UTL_TRAIT_is_assignable(...) UTL_BUILTIN_is_assignable(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_assignable(...) __UTL is_assignable_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_assignable(...) __UTL is_assignable<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_base_of.h
+++ b/src/utl/public/utl/type_traits/utl_is_base_of.h
@@ -87,9 +87,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_base_of
-#  define UTL_TRAIT_is_base_of(...) UTL_BUILTIN_is_base_of(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_base_of(...) __UTL is_base_of_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_base_of(...) __UTL is_base_of<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_class.h
+++ b/src/utl/public/utl/type_traits/utl_is_class.h
@@ -67,9 +67,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_class
-#  define UTL_TRAIT_is_class(...) UTL_BUILTIN_is_class(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_class(...) __UTL is_class_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_class(...) __UTL is_class<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_complete.h
+++ b/src/utl/public/utl/type_traits/utl_is_complete.h
@@ -8,24 +8,23 @@
 
 UTL_NAMESPACE_BEGIN
 
-namespace type_traits {
 namespace details {
-using size_t = decltype(sizeof(0));
+namespace complete_type {
 
-template <typename T, size_t = sizeof(T)>
-__UTL_HIDE_FROM_ABI true_type is_complete(int);
+template <typename T, int = sizeof(T)>
+__UTL_HIDE_FROM_ABI __UTL true_type is_complete(int) noexcept;
 
 template <typename T>
-__UTL_HIDE_FROM_ABI false_type is_complete(float);
+__UTL_HIDE_FROM_ABI __UTL false_type is_complete(float) noexcept;
 
+} // namespace complete_type
 } // namespace details
-} // namespace type_traits
 
-template <typename T, typename R = decltype(type_traits::details::is_complete<T>(0))>
+template <typename T, typename R = decltype(details::complete_type::is_complete<T>(0))>
 struct __UTL_PUBLIC_TEMPLATE is_complete : R {};
 
 #if UTL_CXX14
-template <typename T, typename R = decltype(type_traits::details::is_complete<T>(0))>
+template <typename T, typename R = decltype(details::complete_type::is_complete<T>(0))>
 UTL_INLINE_CXX17 constexpr bool is_complete_v = R::value;
 #endif // UTL_CXX14
 

--- a/src/utl/public/utl/type_traits/utl_is_const.h
+++ b/src/utl/public/utl/type_traits/utl_is_const.h
@@ -73,9 +73,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_const
-#  define UTL_TRAIT_is_const(...) UTL_BUILTIN_is_const(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_const(...) __UTL is_const_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_const(...) __UTL is_const<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_constructible.h
+++ b/src/utl/public/utl/type_traits/utl_is_constructible.h
@@ -87,9 +87,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_constructible
-#  define UTL_TRAIT_is_constructible(...) UTL_BUILTIN_is_constructible(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_constructible(...) __UTL is_constructible_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_constructible(...) __UTL is_constructible<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_convertible.h
+++ b/src/utl/public/utl/type_traits/utl_is_convertible.h
@@ -88,9 +88,7 @@ UTL_NAMESPACE_END
 
 #define UTL_TRAIT_SUPPORTED_is_convertible 1
 
-#ifdef UTL_BUILTIN_is_convertible
-#  define UTL_TRAIT_is_convertible(...) UTL_BUILTIN_is_convertible(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_convertible(...) __UTL is_convertible_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_convertible(...) __UTL is_convertible<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_default_constructible.h
+++ b/src/utl/public/utl/type_traits/utl_is_default_constructible.h
@@ -68,9 +68,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_default_constructible
-#  define UTL_TRAIT_is_default_constructible(...) UTL_BUILTIN_is_default_constructible(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_default_constructible(...) __UTL is_default_constructible_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_default_constructible(...) __UTL is_default_constructible<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_destructible.h
+++ b/src/utl/public/utl/type_traits/utl_is_destructible.h
@@ -91,9 +91,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_destructible
-#  define UTL_TRAIT_is_destructible(...) UTL_BUILTIN_is_destructible(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_destructible(...) __UTL is_destructible_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_destructible(...) __UTL is_destructible<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_empty.h
+++ b/src/utl/public/utl/type_traits/utl_is_empty.h
@@ -78,9 +78,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_empty
-#  define UTL_TRAIT_is_empty(...) UTL_BUILTIN_is_empty(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_empty(...) __UTL is_empty_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_empty(...) __UTL is_empty<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_enum.h
+++ b/src/utl/public/utl/type_traits/utl_is_enum.h
@@ -67,9 +67,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_enum
-#  define UTL_TRAIT_is_enum(...) UTL_BUILTIN_is_enum(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_enum(...) __UTL is_enum_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_enum(...) __UTL is_enum<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_final.h
+++ b/src/utl/public/utl/type_traits/utl_is_final.h
@@ -69,9 +69,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_final
-#  define UTL_TRAIT_is_final(...) UTL_BUILTIN_is_final(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_final(...) __UTL is_final_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_final(...) __UTL is_final<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_floating_point.h
+++ b/src/utl/public/utl/type_traits/utl_is_floating_point.h
@@ -105,9 +105,7 @@ struct __UTL_PUBLIC_TEMPLATE is_floating_point<bfloat16> : true_type {};
 UTL_NAMESPACE_END
 #endif // if UTL_CXX23
 
-#ifdef UTL_BUILTIN_is_floating_point
-#  define UTL_TRAIT_is_floating_point(...) UTL_BUILTIN_is_floating_point(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_floating_point(...) __UTL is_floating_point_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_floating_point(...) __UTL is_floating_point<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_function.h
+++ b/src/utl/public/utl/type_traits/utl_is_function.h
@@ -71,9 +71,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_function
-#  define UTL_TRAIT_is_function(...) UTL_BUILTIN_is_function(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_function(...) __UTL is_function_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_function(...) __UTL is_function<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_fundamental.h
+++ b/src/utl/public/utl/type_traits/utl_is_fundamental.h
@@ -74,9 +74,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_fundamental
-#  define UTL_TRAIT_is_fundamental(...) UTL_BUILTIN_is_fundamental(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_fundamental(...) __UTL is_fundamental_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_fundamental(...) __UTL is_fundamental<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_implicit_lifetime.h
+++ b/src/utl/public/utl/type_traits/utl_is_implicit_lifetime.h
@@ -68,9 +68,7 @@ UTL_NAMESPACE_END
 
 #define UTL_TRAIT_SUPPORTED_is_implicit_lifetime 1
 
-#ifdef UTL_BUILTIN_is_implicit_lifetime
-#  define UTL_TRAIT_is_implicit_lifetime(...) UTL_BUILTIN_is_implicit_lifetime(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_implicit_lifetime(...) __UTL is_implicit_lifetime_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_implicit_lifetime(...) __UTL is_implicit_lifetime<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_integral.h
+++ b/src/utl/public/utl/type_traits/utl_is_integral.h
@@ -113,9 +113,7 @@ UTL_NAMESPACE_END
 
 #define UTL_TRAIT_SUPPORTED_is_integral 1
 
-#ifdef UTL_BUILTIN_is_integral
-#  define UTL_TRAIT_is_integral(...) UTL_BUILTIN_is_integral(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_integral(...) __UTL is_integral_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_integral(...) __UTL is_integral<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_layout_compatible.h
+++ b/src/utl/public/utl/type_traits/utl_is_layout_compatible.h
@@ -64,9 +64,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS && UTL_CXX20
 
-#ifdef UTL_BUILTIN_is_layout_compatible
-#  define UTL_TRAIT_is_layout_compatible(...) UTL_BUILTIN_is_layout_compatible(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_layout_compatible(...) __UTL is_layout_compatible_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_layout_compatible(...) __UTL is_layout_compatible<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_lvalue_reference.h
+++ b/src/utl/public/utl/type_traits/utl_is_lvalue_reference.h
@@ -71,9 +71,7 @@ UTL_NAMESPACE_END
 
 #define UTL_TRAIT_SUPPORTED_is_lvalue_reference 1
 
-#ifdef UTL_BUILTIN_is_lvalue_reference
-#  define UTL_TRAIT_is_lvalue_reference(...) UTL_BUILTIN_is_lvalue_reference(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_lvalue_reference(...) __UTL is_lvalue_reference_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_lvalue_reference(...) __UTL is_lvalue_reference<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_member_function_pointer.h
+++ b/src/utl/public/utl/type_traits/utl_is_member_function_pointer.h
@@ -75,10 +75,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_member_function_pointer
-#  define UTL_TRAIT_is_member_function_pointer(...) \
-      UTL_BUILTIN_is_member_function_pointer(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_member_function_pointer(...) __UTL is_member_function_pointer_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_member_function_pointer(...) \

--- a/src/utl/public/utl/type_traits/utl_is_member_object_pointer.h
+++ b/src/utl/public/utl/type_traits/utl_is_member_object_pointer.h
@@ -76,9 +76,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_member_object_pointer
-#  define UTL_TRAIT_is_member_object_pointer(...) UTL_BUILTIN_is_member_object_pointer(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_member_object_pointer(...) __UTL is_member_object_pointer_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_member_object_pointer(...) __UTL is_member_object_pointer<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_member_pointer.h
+++ b/src/utl/public/utl/type_traits/utl_is_member_pointer.h
@@ -72,9 +72,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_member_pointer
-#  define UTL_TRAIT_is_member_pointer(...) UTL_BUILTIN_is_member_pointer(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_member_pointer(...) __UTL is_member_pointer_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_member_pointer(...) __UTL is_member_pointer<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_nothrow_assignable.h
+++ b/src/utl/public/utl/type_traits/utl_is_nothrow_assignable.h
@@ -103,9 +103,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_nothrow_assignable
-#  define UTL_TRAIT_is_nothrow_assignable(...) UTL_BUILTIN_is_nothrow_assignable(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_nothrow_assignable(...) __UTL is_nothrow_assignable_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_nothrow_assignable(...) __UTL is_nothrow_assignable<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_nothrow_constructible.h
+++ b/src/utl/public/utl/type_traits/utl_is_nothrow_constructible.h
@@ -104,9 +104,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_nothrow_constructible
-#  define UTL_TRAIT_is_nothrow_constructible(...) UTL_BUILTIN_is_nothrow_constructible(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_nothrow_constructible(...) __UTL is_nothrow_constructible_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_nothrow_constructible(...) __UTL is_nothrow_constructible<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_nothrow_convertible.h
+++ b/src/utl/public/utl/type_traits/utl_is_nothrow_convertible.h
@@ -94,9 +94,7 @@ UTL_NAMESPACE_END
 
 #endif // if UTL_USE_STD_TYPE_TRAITS && UTL_CXX20
 
-#ifdef UTL_BUILTIN_is_nothrow_convertible
-#  define UTL_TRAIT_is_nothrow_convertible(...) UTL_BUILTIN_is_nothrow_convertible(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_nothrow_convertible(...) __UTL is_nothrow_convertible_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_nothrow_convertible(...) __UTL is_nothrow_convertible<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_nothrow_destructible.h
+++ b/src/utl/public/utl/type_traits/utl_is_nothrow_destructible.h
@@ -90,9 +90,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_nothrow_destructible
-#  define UTL_TRAIT_is_nothrow_destructible(...) UTL_BUILTIN_is_nothrow_destructible(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_nothrow_destructible(...) __UTL is_nothrow_destructible_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_nothrow_destructible(...) __UTL is_nothrow_destructible<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_null_pointer.h
+++ b/src/utl/public/utl/type_traits/utl_is_null_pointer.h
@@ -75,9 +75,7 @@ UTL_NAMESPACE_END
 
 #define UTL_TRAIT_SUPPORTED_is_null_pointer 1
 
-#ifdef UTL_BUILTIN_is_null_pointer
-#  define UTL_TRAIT_is_null_pointer(...) UTL_BUILTIN_is_null_pointer(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_null_pointer(...) __UTL is_null_pointer_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_null_pointer(...) __UTL is_null_pointer<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_object.h
+++ b/src/utl/public/utl/type_traits/utl_is_object.h
@@ -76,9 +76,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_object
-#  define UTL_TRAIT_is_object(...) UTL_BUILTIN_is_object(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_object(...) __UTL is_object_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_object(...) __UTL is_object<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_pointer.h
+++ b/src/utl/public/utl/type_traits/utl_is_pointer.h
@@ -75,9 +75,7 @@ UTL_NAMESPACE_END
 
 #define UTL_TRAIT_SUPPORTED_is_pointer 1
 
-#ifdef UTL_BUILTIN_is_pointer
-#  define UTL_TRAIT_is_pointer(...) UTL_BUILTIN_is_pointer(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_pointer(...) __UTL is_pointer_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_pointer(...) __UTL is_pointer<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_pointer_interconvertible_base_of.h
+++ b/src/utl/public/utl/type_traits/utl_is_pointer_interconvertible_base_of.h
@@ -67,10 +67,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS && UTL_CXX20
 
-#ifdef UTL_BUILTIN_is_pointer_interconvertible_base_of
-#  define UTL_TRAIT_is_pointer_interconvertible_base_of(...) \
-      UTL_BUILTIN_is_pointer_interconvertible_base_of(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_pointer_interconvertible_base_of(...) \
       __UTL is_pointer_interconvertible_base_of_v<__VA_ARGS__>
 #else

--- a/src/utl/public/utl/type_traits/utl_is_polymorphic.h
+++ b/src/utl/public/utl/type_traits/utl_is_polymorphic.h
@@ -67,9 +67,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_polymorphic
-#  define UTL_TRAIT_is_polymorphic(...) UTL_BUILTIN_is_polymorphic(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_polymorphic(...) __UTL is_polymorphic_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_polymorphic(...) __UTL is_polymorphic<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_reference.h
+++ b/src/utl/public/utl/type_traits/utl_is_reference.h
@@ -73,9 +73,7 @@ UTL_NAMESPACE_END
 
 #define UTL_TRAIT_SUPPORTED_is_reference 1
 
-#ifdef UTL_BUILTIN_is_reference
-#  define UTL_TRAIT_is_reference(...) UTL_BUILTIN_is_reference(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_reference(...) __UTL is_reference_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_reference(...) __UTL is_reference<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_rvalue_reference.h
+++ b/src/utl/public/utl/type_traits/utl_is_rvalue_reference.h
@@ -71,9 +71,7 @@ UTL_NAMESPACE_END
 
 #define UTL_TRAIT_SUPPORTED_is_rvalue_reference 1
 
-#ifdef UTL_BUILTIN_is_rvalue_reference
-#  define UTL_TRAIT_is_rvalue_reference(...) UTL_BUILTIN_is_rvalue_reference(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_rvalue_reference(...) __UTL is_rvalue_reference_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_rvalue_reference(...) __UTL is_rvalue_reference<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_same.h
+++ b/src/utl/public/utl/type_traits/utl_is_same.h
@@ -66,9 +66,7 @@ UTL_NAMESPACE_END
 
 #define UTL_TRAIT_SUPPORTED_is_same 1
 
-#ifdef UTL_BUILTIN_is_same
-#  define UTL_TRAIT_is_same(...) UTL_BUILTIN_is_same(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_same(...) __UTL is_same_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_same(...) __UTL is_same<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_scalar.h
+++ b/src/utl/public/utl/type_traits/utl_is_scalar.h
@@ -78,9 +78,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_scalar
-#  define UTL_TRAIT_is_scalar(...) UTL_BUILTIN_is_scalar(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_scalar(...) __UTL is_scalar_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_scalar(...) __UTL is_scalar<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_signed.h
+++ b/src/utl/public/utl/type_traits/utl_is_signed.h
@@ -73,9 +73,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_signed
-#  define UTL_TRAIT_is_signed(...) UTL_BUILTIN_is_signed(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_signed(...) __UTL is_signed_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_signed(...) __UTL is_signed<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_standard_layout.h
+++ b/src/utl/public/utl/type_traits/utl_is_standard_layout.h
@@ -68,9 +68,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_standard_layout
-#  define UTL_TRAIT_is_standard_layout(...) UTL_BUILTIN_is_standard_layout(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_standard_layout(...) __UTL is_standard_layout_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_standard_layout(...) __UTL is_standard_layout<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_trivial.h
+++ b/src/utl/public/utl/type_traits/utl_is_trivial.h
@@ -67,9 +67,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_trivial
-#  define UTL_TRAIT_is_trivial(...) UTL_BUILTIN_is_trivial(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_trivial(...) __UTL is_trivial_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_trivial(...) __UTL is_trivial<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_trivially_assignable.h
+++ b/src/utl/public/utl/type_traits/utl_is_trivially_assignable.h
@@ -66,10 +66,16 @@ template <typename T, typename U>
 UTL_INLINE_CXX17 constexpr bool is_trivially_assignable_v = is_trivially_assignable<T, U>::value;
 #    endif // UTL_CXX14
 
-#    define UTL_TRAIT_SUPPORTED_is_nothrow_assignable 0
+#    define UTL_TRAIT_SUPPORTED_is_trivially_assignable 0
 
 UTL_NAMESPACE_END
 
 #  endif // ifdef UTL_BUILTIN_is_trivially_assignable
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
+
+#if UTL_CXX14
+#  define UTL_TRAIT_is_trivially_assignable(...) __UTL is_trivially_assignable_v<__VA_ARGS__>
+#else
+#  define UTL_TRAIT_is_trivially_assignable(...) __UTL is_trivially_assignable<__VA_ARGS__>::value
+#endif

--- a/src/utl/public/utl/type_traits/utl_is_trivially_constructible.h
+++ b/src/utl/public/utl/type_traits/utl_is_trivially_constructible.h
@@ -67,10 +67,17 @@ template <typename T, typename... Args>
 UTL_INLINE_CXX17 constexpr bool is_trivially_constructible_v = is_trivially_constructible<T, Args...>::value;
 #    endif // UTL_CXX14
 
-#    define UTL_TRAIT_SUPPORTED_is_nothrow_constructible 0
+#    define UTL_TRAIT_SUPPORTED_is_trivially_constructible 0
 
 UTL_NAMESPACE_END
 
 #  endif // ifdef UTL_BUILTIN_is_trivially_constructible
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
+
+#if UTL_CXX14
+#  define UTL_TRAIT_is_trivially_constructible(...) __UTL is_trivially_constructible_v<__VA_ARGS__>
+#else
+#  define UTL_TRAIT_is_trivially_constructible(...) \
+      __UTL is_trivially_constructible<__VA_ARGS__>::value
+#endif

--- a/src/utl/public/utl/type_traits/utl_is_trivially_copyable.h
+++ b/src/utl/public/utl/type_traits/utl_is_trivially_copyable.h
@@ -74,9 +74,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_trivially_copyable
-#  define UTL_TRAIT_is_trivially_copyable(...) UTL_BUILTIN_is_trivially_copyable(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_trivially_copyable(...) __UTL is_trivially_copyable_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_trivially_copyable(...) __UTL is_trivially_copyable<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_trivially_default_constructible.h
+++ b/src/utl/public/utl/type_traits/utl_is_trivially_default_constructible.h
@@ -71,10 +71,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_trivially_constructible
-#  define UTL_TRAIT_is_trivially_default_constructible(TYPE) \
-      UTL_BUILTIN_is_trivially_constructible(TYPE)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_trivially_default_constructible(TYPE) \
       __UTL is_trivially_default_constructible_v<TYPE>
 #else

--- a/src/utl/public/utl/type_traits/utl_is_trivially_destructible.h
+++ b/src/utl/public/utl/type_traits/utl_is_trivially_destructible.h
@@ -74,10 +74,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_trivially_destructible
-#  define UTL_TRAIT_is_trivially_destructible(...) \
-      UTL_BUILTIN_is_trivially_destructible(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_trivially_destructible(...) __UTL is_trivially_destructible_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_trivially_destructible(...) \

--- a/src/utl/public/utl/type_traits/utl_is_union.h
+++ b/src/utl/public/utl/type_traits/utl_is_union.h
@@ -67,9 +67,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_union
-#  define UTL_TRAIT_is_union(...) UTL_BUILTIN_is_union(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_union(...) __UTL is_union_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_union(...) __UTL is_union<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_unsigned.h
+++ b/src/utl/public/utl/type_traits/utl_is_unsigned.h
@@ -75,9 +75,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_unsigned
-#  define UTL_TRAIT_is_unsigned(...) UTL_BUILTIN_is_unsigned(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_unsigned(...) __UTL is_unsigned_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_unsigned(...) __UTL is_unsigned<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_void.h
+++ b/src/utl/public/utl/type_traits/utl_is_void.h
@@ -75,9 +75,7 @@ UTL_NAMESPACE_END
 
 #define UTL_TRAIT_SUPPORTED_is_void 1
 
-#ifdef UTL_BUILTIN_is_void
-#  define UTL_TRAIT_is_void(...) UTL_BUILTIN_is_void(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_void(...) __UTL is_void_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_void(...) __UTL is_void<__VA_ARGS__>::value

--- a/src/utl/public/utl/type_traits/utl_is_volatile.h
+++ b/src/utl/public/utl/type_traits/utl_is_volatile.h
@@ -73,9 +73,7 @@ UTL_NAMESPACE_END
 
 #endif // ifdef UTL_USE_STD_TYPE_TRAITS
 
-#ifdef UTL_BUILTIN_is_volatile
-#  define UTL_TRAIT_is_volatile(...) UTL_BUILTIN_is_volatile(__VA_ARGS__)
-#elif UTL_CXX14
+#if UTL_CXX14
 #  define UTL_TRAIT_is_volatile(...) __UTL is_volatile_v<__VA_ARGS__>
 #else
 #  define UTL_TRAIT_is_volatile(...) __UTL is_volatile<__VA_ARGS__>::value


### PR DESCRIPTION
Do not let trait macros resolve to compiler intrinsic; return value SFINAE is not supported if intrinsic are use in GCC or Clang (<18).