### PR TITLE
Rename from requires to constraint

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -109,12 +109,12 @@ Macros:
 - UTL_CONSTEXPR_CXX20=constexpr
 - UTL_CONSTEXPR_CXX23=constexpr
 - UTL_CONSTEVAL=consteval
-- UTL_REQUIRES_CXX11(X)=,typename=enable_if_t<X>
-- UTL_REQUIRES_CXX11(X,Y)=,typename=enable_if_t<X,Y>
-- UTL_REQUIRES_CXX11(X,Y,Z)=,typename=enable_if_t<X,Y,Z>
-- UTL_REQUIRES_CXX20(X)=requires (X)
-- UTL_REQUIRES_CXX20(X,Y)=requires (X,Y)
-- UTL_REQUIRES_CXX20(X,Y,Z)=requires (X,Y,Z)
+- UTL_CONSTRAINT_CXX11(X)=,typename=enable_if_t<X>
+- UTL_CONSTRAINT_CXX11(X,Y)=,typename=enable_if_t<X,Y>
+- UTL_CONSTRAINT_CXX11(X,Y,Z)=,typename=enable_if_t<X,Y,Z>
+- UTL_CONSTRAINT_CXX20(X)=requires (X)
+- UTL_CONSTRAINT_CXX20(X,Y)=requires (X,Y)
+- UTL_CONSTRAINT_CXX20(X,Y,Z)=requires (X,Y,Z)
 - UTL_CONCEPT_CXX20(X)=type<X>
 - UTL_NODISCARD=[[nodiscard]]
 - UTL_ENABLE_IF_CXX11(X,Y)=void

--- a/src/utl/public/utl/bit/utl_bit_ceil.h
+++ b/src/utl/public/utl/bit/utl_bit_ceil.h
@@ -10,7 +10,7 @@ namespace details {
 namespace bit {
 
 template <typename T>
-UTL_REQUIRES_CXX20(requires(T x) {
+UTL_CONSTRAINT_CXX20(requires(T x) {
     { +x } -> same_as<T>;
 })
 UTL_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD) inline constexpr auto bit_ceil(T x) noexcept -> UTL_ENABLE_IF_CXX11(

--- a/src/utl/public/utl/configuration/utl_standard.h
+++ b/src/utl/public/utl/configuration/utl_standard.h
@@ -44,8 +44,8 @@
 #    define UTL_IMPLICIT_IF(...) explicit(!(__VA_ARGS__))
 
 #    define UTL_ENABLE_IF_CXX11(TYPE, ...) TYPE
-#    define UTL_REQUIRES_CXX11(...)
-#    define UTL_REQUIRES_CXX20(...) requires (__VA_ARGS__)
+#    define UTL_CONSTRAINT_CXX11(...)
+#    define UTL_CONSTRAINT_CXX20(...) requires (__VA_ARGS__)
 #    define UTL_CONCEPT_CXX20(...) __VA_ARGS__
 
 #  else /* UTL_CXX >= 202002L */
@@ -55,8 +55,8 @@
 #    define UTL_EXPLICIT_IF(...)
 #    define UTL_IMPLICIT_IF(...) explicit
 #    define UTL_ENABLE_IF_CXX11(TYPE, ...) __UTL enable_if_t<(__VA_ARGS__), TYPE>
-#    define UTL_REQUIRES_CXX11(...) , __UTL enable_if_t<(__VA_ARGS__), int> = __LINE__
-#    define UTL_REQUIRES_CXX20(...)
+#    define UTL_CONSTRAINT_CXX11(...) , __UTL enable_if_t<(__VA_ARGS__), int> = __LINE__
+#    define UTL_CONSTRAINT_CXX20(...)
 #    define UTL_CONCEPT_CXX20(...) typename
 #  endif /* UTL_CXX >= 202002L */
 

--- a/src/utl/public/utl/exception/utl_program_exception.h
+++ b/src/utl/public/utl/exception/utl_program_exception.h
@@ -118,7 +118,7 @@ public:
      * @param fmt The message format object containing the format string and source location.
      * @param args The additional arguments for the message format.
      */
-    template <UTL_CONCEPT_CXX20(constructible_as<T>) U, typename... Args UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(constructible_as<T>) U, typename... Args UTL_CONSTRAINT_CXX11(
         is_constructible<T, U>::value)>
     __UTL_HIDE_FROM_ABI basic_exception(U&& u, exceptions::message_format fmt,
         Args... args) noexcept(UTL_TRAIT_is_nothrow_constructible(T, U))

--- a/src/utl/public/utl/functional/utl_invoke.h
+++ b/src/utl/public/utl/functional/utl_invoke.h
@@ -38,9 +38,9 @@ struct invoke_t<void> {
 } // namespace invoke
 } // namespace details
 
-template <typename R, typename F, typename... Args UTL_REQUIRES_CXX11(
+template <typename R, typename F, typename... Args UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_invocable_r(R, F, Args...))>
-UTL_REQUIRES_CXX20(UTL_TRAIT_is_invocable_r(R, F, Args...))
+UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_invocable_r(R, F, Args...))
 UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) inline constexpr R invoke_r(F&& f, Args&&... args) noexcept(
     UTL_TRAIT_is_nothrow_invocable_r(R, F, Args...)) {
     return details::invoke::invoke_t<R>::call(__UTL forward<F>(f), __UTL forward<Args>(args)...);

--- a/src/utl/public/utl/iterator/utl_contiguous_iterator_base.h
+++ b/src/utl/public/utl/iterator/utl_contiguous_iterator_base.h
@@ -158,13 +158,13 @@ protected:
     __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX20 ~contiguous_iterator_base() noexcept = default;
 
     template <UTL_CONCEPT_CXX20(constructible_as<stored_pointer, __UTL add_pointer>) T
-            UTL_REQUIRES_CXX11(UTL_TRAIT_is_constructible(stored_pointer, T*))>
+            UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_constructible(stored_pointer, T*))>
     __UTL_HIDE_FROM_ABI constexpr contiguous_iterator_base(
         contiguous_iterator_base<It, T> it) noexcept
         : ptr_(it.operator->()){};
 
     template <UTL_CONCEPT_CXX20(assignable_to<stored_pointer, __UTL add_pointer>) T
-            UTL_REQUIRES_CXX11(UTL_TRAIT_is_assignable(stored_pointer&, T*))>
+            UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_assignable(stored_pointer&, T*))>
     __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 contiguous_iterator_base& operator=(
         contiguous_iterator_base<It, T> it) noexcept {
         ptr_ = it.operator->();

--- a/src/utl/public/utl/iterator/utl_incrementable_traits.h
+++ b/src/utl/public/utl/iterator/utl_incrementable_traits.h
@@ -77,12 +77,12 @@ template <typename T>
 struct difference_identity {
     using difference_type UTL_NODEBUG = T;
 };
-template <typename T UTL_REQUIRES_CXX11(UTL_TRAIT_is_object(T))>
+template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_object(T))>
 using object_pointer UTL_NODEBUG = difference_identity<ptrdiff_t>;
-template <typename T UTL_REQUIRES_CXX11(UTL_TRAIT_has_member_difference_type(T))>
+template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_has_member_difference_type(T))>
 __UTL_HIDE_FROM_ABI auto resolve_trait(int) noexcept
     -> difference_identity<typename T::difference_type>;
-template <typename T UTL_REQUIRES_CXX11(!UTL_TRAIT_has_member_difference_type(T))>
+template <typename T UTL_CONSTRAINT_CXX11(!UTL_TRAIT_has_member_difference_type(T))>
 __UTL_HIDE_FROM_ABI auto resolve_trait(int) noexcept -> difference_identity<subtract_result_t<T>>;
 
 struct fallback_t {};

--- a/src/utl/public/utl/iterator/utl_iter_common_reference_t.h
+++ b/src/utl/public/utl/iterator/utl_iter_common_reference_t.h
@@ -14,7 +14,7 @@ UTL_NAMESPACE_BEGIN
 namespace details {
 namespace iter_common_reference {
 
-template <UTL_CONCEPT_CXX20(__UTL indirectly_readable) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(__UTL indirectly_readable) T UTL_CONSTRAINT_CXX11(
     __UTL is_indirectly_readable<T>::value)>
 __UTL_HIDE_FROM_ABI auto resolve(int) noexcept
     -> __UTL common_reference_t<__UTL iter_reference_t<T>, __UTL iter_value_t<T>&>;

--- a/src/utl/public/utl/iterator/utl_iter_const_reference_t.h
+++ b/src/utl/public/utl/iterator/utl_iter_const_reference_t.h
@@ -14,7 +14,7 @@ UTL_NAMESPACE_BEGIN
 namespace details {
 namespace iter_const_reference {
 
-template <UTL_CONCEPT_CXX20(__UTL indirectly_readable) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(__UTL indirectly_readable) T UTL_CONSTRAINT_CXX11(
     __UTL is_indirectly_readable<T>::value)>
 __UTL_HIDE_FROM_ABI auto resolve(int) noexcept
     -> __UTL common_reference_t<const __UTL iter_value_t<T>&&, __UTL iter_reference_t<T>>;

--- a/src/utl/public/utl/iterator/utl_iter_difference_t.h
+++ b/src/utl/public/utl/iterator/utl_iter_difference_t.h
@@ -13,7 +13,7 @@ UTL_NAMESPACE_BEGIN
 
 namespace details {
 namespace iter_difference {
-template <UTL_CONCEPT_CXX20(__UTL details::iterator_traits::is_specialized) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(__UTL details::iterator_traits::is_specialized) T UTL_CONSTRAINT_CXX11(
     __UTL details::iterator_traits::is_specialized<T>::value)>
 __UTL_HIDE_FROM_ABI typename __UTL iterator_traits<T>::difference_type resolve(int) noexcept;
 template <typename T>

--- a/src/utl/public/utl/iterator/utl_iter_move.h
+++ b/src/utl/public/utl/iterator/utl_iter_move.h
@@ -19,10 +19,10 @@ UTL_NAMESPACE_BEGIN
 
 namespace details {
 namespace iterator_move {
-template <typename T UTL_REQUIRES_CXX11(
+template <typename T UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_lvalue_reference(decltype(*__UTL declval<T&>())) &&
     UTL_TRAIT_is_rvalue_reference(decltype(__UTL move(*__UTL declval<T&>()))))>
-UTL_REQUIRES_CXX20(requires(T&& it) {
+UTL_CONSTRAINT_CXX20(requires(T&& it) {
     { *it } -> lvalue_reference;
     __UTL move(*it);
 })
@@ -31,9 +31,9 @@ __UTL_HIDE_FROM_ABI constexpr auto iter_move(T&& it) noexcept(
     return __UTL move(*it);
 }
 
-template <typename T UTL_REQUIRES_CXX11(
+template <typename T UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_rvalue_reference(decltype(*__UTL declval<T&>())))>
-UTL_REQUIRES_CXX20(requires(T&& it) {
+UTL_CONSTRAINT_CXX20(requires(T&& it) {
     { *it } -> rvalue_reference;
 })
 __UTL_HIDE_FROM_ABI constexpr auto iter_move(T&& it) noexcept(
@@ -42,9 +42,9 @@ __UTL_HIDE_FROM_ABI constexpr auto iter_move(T&& it) noexcept(
 }
 
 struct function_t {
-    template <typename T UTL_REQUIRES_CXX11(
+    template <typename T UTL_CONSTRAINT_CXX11(
         __UTL always_true_type<decltype(iter_move(__UTL declval<T>()))>::value)>
-    UTL_REQUIRES_CXX20(requires(T&& it) { iter_move(__UTL forward<T>(it)); })
+    UTL_CONSTRAINT_CXX20(requires(T&& it) { iter_move(__UTL forward<T>(it)); })
     __UTL_HIDE_FROM_ABI constexpr auto operator()(T&& it) const
         noexcept(UTL_TRAIT_is_nothrow_dereferenceable(T))
             -> decltype(iter_move(__UTL declval<T>())) {

--- a/src/utl/public/utl/iterator/utl_iter_reference_t.h
+++ b/src/utl/public/utl/iterator/utl_iter_reference_t.h
@@ -14,7 +14,7 @@ UTL_NAMESPACE_BEGIN
 namespace details {
 namespace iter_reference {
 
-template <UTL_CONCEPT_CXX20(__UTL dereferenceable) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(__UTL dereferenceable) T UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_dereferenceable(T))>
 __UTL_HIDE_FROM_ABI auto resolve(int) noexcept -> decltype(*__UTL declval<T&>());
 

--- a/src/utl/public/utl/iterator/utl_iter_rvalue_reference_t.h
+++ b/src/utl/public/utl/iterator/utl_iter_rvalue_reference_t.h
@@ -39,7 +39,8 @@ UTL_NAMESPACE_BEGIN
 namespace details {
 namespace iter_rvalue_reference {
 
-template <UTL_CONCEPT_CXX20(dereferenceable) T UTL_REQUIRES_CXX11(UTL_TRAIT_is_dereferenceable(T))>
+template <UTL_CONCEPT_CXX20(dereferenceable) T UTL_CONSTRAINT_CXX11(
+    UTL_TRAIT_is_dereferenceable(T))>
 __UTL_HIDE_FROM_ABI auto resolve(int) noexcept -> __UTL
     enable_if_t<UTL_TRAIT_is_referenceable(decltype(ranges::iter_move(__UTL declval<T&>()))),
         decltype(ranges::iter_move(__UTL declval<T&>()))>;

--- a/src/utl/public/utl/iterator/utl_iter_value_t.h
+++ b/src/utl/public/utl/iterator/utl_iter_value_t.h
@@ -29,7 +29,7 @@ UTL_NAMESPACE_BEGIN
 namespace details {
 namespace iter_value {
 
-template <typename T UTL_REQUIRES_CXX11(__UTL details::iterator_traits::is_specialized<T>::value)>
+template <typename T UTL_CONSTRAINT_CXX11(__UTL details::iterator_traits::is_specialized<T>::value)>
 __UTL_HIDE_FROM_ABI typename __UTL iterator_traits<T>::value_type resolve(int) noexcept;
 } // namespace iter_value
 } // namespace details

--- a/src/utl/public/utl/iterator/utl_iterator_concept_t.h
+++ b/src/utl/public/utl/iterator/utl_iterator_concept_t.h
@@ -109,14 +109,14 @@ template <typename T>
 struct has_member_iterator_category<T, __UTL void_t<typename trait_type_t<T>::iterator_category>> :
     __UTL true_type {};
 
-template <typename T UTL_REQUIRES_CXX11(has_member_iterator_concept<T>::value)>
+template <typename T UTL_CONSTRAINT_CXX11(has_member_iterator_concept<T>::value)>
 __UTL_HIDE_FROM_ABI auto resolve(int) noexcept -> typename trait_type_t<T>::iterator_concept;
 
-template <typename T UTL_REQUIRES_CXX11(
+template <typename T UTL_CONSTRAINT_CXX11(
     !has_member_iterator_concept<T>::value && has_member_iterator_category<T>::value)>
 __UTL_HIDE_FROM_ABI auto resolve(int) noexcept -> typename trait_type_t<T>::iterator_category;
 
-template <typename T UTL_REQUIRES_CXX11(!has_member_iterator_concept<T>::value &&
+template <typename T UTL_CONSTRAINT_CXX11(!has_member_iterator_concept<T>::value &&
     !has_member_iterator_category<T>::value &&
     !__UTL details::iterator_traits::is_specialized<T>::value)>
 __UTL_HIDE_FROM_ABI auto resolve(int) noexcept -> __UTL random_access_iterator_tag;

--- a/src/utl/public/utl/iterator/utl_reverse_iterator.h
+++ b/src/utl/public/utl/iterator/utl_reverse_iterator.h
@@ -127,7 +127,7 @@ private:
         __UTL conditional_t<!UTL_TRAIT_is_base_of(random_access_iterator_tag, iterator_concept),
             difference_type, inaccessible_t>;
 
-    template <UTL_CONCEPT_CXX20(legacy_random_access_iterator) I UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(legacy_random_access_iterator) I UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_legacy_random_access_iterator(I))>
     __UTL_HIDE_FROM_ABI static constexpr auto subscript(I const& current,
         difference_type idx) noexcept(UTL_TRAIT_is_nothrow_subscriptable(I, difference_type))
@@ -140,8 +140,8 @@ private:
         return 0;
     }
 
-    template <typename I UTL_REQUIRES_CXX11(UTL_TRAIT_is_pointer(I))>
-    UTL_REQUIRES_CXX20(is_pointer_v<I>)
+    template <typename I UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(I))>
+    UTL_CONSTRAINT_CXX20(is_pointer_v<I>)
     __UTL_HIDE_FROM_ABI static constexpr auto redirect(I current, int) noexcept -> I {
         return current - 1;
     }
@@ -168,9 +168,9 @@ public:
         UTL_TRAIT_is_nothrow_copy_constructible(iterator_type)) = default;
     __UTL_HIDE_FROM_ABI constexpr reverse_iterator(reverse_iterator&&) noexcept(
         UTL_TRAIT_is_nothrow_move_constructible(iterator_type)) = default;
-    template <typename U UTL_REQUIRES_CXX11(
+    template <typename U UTL_CONSTRAINT_CXX11(
         !UTL_TRAIT_is_same(U, iterator_type) && UTL_TRAIT_is_convertible(U const&, iterator_type))>
-    UTL_REQUIRES_CXX20(!same_as<U, iterator_type> && convertible_to<U const&, iterator_type>)
+    UTL_CONSTRAINT_CXX20(!same_as<U, iterator_type> && convertible_to<U const&, iterator_type>)
     __UTL_HIDE_FROM_ABI constexpr reverse_iterator(reverse_iterator<U> const& it) noexcept(
         UTL_TRAIT_is_nothrow_convertible(U const&, iterator_type))
         : current(it.base()) {}
@@ -179,10 +179,10 @@ public:
         UTL_TRAIT_is_nothrow_copy_assignable(iterator_type)) = default;
     __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 reverse_iterator& operator=(reverse_iterator&&) noexcept(
         UTL_TRAIT_is_nothrow_move_assignable(iterator_type)) = default;
-    template <typename U UTL_REQUIRES_CXX11(!UTL_TRAIT_is_same(U, iterator_type) &&
+    template <typename U UTL_CONSTRAINT_CXX11(!UTL_TRAIT_is_same(U, iterator_type) &&
         UTL_TRAIT_is_convertible(U const&, iterator_type) &&
         UTL_TRAIT_is_assignable(iterator_type&, U const&))>
-    UTL_REQUIRES_CXX20(!same_as<U, iterator_type> && convertible_to<U const&, iterator_type> &&
+    UTL_CONSTRAINT_CXX20(!same_as<U, iterator_type> && convertible_to<U const&, iterator_type> &&
         assignable_from<iterator_type&, U const&>)
     __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 reverse_iterator&
     operator=(reverse_iterator<U> const& it) noexcept(
@@ -206,7 +206,7 @@ public:
 
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD, FLATTEN) constexpr pointer operator->() const
         noexcept(noexcept(redirect(this->current, 0u)))
-        UTL_REQUIRES_CXX20(__UTL is_pointer_v<iterator_type> ||
+        UTL_CONSTRAINT_CXX20(__UTL is_pointer_v<iterator_type> ||
         requires(iterator_type const i) { i.operator->(); })
     {
         return redirect(this->current, 0u);
@@ -314,7 +314,7 @@ UTL_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD, ALWAYS_INLINE) constexpr reverse_itera
 }
 
 template <typename It1, typename It2>
-UTL_REQUIRES_CXX20(requires(It1 l, It2 r) { l == r; })
+UTL_CONSTRAINT_CXX20(requires(It1 l, It2 r) { l == r; })
 UTL_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD, ALWAYS_INLINE) constexpr auto
 operator==(reverse_iterator<It1> const& l, reverse_iterator<It1> const& r) noexcept(
     UTL_TRAIT_is_nothrow_equality_comparable_with(decltype(l.base()), decltype(r.base()))) -> 
@@ -323,7 +323,7 @@ operator==(reverse_iterator<It1> const& l, reverse_iterator<It1> const& r) noexc
 }
 
 template <typename It1, typename It2>
-UTL_REQUIRES_CXX20(requires(It1 l, It2 r) { l != r; })
+UTL_CONSTRAINT_CXX20(requires(It1 l, It2 r) { l != r; })
 UTL_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD, ALWAYS_INLINE) constexpr auto
 operator!=(reverse_iterator<It1> const& l, reverse_iterator<It1> const& r) noexcept(
     UTL_TRAIT_is_nothrow_inequality_comparable_with(decltype(l.base()), decltype(r.base())))
@@ -333,7 +333,7 @@ operator!=(reverse_iterator<It1> const& l, reverse_iterator<It1> const& r) noexc
 }
 
 template <typename It1, typename It2>
-UTL_REQUIRES_CXX20(requires(It1 l, It2 r) { l < r; })
+UTL_CONSTRAINT_CXX20(requires(It1 l, It2 r) { l < r; })
 UTL_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD, ALWAYS_INLINE) constexpr auto
 operator<(reverse_iterator<It1> const& l, reverse_iterator<It1> const& r) noexcept(
     UTL_TRAIT_is_nothrow_strict_subordinate_comparable_with(decltype(l.base()), decltype(r.base())))
@@ -343,7 +343,7 @@ operator<(reverse_iterator<It1> const& l, reverse_iterator<It1> const& r) noexce
 }
 
 template <typename It1, typename It2>
-UTL_REQUIRES_CXX20(requires(It1 l, It2 r) { l > r; })
+UTL_CONSTRAINT_CXX20(requires(It1 l, It2 r) { l > r; })
 UTL_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD, ALWAYS_INLINE) constexpr auto
 operator>(reverse_iterator<It1> const& l, reverse_iterator<It1> const& r) noexcept(
     UTL_TRAIT_is_nothrow_strict_superordinate_comparable_with(
@@ -353,7 +353,7 @@ operator>(reverse_iterator<It1> const& l, reverse_iterator<It1> const& r) noexce
 }
 
 template <typename It1, typename It2>
-UTL_REQUIRES_CXX20(requires(It1 l, It2 r) { l <= r; })
+UTL_CONSTRAINT_CXX20(requires(It1 l, It2 r) { l <= r; })
 UTL_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD, ALWAYS_INLINE) constexpr auto
 operator<=(reverse_iterator<It1> const& l, reverse_iterator<It1> const& r) noexcept(
     UTL_TRAIT_is_nothrow_subordinate_comparable_with(decltype(l.base()), decltype(r.base())))
@@ -363,7 +363,7 @@ operator<=(reverse_iterator<It1> const& l, reverse_iterator<It1> const& r) noexc
 }
 
 template <typename It1, typename It2>
-UTL_REQUIRES_CXX20(requires(It1 l, It2 r) { l >= r; })
+UTL_CONSTRAINT_CXX20(requires(It1 l, It2 r) { l >= r; })
 UTL_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD, ALWAYS_INLINE) constexpr auto
 operator>=(reverse_iterator<It1> const& l, reverse_iterator<It1> const& r) noexcept(
     UTL_TRAIT_is_nothrow_superordinate_comparable_with(decltype(l.base()), decltype(r.base())))
@@ -374,7 +374,7 @@ operator>=(reverse_iterator<It1> const& l, reverse_iterator<It1> const& r) noexc
 
 #if UTL_CXX20
 template <typename It1, typename It2>
-UTL_REQUIRES_CXX20(requires(It1 l, It2 r) { l <=> r; })
+UTL_CONSTRAINT_CXX20(requires(It1 l, It2 r) { l <=> r; })
 UTL_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD, ALWAYS_INLINE) constexpr auto
 operator<=>(reverse_iterator<It1> const& l, reverse_iterator<It1> const& r) noexcept(
     UTL_TRAIT_is_nothrow_three_way_comparable_with(decltype(l.base()), decltype(r.base())))
@@ -387,7 +387,7 @@ operator<=>(reverse_iterator<It1> const& l, reverse_iterator<It1> const& r) noex
 #if UTL_CXX14
 
 template <typename It1, typename It2>
-UTL_REQUIRES_CXX20(!sized_sentinel_for<It1, It2>)
+UTL_CONSTRAINT_CXX20(!sized_sentinel_for<It1, It2>)
 UTL_INLINE_CXX17 constexpr bool disable_sized_sentinel_for<reverse_iterator<It1>, reverse_iterator<It2>> =
     !is_sized_sentinel_for_v<It1, It2>;
 

--- a/src/utl/public/utl/memory/utl_allocator_traits.h
+++ b/src/utl/public/utl/memory/utl_allocator_traits.h
@@ -174,9 +174,9 @@ __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX20 pointer_t<T> fallback_reallocate(
     return blessed;
 }
 
-template <UTL_CONCEPT_CXX20(implements_reallocate) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(implements_reallocate) T UTL_CONSTRAINT_CXX11(
     implements_reallocate<T>::value && is_pointer<pointer_t<T>>::value)>
-UTL_REQUIRES_CXX20(is_pointer_v<pointer_t<T>>)
+UTL_CONSTRAINT_CXX20(is_pointer_v<pointer_t<T>>)
 __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX20 pointer_t<T> reallocate(
     T& allocator, result_type_t<T> arg, size_type_t<T> size) {
 #if UTL_CXX20
@@ -187,15 +187,15 @@ __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX20 pointer_t<T> reallocate(
     return allocator.reallocate(arg, size);
 }
 
-template <UTL_CONCEPT_CXX20(implements_reallocate) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(implements_reallocate) T UTL_CONSTRAINT_CXX11(
     implements_reallocate<T>::value && !is_pointer<pointer_t<T>>::value)>
-UTL_REQUIRES_CXX20(!is_pointer_v<pointer_t<T>>)
+UTL_CONSTRAINT_CXX20(!is_pointer_v<pointer_t<T>>)
 __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX20 pointer_t<T> reallocate(
     T& allocator, result_type_t<T> arg, size_type_t<T> size) {
     return allocator.reallocate(arg, size);
 }
 
-template <typename T UTL_REQUIRES_CXX11(!implements_reallocate<T>::value)>
+template <typename T UTL_CONSTRAINT_CXX11(!implements_reallocate<T>::value)>
 __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX20 pointer_t<T> reallocate(
     T& allocator, result_type_t<T> arg, size_type_t<T> size) {
     return fallback_reallocate(allocator, arg, size);
@@ -223,13 +223,13 @@ concept implements_allocate_at_least = requires(T& alloc, size_type_t<T> size) {
 
 #endif
 
-template <typename T UTL_REQUIRES_CXX11(!implements_allocate_at_least<T>::value)>
+template <typename T UTL_CONSTRAINT_CXX11(!implements_allocate_at_least<T>::value)>
 __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX20 result_type_t<T> allocate_at_least(
     T& allocator, size_type_t<T> size) {
     return {allocator.allocate(size), size};
 }
 
-template <UTL_CONCEPT_CXX20(implements_allocate_at_least) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(implements_allocate_at_least) T UTL_CONSTRAINT_CXX11(
     implements_allocate_at_least<T>::value)>
 __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX20 result_type_t<T> allocate_at_least(
     T& allocator, size_type_t<T> size) {
@@ -258,13 +258,13 @@ concept implements_reallocate_at_least = requires(T& alloc, result_type_t<T> r, 
 
 #endif
 
-template <typename T UTL_REQUIRES_CXX11(!implements_reallocate_at_least<T>::value)>
+template <typename T UTL_CONSTRAINT_CXX11(!implements_reallocate_at_least<T>::value)>
 __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX20 result_type_t<T> reallocate_at_least(
     T& allocator, result_type_t<T> arg, size_type_t<T> new_size) {
     return {__UTL details::allocator::reallocate(allocator, arg, new_size), new_size};
 }
 
-template <UTL_CONCEPT_CXX20(implements_reallocate_at_least) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(implements_reallocate_at_least) T UTL_CONSTRAINT_CXX11(
     implements_reallocate_at_least<T>::value)>
 __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX20 result_type_t<T> reallocate_at_least(
     T& allocator, result_type_t<T> arg, size_type_t<T> size) {

--- a/src/utl/public/utl/memory/utl_nonnull_ptr.h
+++ b/src/utl/public/utl/memory/utl_nonnull_ptr.h
@@ -46,7 +46,7 @@ public:
                                                 "Reason=[Pointer argument cannot be null]")));
     }
 
-    template <UTL_CONCEPT_CXX20(convertible_to<T*>) U UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(convertible_to<T*>) U UTL_CONSTRAINT_CXX11(
         is_convertible<U, T*>::value)>
     __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 nonnull_ptr(U&& obj)
         UTL_THROWS : nonnull_ptr((T*)obj) {}

--- a/src/utl/public/utl/memory/utl_reference_counting_destroy.h
+++ b/src/utl/public/utl/memory/utl_reference_counting_destroy.h
@@ -52,15 +52,15 @@ private:
     using has_custom_destroy UTL_NODEBUG = decltype(has_custom_destroy_impl<T>(0));
 
 public:
-    template <UTL_CONCEPT_CXX20(reference_countable) T UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(reference_countable) T UTL_CONSTRAINT_CXX11(
         is_reference_countable<T>::value && has_custom_destroy<T>::value)>
-    UTL_REQUIRES_CXX20(requires(T* p) {
+    UTL_CONSTRAINT_CXX20(requires(T* p) {
         destroy(p); })
     __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX20 void operator()(T* ptr) const noexcept {
         destroy(ptr);
     }
 
-    template <UTL_CONCEPT_CXX20(reference_countable) T UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(reference_countable) T UTL_CONSTRAINT_CXX11(
         is_reference_countable<T>::value && !has_custom_destroy<T>::value)>
     __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX20 void operator()(T* ptr) const noexcept {
         delete ptr;

--- a/src/utl/public/utl/memory/utl_to_address.h
+++ b/src/utl/public/utl/memory/utl_to_address.h
@@ -73,17 +73,17 @@ struct to_address_t {
         return ptr;
     }
 
-    template <UTL_CONCEPT_CXX20(has_to_address) T UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(has_to_address) T UTL_CONSTRAINT_CXX11(
         !__UTL is_pointer<T>::value && has_to_address<T>::value)>
-    UTL_REQUIRES_CXX20(!__UTL is_pointer<T>::value)
+    UTL_CONSTRAINT_CXX20(!__UTL is_pointer<T>::value)
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD, ALWAYS_INLINE) inline constexpr auto operator()(
         T const& ptr) const noexcept -> decltype(__UTL pointer_traits<T>::to_address(ptr)) {
         return __UTL pointer_traits<T>::to_address(ptr);
     }
 
-    template <UTL_CONCEPT_CXX20(has_arrow_operator) T UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(has_arrow_operator) T UTL_CONSTRAINT_CXX11(
         !__UTL is_pointer<T>::value && !has_to_address<T>::value && has_arrow_operator<T>::value)>
-    UTL_REQUIRES_CXX20(!__UTL is_pointer<T>::value && !has_to_address<T>)
+    UTL_CONSTRAINT_CXX20(!__UTL is_pointer<T>::value && !has_to_address<T>)
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD, ALWAYS_INLINE) inline constexpr auto operator()(
         T const& ptr) const noexcept -> decltype(this->operator()(ptr.operator->())) {
         return this->operator()(ptr.operator->());

--- a/src/utl/public/utl/memory/utl_uses_allocator.h
+++ b/src/utl/public/utl/memory/utl_uses_allocator.h
@@ -44,10 +44,10 @@ using impl UTL_NODEBUG = R;
 
 struct __UTL_ABI_PUBLIC allocator_arg_t {
     explicit constexpr allocator_arg_t() noexcept = default;
-    template <UTL_CONCEPT_CXX20(same_as<::std::allocator_arg_t>) T UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(same_as<::std::allocator_arg_t>) T UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_same(T, ::std::allocator_arg_t))>
     __UTL_HIDE_FROM_ABI constexpr allocator_arg_t(T) noexcept {}
-    template <UTL_CONCEPT_CXX20(same_as<::std::allocator_arg_t>) T UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(same_as<::std::allocator_arg_t>) T UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_same(T, ::std::allocator_arg_t))>
     __UTL_HIDE_FROM_ABI constexpr operator T() const noexcept {
         return {};

--- a/src/utl/public/utl/numeric/arm/utl_add_sat.h
+++ b/src/utl/public/utl/numeric/arm/utl_add_sat.h
@@ -23,10 +23,10 @@ namespace details {
 namespace add_sat {
 namespace runtime {
 
-template <typename T UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(8, T))>
+template <typename T UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(8, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
 template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<8>) T
-        UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(8, T))>
+        UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(8, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     static constexpr auto max = UTL_NUMERIC_maximum(T);
     static constexpr int shift = sizeof(l) * CHAR_BIT - 1;
@@ -40,10 +40,10 @@ __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     return l;
 }
 
-template <typename T UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(4, T))>
+template <typename T UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(4, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
 template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<4>) T
-        UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(4, T))>
+        UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(4, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     static constexpr auto max = UTL_NUMERIC_maximum(T);
     static constexpr int shift = sizeof(l) * CHAR_BIT - 1;
@@ -57,10 +57,10 @@ __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     return l;
 }
 
-template <typename T UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(2, T))>
+template <typename T UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(2, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
 template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<2>) T
-        UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(2, T))>
+        UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(2, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     using w_type = int32_t;
     static constexpr auto max = UTL_NUMERIC_maximum(w_type);
@@ -78,10 +78,10 @@ __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     return l;
 }
 
-template <typename T UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(1, T))>
+template <typename T UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(1, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
 template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<1>) T
-        UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(1, T))>
+        UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(1, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     using w_type = int32_t;
     static constexpr auto max = UTL_NUMERIC_maximum(w_type);
@@ -111,28 +111,28 @@ namespace details {
 namespace add_sat {
 namespace runtime {
 
-template <typename T UTL_REQUIRES_CXX11(UTL_TRAIT_is_sized_signed_integral(4, T))>
+template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_signed_integral(4, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
-template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<4>) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<4>) T UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_sized_signed_integral(4, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     __asm("qadd    %[left], %[left], %[right]" : [left] "+r"(l) : [right] "r"(r) : "cc");
     return l;
 }
 
-template <typename T UTL_REQUIRES_CXX11(UTL_TRAIT_is_sized_signed_integral(2, T))>
+template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_signed_integral(2, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
 
-template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<2>) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<2>) T UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_sized_signed_integral(2, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     __asm("qadd16    %[left], %[left], %[right]" : [left] "+r"(l) : [right] "r"(r) : "cc");
     return l;
 }
 
-template <typename T UTL_REQUIRES_CXX11(UTL_TRAIT_is_sized_signed_integral(1, T))>
+template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_signed_integral(1, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
-template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<1>) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<1>) T UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_sized_signed_integral(1, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     __asm("qadd8    %[left], %[left], %[right]" : [left] "+r"(l) : [right] "r"(r) : "cc");

--- a/src/utl/public/utl/numeric/arm/utl_sub_sat.h
+++ b/src/utl/public/utl/numeric/arm/utl_sub_sat.h
@@ -24,10 +24,10 @@ namespace details {
 namespace sub_sat {
 namespace runtime {
 
-template <typename T UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(8, T))>
+template <typename T UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(8, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
 template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<8>) T
-        UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(8, T))>
+        UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(8, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     static constexpr auto min = UTL_NUMERIC_minimum(T);
     static constexpr int shift = sizeof(l) * CHAR_BIT - 1;
@@ -41,10 +41,10 @@ __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     return l;
 }
 
-template <typename T UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(4, T))>
+template <typename T UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(4, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
 template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<4>) T
-        UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(4, T))>
+        UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(4, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     static constexpr auto min = UTL_NUMERIC_minimum(T);
     static constexpr int shift = sizeof(l) * CHAR_BIT - 1;
@@ -58,10 +58,10 @@ __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     return l;
 }
 
-template <typename T UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(2, T))>
+template <typename T UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(2, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
 template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<2>) T
-        UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(2, T))>
+        UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(2, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     static constexpr auto max = UTL_NUMERIC_maximum(T);
     static constexpr int ls = 2 * CHAR_BIT;
@@ -78,10 +78,10 @@ __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     return l;
 }
 
-template <typename T UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(1, T))>
+template <typename T UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(1, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
 template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<1>) T
-        UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(1, T))>
+        UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(1, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     static constexpr auto max = UTL_NUMERIC_maximum(T);
     static constexpr int ls = 3 * CHAR_BIT;
@@ -110,28 +110,28 @@ namespace details {
 namespace sub_sat {
 namespace runtime {
 
-template <typename T UTL_REQUIRES_CXX11(UTL_TRAIT_is_sized_signed_integral(4, T))>
+template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_signed_integral(4, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
-template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<4>) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<4>) T UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_sized_signed_integral(4, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     __asm("qsub    %[left], %[left], %[right]" : [left] "+r"(l) : [right] "r"(r) : "cc");
     return l;
 }
 
-template <typename T UTL_REQUIRES_CXX11(UTL_TRAIT_is_sized_signed_integral(2, T))>
+template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_signed_integral(2, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
 
-template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<2>) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<2>) T UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_sized_signed_integral(2, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     __asm("qsub16    %[left], %[left], %[right]" : [left] "+r"(l) : [right] "r"(r) : "cc");
     return l;
 }
 
-template <typename T UTL_REQUIRES_CXX11(UTL_TRAIT_is_sized_signed_integral(1, T))>
+template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_signed_integral(1, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
-template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<1>) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<1>) T UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_sized_signed_integral(1, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     __asm("qsub8    %[left], %[left], %[right]" : [left] "+r"(l) : [right] "r"(r) : "cc");

--- a/src/utl/public/utl/numeric/utl_add_sat.h
+++ b/src/utl/public/utl/numeric/utl_add_sat.h
@@ -65,7 +65,7 @@ private:
     value_type result_;
 };
 
-template <UTL_CONCEPT_CXX20(signed_integral) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(signed_integral) T UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_signed(T) && UTL_TRAIT_is_integral(T))>
 __UTL_HIDE_FROM_ABI constexpr T impl(T left, T right) noexcept {
     return signed_impl<T>(left, right).result();
@@ -117,7 +117,7 @@ __UTL_HIDE_FROM_ABI auto has_overload_impl(float) noexcept -> __UTL false_type;
 template <typename T>
 using has_overload = decltype(__UTL details::add_sat::runtime::has_overload_impl<T>(0));
 
-template <UTL_CONCEPT_CXX20(signed_integral) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(signed_integral) T UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_signed(T) && UTL_TRAIT_is_integral(T) && !has_overload<T>::value)>
 __UTL_HIDE_FROM_ABI T impl(T left, T right) noexcept {
     return __UTL details::add_sat::compile_time::impl(left, right);
@@ -125,7 +125,7 @@ __UTL_HIDE_FROM_ABI T impl(T left, T right) noexcept {
 
 } // namespace runtime
 
-template <UTL_CONCEPT_CXX20(signed_integral) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(signed_integral) T UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_signed(T) && UTL_TRAIT_is_integral(T) && !runtime::has_overload<T>::value)>
 __UTL_HIDE_FROM_ABI constexpr T impl(T left, T right) noexcept {
     return UTL_CONSTANT_P(left == right) ? __UTL details::add_sat::compile_time::impl(left, right)
@@ -137,7 +137,7 @@ __UTL_HIDE_FROM_ABI constexpr T saturate(T result, T left) noexcept {
     return result | -(result < left);
 }
 
-template <UTL_CONCEPT_CXX20(unsigned_integral) T UTL_REQUIRES_CXX11(UTL_TRAIT_is_unsigned(T))>
+template <UTL_CONCEPT_CXX20(unsigned_integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_unsigned(T))>
 __UTL_HIDE_FROM_ABI constexpr T impl(T left, T right) noexcept {
     return __UTL details::add_sat::saturate(left + right, left);
 }
@@ -145,7 +145,7 @@ __UTL_HIDE_FROM_ABI constexpr T impl(T left, T right) noexcept {
 } // namespace add_sat
 } // namespace details
 
-template <UTL_CONCEPT_CXX20(saturatable) T UTL_REQUIRES_CXX11(UTL_TRAIT_is_saturatable(T))>
+template <UTL_CONCEPT_CXX20(saturatable) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_saturatable(T))>
 UTL_ATTRIBUTES(NODISCARD, CONST, _HIDE_FROM_ABI, FLATTEN) constexpr T add_sat(T left, T right) noexcept {
     return __UTL details::add_sat::impl(left, right);
 }

--- a/src/utl/public/utl/numeric/utl_sub_sat.h
+++ b/src/utl/public/utl/numeric/utl_sub_sat.h
@@ -63,7 +63,7 @@ private:
     value_type result_;
 };
 
-template <UTL_CONCEPT_CXX20(signed_integral) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(signed_integral) T UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_signed(T) && UTL_TRAIT_is_integral(T))>
 __UTL_HIDE_FROM_ABI constexpr T impl(T left, T right) noexcept {
     return signed_impl<T>(left, right).result();
@@ -115,7 +115,7 @@ __UTL_HIDE_FROM_ABI auto has_overload_impl(float) noexcept -> __UTL false_type;
 template <typename T>
 using has_overload = decltype(__UTL details::sub_sat::runtime::has_overload_impl<T>(0));
 
-template <UTL_CONCEPT_CXX20(signed_integral) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(signed_integral) T UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_signed(T) && UTL_TRAIT_is_integral(T) && !has_overload<T>::value)>
 __UTL_HIDE_FROM_ABI T impl(T left, T right) noexcept {
     return __UTL details::sub_sat::compile_time::impl(left, right);
@@ -123,7 +123,7 @@ __UTL_HIDE_FROM_ABI T impl(T left, T right) noexcept {
 
 } // namespace runtime
 
-template <UTL_CONCEPT_CXX20(signed_integral) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(signed_integral) T UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_signed(T) && UTL_TRAIT_is_integral(T) && !runtime::has_overload<T>::value)>
 __UTL_HIDE_FROM_ABI constexpr T impl(T left, T right) noexcept {
     return UTL_CONSTANT_P(left == right) ? __UTL details::sub_sat::compile_time::impl(left, right)
@@ -135,7 +135,7 @@ __UTL_HIDE_FROM_ABI constexpr T saturate(T result, T left) noexcept {
     return result & -(result <= left);
 }
 
-template <UTL_CONCEPT_CXX20(unsigned_integral) T UTL_REQUIRES_CXX11(UTL_TRAIT_is_unsigned(T))>
+template <UTL_CONCEPT_CXX20(unsigned_integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_unsigned(T))>
 __UTL_HIDE_FROM_ABI constexpr T impl(T left, T right) noexcept {
     return __UTL details::sub_sat::saturate(left - right, left);
 }
@@ -143,7 +143,7 @@ __UTL_HIDE_FROM_ABI constexpr T impl(T left, T right) noexcept {
 } // namespace sub_sat
 } // namespace details
 
-template <UTL_CONCEPT_CXX20(saturatable) T UTL_REQUIRES_CXX11(UTL_TRAIT_is_saturatable(T))>
+template <UTL_CONCEPT_CXX20(saturatable) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_saturatable(T))>
 UTL_ATTRIBUTES(NODISCARD, CONST, _HIDE_FROM_ABI, FLATTEN) constexpr T sub_sat(T left, T right) noexcept {
     return __UTL details::sub_sat::impl(left, right);
 }

--- a/src/utl/public/utl/numeric/x86/utl_add_sat.h
+++ b/src/utl/public/utl/numeric/x86/utl_add_sat.h
@@ -23,10 +23,10 @@ namespace add_sat {
 namespace runtime {
 
 #  if UTL_ARCH_x86_64
-template <typename T UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(8, T))>
+template <typename T UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(8, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
 template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<8>) T
-        UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(8, T))>
+        UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(8, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     auto sat = l;
     // Need to move imm64 to a register before it is usable
@@ -43,10 +43,10 @@ __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
 }
 #  endif // UTL_ARCH_x86_64
 
-template <typename T UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(4, T))>
+template <typename T UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(4, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
 template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<4>) T
-        UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(4, T))>
+        UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(4, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     static constexpr auto max = UTL_NUMERIC_maximum(T);
     static constexpr int shift = sizeof(l) * CHAR_BIT - 1;
@@ -61,10 +61,10 @@ __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     return sat;
 }
 
-template <typename T UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(2, T))>
+template <typename T UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(2, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
 template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<2>) T
-        UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(2, T))>
+        UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(2, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     static constexpr auto max = UTL_NUMERIC_maximum(T);
     static constexpr int shift = sizeof(l) * CHAR_BIT - 1;
@@ -79,10 +79,10 @@ __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     return sat;
 }
 
-template <typename T UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(1, T))>
+template <typename T UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(1, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
 template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<1>) T
-        UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(1, T))>
+        UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(1, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     using x86w = int16_t;
     static constexpr x86w max = UTL_NUMERIC_maximum(T);
@@ -117,9 +117,9 @@ namespace add_sat {
 namespace runtime {
 
 #  if UTL_ARCH_x86_64
-template <typename T UTL_REQUIRES_CXX11(UTL_TRAIT_is_sized_signed_integral(8, T))>
+template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_signed_integral(8, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
-template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<8>) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<8>) T UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_sized_signed_integral(8, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     static constexpr int shift = sizeof(l) * CHAR_BIT - 1;
@@ -129,9 +129,9 @@ __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
 }
 #  endif // UTL_ARCH_x86_64
 
-template <typename T UTL_REQUIRES_CXX11(UTL_TRAIT_is_sized_signed_integral(4, T))>
+template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_signed_integral(4, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
-template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<4>) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<4>) T UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_sized_signed_integral(4, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     static constexpr int shift = sizeof(l) * CHAR_BIT - 1;
@@ -140,9 +140,9 @@ __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     return !_addcarry_u32(0, l, r, &tmp) ? __UTL to_signed(tmp) : sat;
 }
 
-template <typename T UTL_REQUIRES_CXX11(UTL_TRAIT_is_sized_signed_integral(2, T))>
+template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_signed_integral(2, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
-template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<2>) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<2>) T UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_sized_signed_integral(2, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     static constexpr int shift = sizeof(l) * CHAR_BIT - 1;
@@ -151,9 +151,9 @@ __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     return !_addcarry_u16(0, l, r, &tmp) ? __UTL to_signed(tmp) : sat;
 }
 
-template <typename T UTL_REQUIRES_CXX11(UTL_TRAIT_is_sized_signed_integral(1, T))>
+template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_signed_integral(1, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
-template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<1>) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<1>) T UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_sized_signed_integral(1, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     static constexpr int shift = sizeof(l) * CHAR_BIT - 1;

--- a/src/utl/public/utl/numeric/x86/utl_sub_sat.h
+++ b/src/utl/public/utl/numeric/x86/utl_sub_sat.h
@@ -23,10 +23,10 @@ namespace sub_sat {
 namespace runtime {
 
 #  if UTL_ARCH_x86_64
-template <typename T UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(8, T))>
+template <typename T UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(8, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
 template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<8>) T
-        UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(8, T))>
+        UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(8, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     auto sat = l;
     // Need to move imm64 to a register before it is usable
@@ -43,10 +43,10 @@ __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
 }
 #  endif // UTL_ARCH_x86_64
 
-template <typename T UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(4, T))>
+template <typename T UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(4, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
 template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<4>) T
-        UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(4, T))>
+        UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(4, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     static constexpr auto max = UTL_NUMERIC_maximum(T);
     static constexpr int shift = sizeof(l) * CHAR_BIT - 1;
@@ -61,10 +61,10 @@ __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     return sat;
 }
 
-template <typename T UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(2, T))>
+template <typename T UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(2, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
 template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<2>) T
-        UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(2, T))>
+        UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(2, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     static constexpr auto max = UTL_NUMERIC_maximum(T);
     static constexpr int shift = sizeof(l) * CHAR_BIT - 1;
@@ -79,10 +79,10 @@ __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     return sat;
 }
 
-template <typename T UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(1, T))>
+template <typename T UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(1, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
 template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<1>) T
-        UTL_REQUIRES_CXX11( UTL_TRAIT_is_sized_signed_integral(1, T))>
+        UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_sized_signed_integral(1, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     using x86w = int16_t;
     static constexpr x86w max = UTL_NUMERIC_maximum(T);
@@ -118,9 +118,9 @@ namespace sub_sat {
 namespace runtime {
 
 #  if UTL_ARCH_x86_64
-template <typename T UTL_REQUIRES_CXX11(UTL_TRAIT_is_sized_signed_integral(8, T))>
+template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_signed_integral(8, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
-template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<8>) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<8>) T UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_sized_signed_integral(8, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     static constexpr int shift = sizeof(l) * CHAR_BIT - 1;
@@ -130,9 +130,9 @@ __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
 }
 #  endif // UTL_ARCH_x86_64
 
-template <typename T UTL_REQUIRES_CXX11(UTL_TRAIT_is_sized_signed_integral(4, T))>
+template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_signed_integral(4, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
-template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<4>) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<4>) T UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_sized_signed_integral(4, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     static constexpr int shift = sizeof(l) * CHAR_BIT - 1;
@@ -141,9 +141,9 @@ __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     return !_subborrow_u32(0, l, r, &tmp) ? __UTL to_signed(tmp) : sat;
 }
 
-template <typename T UTL_REQUIRES_CXX11(UTL_TRAIT_is_sized_signed_integral(2, T))>
+template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_signed_integral(2, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
-template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<2>) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<2>) T UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_sized_signed_integral(2, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     static constexpr int shift = sizeof(l) * CHAR_BIT - 1;
@@ -152,9 +152,9 @@ __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     return !_subborrow_u16(0, l, r, &tmp) ? __UTL to_signed(tmp) : sat;
 }
 
-template <typename T UTL_REQUIRES_CXX11(UTL_TRAIT_is_sized_signed_integral(1, T))>
+template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_signed_integral(1, T))>
 __UTL_HIDE_FROM_ABI auto has_overload_impl(int) noexcept -> __UTL true_type;
-template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<1>) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(__UTL sized_signed_integral<1>) T UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_sized_signed_integral(1, T))>
 __UTL_HIDE_FROM_ABI T impl(T l, T r) noexcept {
     static constexpr int shift = sizeof(l) * CHAR_BIT - 1;

--- a/src/utl/public/utl/scope/utl_scope_exit.h
+++ b/src/utl/public/utl/scope/utl_scope_exit.h
@@ -24,7 +24,7 @@ class UTL_ATTRIBUTES(
     using move_t UTL_NODEBUG = conditional_t<is_movable::value, scope_exit, invalid_t>;
 
 public:
-    template <UTL_CONCEPT_CXX20(constructible_as<F, add_rvalue_reference>) Fn UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(constructible_as<F, add_rvalue_reference>) Fn UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_constructible(F, Fn&&))>
     __UTL_HIDE_FROM_ABI explicit scope_exit(Fn&& func) noexcept(
         UTL_TRAIT_is_nothrow_constructible(F, Fn&&))

--- a/src/utl/public/utl/scope/utl_scope_fail.h
+++ b/src/utl/public/utl/scope/utl_scope_fail.h
@@ -28,7 +28,7 @@ class
 
 public:
     template <UTL_CONCEPT_CXX20(constructible_as<F, add_rvalue_reference>) Fn
-            UTL_REQUIRES_CXX11(UTL_TRAIT_is_constructible(F, Fn&&))>
+            UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_constructible(F, Fn&&))>
     __UTL_HIDE_FROM_ABI explicit scope_fail(Fn&& func) noexcept(
         UTL_TRAIT_is_nothrow_constructible(F, Fn&&))
         : base_type(__UTL forward<Fn>(func))

--- a/src/utl/public/utl/scope/utl_scope_impl.h
+++ b/src/utl/public/utl/scope/utl_scope_impl.h
@@ -33,7 +33,7 @@ private:
     using not_move_t UTL_NODEBUG = conditional_t<is_movable::value, invalid_t, impl>;
 
 protected:
-    template <UTL_CONCEPT_CXX20(constructible_as<F, add_rvalue_reference>) Fn UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(constructible_as<F, add_rvalue_reference>) Fn UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_constructible(F, Fn&&))>
     __UTL_HIDE_FROM_ABI constexpr impl(Fn&& func) noexcept(
         UTL_TRAIT_is_nothrow_constructible(F, Fn&&))
@@ -56,13 +56,13 @@ protected:
     }
 
 private:
-    template <UTL_CONCEPT_CXX20(same_as<invalid_t>) T UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(same_as<invalid_t>) T UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_same(T, invalid_t))>
     __UTL_HIDE_FROM_ABI impl(false_type, T&& other) noexcept;
 
-    template <UTL_CONCEPT_CXX20(same_as<impl>) T = impl UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(same_as<impl>) T = impl UTL_CONSTRAINT_CXX11(
         is_movable::value && UTL_TRAIT_is_same(T, impl))>
-    UTL_REQUIRES_CXX20(is_movable::value)
+    UTL_CONSTRAINT_CXX20(is_movable::value)
     __UTL_HIDE_FROM_ABI constexpr impl(true_type, T&& other) noexcept
         : callable_(__UTL move(other.callable_))
         , released_(other.released_) {

--- a/src/utl/public/utl/scope/utl_scope_success.h
+++ b/src/utl/public/utl/scope/utl_scope_success.h
@@ -27,7 +27,7 @@ class UTL_ATTRIBUTES(_PUBLIC_TEMPLATE, NODISCARD) scope_success :
 
 public:
     template <UTL_CONCEPT_CXX20(constructible_as<F, add_rvalue_reference>) Fn
-            UTL_REQUIRES_CXX11(UTL_TRAIT_is_constructible(F, Fn&&))>
+            UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_constructible(F, Fn&&))>
     __UTL_HIDE_FROM_ABI explicit scope_success(Fn&& func) noexcept(
         UTL_TRAIT_is_nothrow_constructible(F, Fn&&))
         : base_type(__UTL forward<Fn>(func))

--- a/src/utl/public/utl/string/utl_basic_short_string.h
+++ b/src/utl/public/utl/string/utl_basic_short_string.h
@@ -192,7 +192,7 @@ public:
         assign(str, len);
     }
 
-    template <UTL_CONCEPT_CXX20(__UTL legacy_input_iterator) It UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(__UTL legacy_input_iterator) It UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_legacy_input_iterator(It))>
     __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string(
         It first, It last, allocator_type const& a = allocator_type()) UTL_THROWS
@@ -214,7 +214,7 @@ public:
         resize(count, ch);
     }
 
-    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
     __UTL_ABI_PRIVATE explicit UTL_CONSTEXPR_CXX14 basic_short_string(View const& view,
         allocator_type const& a = allocator_type()) noexcept(!utl::with_exceptions &&
@@ -223,7 +223,7 @@ public:
         assign(view);
     }
 
-    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
     __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string(View const& view, size_type pos, size_type n,
         allocator_type const& a = allocator_type()) noexcept(!utl::with_exceptions &&
@@ -386,9 +386,9 @@ public:
         size_ = new_size;
     }
 
-    template <typename Op UTL_REQUIRES_CXX11(
+    template <typename Op UTL_CONSTRAINT_CXX11(
         is_integral<decltype(__UTL declval<Op>()(char_pointer{}, size_type{}))>::value)>
-    UTL_REQUIRES_CXX20(requires(Op op, char_pointer p, size_type s) {
+    UTL_CONSTRAINT_CXX20(requires(Op op, char_pointer p, size_type s) {
         { op(p, s) } -> integral;
     })
     __UTL_ABI_PRIVATE UTL_CONSTEXPR_WITH_TRY void resize_and_overwrite(
@@ -553,7 +553,7 @@ public:
         assign(str, traits_type::length(str));
     }
 
-    template <UTL_CONCEPT_CXX20(__UTL legacy_input_iterator) It UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(__UTL legacy_input_iterator) It UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_legacy_input_iterator(It) && !UTL_TRAIT_is_legacy_forward_iterator(It))>
     __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& assign(It begin, It end)
         UTL_THROWS UTL_LIFETIMEBOUND {
@@ -564,7 +564,7 @@ public:
         }
     }
 
-    template <UTL_CONCEPT_CXX20(__UTL legacy_forward_iterator) It UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(__UTL legacy_forward_iterator) It UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_legacy_forward_iterator(It))>
     __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX17 basic_short_string& assign(It begin, It end)
         UTL_THROWS UTL_LIFETIMEBOUND {
@@ -588,7 +588,7 @@ public:
         assign(list.begin(), list.end());
     }
 
-    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
     __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& assign(View const& view)
         UTL_THROWS UTL_LIFETIMEBOUND {
@@ -596,7 +596,7 @@ public:
         return assign(v.data(), v.size());
     }
 
-    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
     __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& assign(View const& view, size_type subidx,
         size_type subcount = npos) UTL_THROWS UTL_LIFETIMEBOUND {
@@ -673,7 +673,7 @@ public:
         return insert(pos, 1, ch);
     }
 
-    template <UTL_CONCEPT_CXX20(__UTL legacy_input_iterator) It UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(__UTL legacy_input_iterator) It UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_legacy_input_iterator(It) && !UTL_TRAIT_is_legacy_forward_iterator(It))>
     __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 iterator insert(const_iterator pos, It first, It last)
         UTL_THROWS UTL_LIFETIMEBOUND {
@@ -686,7 +686,7 @@ public:
         return iterator(begin() + idx);
     }
 
-    template <UTL_CONCEPT_CXX20(__UTL legacy_forward_iterator) It UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(__UTL legacy_forward_iterator) It UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_legacy_forward_iterator(It))>
     __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 iterator insert(const_iterator pos, It first, It last)
         UTL_THROWS UTL_LIFETIMEBOUND {
@@ -715,7 +715,7 @@ public:
         return insert(pos, list.begin(), list.size());
     }
 
-    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
     __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& insert(size_type pos, View const& view)
         UTL_THROWS UTL_LIFETIMEBOUND {
@@ -723,7 +723,7 @@ public:
         return insert(pos, v.data(), v.size());
     }
 
-    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
     __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& insert(size_type pos, View const& view,
         size_type subidx, size_type subcount = npos) UTL_THROWS UTL_LIFETIMEBOUND {
@@ -791,7 +791,7 @@ public:
         return insert(size(), str, count);
     }
 
-    template <UTL_CONCEPT_CXX20(__UTL legacy_input_iterator) It UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(__UTL legacy_input_iterator) It UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_legacy_input_iterator(It))>
     __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& append(It first, It last)
         UTL_THROWS UTL_LIFETIMEBOUND {
@@ -803,14 +803,14 @@ public:
         return insert(size(), list.begin(), list.size());
     }
 
-    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
     __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& append(View const& view)
         UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(size(), view);
     }
 
-    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
     __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& append(View const& view, size_type subidx,
         size_type subcount = npos) UTL_THROWS UTL_LIFETIMEBOUND {
@@ -844,7 +844,7 @@ public:
         return append(list);
     }
 
-    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
     __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& operator+=(View const& view)
         UTL_THROWS UTL_LIFETIMEBOUND {
@@ -941,7 +941,7 @@ public:
         return *this;
     }
 
-    template <UTL_CONCEPT_CXX20(__UTL legacy_input_iterator) It UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(__UTL legacy_input_iterator) It UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_legacy_input_iterator(It))>
     __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
         const_iterator last, It in_first, It in_last) UTL_THROWS UTL_LIFETIMEBOUND {
@@ -962,7 +962,7 @@ public:
         return replace(first, last, list.begin(), list.size());
     }
 
-    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
     __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
         const_iterator last, View const& view) UTL_THROWS UTL_LIFETIMEBOUND {
@@ -970,7 +970,7 @@ public:
         return replace(first, last, v.data(), v.size());
     }
 
-    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
     __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
         const_iterator last, View const& view, size_type subidx, size_type subcount = npos)
@@ -985,7 +985,7 @@ public:
         return replace(first, last, v.substr(subidx, subcount));
     }
 
-    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
     __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& replace(
         size_type idx, size_type count, View const& view) UTL_THROWS UTL_LIFETIMEBOUND {
@@ -993,7 +993,7 @@ public:
         return replace(first, first + count, view);
     }
 
-    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
     __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& replace(size_type idx, size_type count,
         View const& view, size_type subidx, size_type subcount = npos)
@@ -1057,7 +1057,7 @@ public:
         return find(view.data(), pos, view.size());
     }
 
-    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
     UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) constexpr size_type find(View const& view, size_type pos = 0) const
         noexcept(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
@@ -1089,7 +1089,7 @@ public:
         return rfind(view.data(), pos, view.size());
     }
 
-    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
     UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) constexpr size_type rfind(View const& view,
         size_type pos = npos) const noexcept(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
@@ -1123,7 +1123,7 @@ public:
         return find_first_of(view.data(), pos, view.size());
     }
 
-    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
     UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) constexpr size_type find_first_of(View const& view,
         size_type pos = 0) const noexcept(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
@@ -1158,7 +1158,7 @@ public:
         return find_first_not_of(view.data(), pos, view.size());
     }
 
-    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
     UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) constexpr size_type find_first_not_of(View const& view,
         size_type pos = 0) const noexcept(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
@@ -1192,7 +1192,7 @@ public:
         return find_last_of(view.data(), pos, view.size());
     }
 
-    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
     UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) constexpr size_type find_last_of(View const& view,
         size_type pos = npos) const noexcept(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
@@ -1226,7 +1226,7 @@ public:
         return find_last_not_of(view.data(), pos, view.size());
     }
 
-    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
     UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) constexpr size_type find_last_not_of(View const& view,
         size_type pos = npos) const UTL_NOEXCEPT(UTL_TRAIT_is_nothrow_convertible(View,
@@ -1247,7 +1247,7 @@ public:
         return details::string::compare<traits_type>(data(), size(), view.data(), view.size());
     }
 
-    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_REQUIRES_CXX11(is_convertible<View, view_type>::value)>
+    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(is_convertible<View, view_type>::value)>
     UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) UTL_CONSTEXPR_CXX14 int compare(View const& view) const
         noexcept(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
         return compare(view_type(view));
@@ -1283,7 +1283,7 @@ public:
         return compare(pos, count, view.data(), view.size());
     }
 
-    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
     UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE)
     UTL_CONSTEXPR_CXX14 int compare(size_type pos, size_type count,
@@ -1313,7 +1313,7 @@ public:
         return compare(pos, count, view.substr(pos2, count2));
     }
 
-    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
     UTL_ATTRIBUTES(NODISCARD, PURE, _ABI_PRIVATE)
     UTL_CONSTEXPR_CXX14 int compare(size_type pos, size_type count,

--- a/src/utl/public/utl/string/utl_basic_string_view.h
+++ b/src/utl/public/utl/string/utl_basic_string_view.h
@@ -83,7 +83,7 @@ public:
         , size_(traits_type::length(data)) {}
 
     template <UTL_CONCEPT_CXX20(contiguous_iterator) It,
-        UTL_CONCEPT_CXX20(sized_sentinel_for<It>) E UTL_REQUIRES_CXX11(
+        UTL_CONCEPT_CXX20(sized_sentinel_for<It>) E UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_contiguous_iterator(It) && UTL_TRAIT_is_sized_sentinel_for(E, It))>
     __UTL_HIDE_FROM_ABI constexpr basic_string_view(It begin, E end) noexcept(
         UTL_TRAIT_is_nothrow_dereferenceable(It) && noexcept(end - begin))

--- a/src/utl/public/utl/string/utl_basic_zstring_view.h
+++ b/src/utl/public/utl/string/utl_basic_zstring_view.h
@@ -56,7 +56,7 @@ public:
         : base_type(data, traits_type::length(data)) {}
 
     template <UTL_CONCEPT_CXX20(contiguous_iterator) It,
-        UTL_CONCEPT_CXX20(sized_sentinel_for<It>) E UTL_REQUIRES_CXX11(
+        UTL_CONCEPT_CXX20(sized_sentinel_for<It>) E UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_contiguous_iterator(It) && UTL_TRAIT_is_sized_sentinel_for(E, It))>
     __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_zstring_view(It begin, E end)
         UTL_NOEXCEPT(UTL_TRAIT_is_nothrow_dereferenceable(It)&& noexcept(end - begin))

--- a/src/utl/public/utl/string/utl_libc.h
+++ b/src/utl/public/utl/string/utl_libc.h
@@ -41,29 +41,29 @@ __UTL_HIDE_FROM_ABI constexpr T* memset(T* dst, T const src, element_count_t cou
 }
 } // namespace unsafe
 
-template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_CONSTRAINT_CXX11(
     is_trivially_copyable<T>::value)>
 __UTL_HIDE_FROM_ABI constexpr T* memcpy(
     T* UTL_RESTRICT dst, T const* UTL_RESTRICT src, element_count_t count) noexcept {
     return unsafe::memcpy(dst, src, count);
 }
 
-template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_CONSTRAINT_CXX11(
     is_trivially_copyable<T>::value)>
 __UTL_HIDE_FROM_ABI constexpr T* memmove(T* dst, T const* src, element_count_t count) noexcept {
     return unsafe::memmove(dst, src, count);
 }
 
-template <UTL_CONCEPT_CXX20(exact_size<1>) T, UTL_CONCEPT_CXX20(exact_size<1>) U UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(exact_size<1>) T, UTL_CONCEPT_CXX20(exact_size<1>) U UTL_CONSTRAINT_CXX11(
     exact_size<T, 1>::value && exact_size<U, 1>::value)>
 UTL_ATTRIBUTE(LIBC_PURE) constexpr T* memchr(T const* str, U value, size_t bytes) noexcept {
     return UTL_CONSTANT_P((value, str + bytes)) ? compile_time::memchr(str, value, bytes)
                                                 : runtime::memchr(str, value, bytes);
 }
 
-template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_CONSTRAINT_CXX11(
     is_trivially_copyable<T>::value && exact_size<T, 1>::value)>
-UTL_REQUIRES_CXX20(exact_size<T, 1>)
+UTL_CONSTRAINT_CXX20(exact_size<T, 1>)
 __UTL_HIDE_FROM_ABI constexpr T* memset(T* dst, T const src, element_count_t count) noexcept {
     return unsafe::memset(dst, src, count);
 }
@@ -75,23 +75,23 @@ UTL_ATTRIBUTE(LIBC_PURE) constexpr int memcmp(T const* lhs, U const* rhs, elemen
     return unsafe::memcmp(lhs, rhs, count);
 }
 
-template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
 UTL_ATTRIBUTE(LIBC_PURE) constexpr size_t strlen(T const* str) noexcept {
     return UTL_CONSTANT_P(str) ? compile_time::strlen(str) : runtime::strlen(str);
 }
 
-template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
 UTL_ATTRIBUTE(LIBC_PURE) constexpr T* strchr(T const* str, T const ch) noexcept {
     return UTL_CONSTANT_P((ch, str)) ? compile_time::strchr(str, ch) : runtime::strchr(str, ch);
 }
 
-template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
 UTL_ATTRIBUTE(LIBC_PURE) constexpr int strcmp(T const* left, T const* right) noexcept {
     return UTL_CONSTANT_P(left != right) ? compile_time::strcmp(left, right)
                                          : runtime::strcmp(left, right);
 }
 
-template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
 UTL_ATTRIBUTE(LIBC_PURE) constexpr int strncmp(
     T const* left, T const* right, element_count_t max_len) noexcept {
     return UTL_CONSTANT_P(left + max_len != right + max_len)
@@ -99,13 +99,13 @@ UTL_ATTRIBUTE(LIBC_PURE) constexpr int strncmp(
         : runtime::strncmp(left, right, max_len);
 }
 
-template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
 __UTL_HIDE_FROM_ABI constexpr T* strnset(T* dst, T const val, element_count_t max_len) noexcept {
     return UTL_CONSTANT_P((dst + max_len, val)) ? compile_time::strnset(dst, val, max_len)
                                                 : runtime::strnset(dst, val, max_len);
 }
 
-template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
 UTL_ATTRIBUTE(LIBC_PURE) constexpr T* strnchr(T const* str, T const ch, element_count_t max_len) noexcept {
     return UTL_CONSTANT_P((str + max_len, ch)) ? compile_time::strnchr(str, ch, max_len)
                                                : runtime::strnchr(str, ch, max_len);

--- a/src/utl/public/utl/string/utl_libc_common.h
+++ b/src/utl/public/utl/string/utl_libc_common.h
@@ -61,7 +61,7 @@ template <typename T, size_t N>
 using exact_size UTL_NODEBUG = bool_constant<!UTL_TRAIT_is_empty(T) && (sizeof(T) == N)>;
 #endif
 
-template <UTL_CONCEPT_CXX20(exact_size<1>) T UTL_REQUIRES_CXX11(exact_size<T, 1>::value)>
+template <UTL_CONCEPT_CXX20(exact_size<1>) T UTL_CONSTRAINT_CXX11(exact_size<T, 1>::value)>
 UTL_ATTRIBUTE(LIBC_API) unsigned char as_byte(T val) noexcept {
     return *((unsigned char const*)&val);
 }

--- a/src/utl/public/utl/string/utl_libc_compile_time.h
+++ b/src/utl/public/utl/string/utl_libc_compile_time.h
@@ -49,8 +49,8 @@ __UTL_HIDE_FROM_ABI constexpr int memcmp(
         : __UTL libc::compile_time::recursive::memcmp(left + 1, right + 1, count - 1);
 }
 
-template <UTL_CONCEPT_CXX20(exact_size<1>) T, UTL_CONCEPT_CXX20(exact_size<1>) U UTL_REQUIRES_CXX11(
-    exact_size<T, 1>::value && exact_size<U, 1>::value)>
+template <UTL_CONCEPT_CXX20(exact_size<1>) T, UTL_CONCEPT_CXX20(
+    exact_size<1>) U UTL_CONSTRAINT_CXX11(exact_size<T, 1>::value && exact_size<U, 1>::value)>
 __UTL_HIDE_FROM_ABI constexpr T* memchr(T const* str, U value, size_t bytes) noexcept {
     return bytes == 0   ? nullptr
         : *str == value ? const_cast<T*>(str)
@@ -106,7 +106,7 @@ __UTL_HIDE_FROM_ABI constexpr T* strnset(
 
 } // namespace recursive
 
-template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_CONSTRAINT_CXX11(
     is_trivially_copyable<T>::value)>
 __UTL_HIDE_FROM_ABI constexpr T* memcpy(T* dst, T const* src, element_count_t count) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_memcpy)
@@ -116,9 +116,9 @@ __UTL_HIDE_FROM_ABI constexpr T* memcpy(T* dst, T const* src, element_count_t co
 #endif
 }
 
-template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_CONSTRAINT_CXX11(
     is_trivially_copyable<T>::value && exact_size<T, 1>::value)>
-UTL_REQUIRES_CXX20(exact_size<T, 1>)
+UTL_CONSTRAINT_CXX20(exact_size<T, 1>)
 __UTL_HIDE_FROM_ABI constexpr T* memset(T* dst, T const src, element_count_t count) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_memset)
     return __builtin_memset(dst, as_byte(src), byte_count<T>(count)), dst;
@@ -127,7 +127,7 @@ __UTL_HIDE_FROM_ABI constexpr T* memset(T* dst, T const src, element_count_t cou
 #endif
 }
 
-template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_CONSTRAINT_CXX11(
     is_trivially_copyable<T>::value)>
 __UTL_HIDE_FROM_ABI constexpr T* memmove(T* dst, T const* src, element_count_t count) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_memmove)
@@ -157,8 +157,8 @@ __UTL_HIDE_FROM_ABI constexpr char* memchr(char const* str, char value, size_t b
 #endif
 }
 
-template <UTL_CONCEPT_CXX20(exact_size<1>) T, UTL_CONCEPT_CXX20(exact_size<1>) U UTL_REQUIRES_CXX11(
-    exact_size<T, 1>::value && exact_size<U, 1>::value)>
+template <UTL_CONCEPT_CXX20(exact_size<1>) T, UTL_CONCEPT_CXX20(
+    exact_size<1>) U UTL_CONSTRAINT_CXX11(exact_size<T, 1>::value && exact_size<U, 1>::value)>
 __UTL_HIDE_FROM_ABI constexpr T* memchr(T const* str, U value, size_t bytes) noexcept {
     return recursive::memchr(str, as_byte(value), bytes);
 }
@@ -179,7 +179,7 @@ __UTL_HIDE_FROM_ABI constexpr size_t strlen(wchar_t const* str) noexcept {
 #endif
 }
 
-template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
 __UTL_HIDE_FROM_ABI constexpr size_t strlen(T const* str) noexcept {
     return recursive::strlen(str);
 }
@@ -200,7 +200,7 @@ __UTL_HIDE_FROM_ABI constexpr wchar_t* strchr(wchar_t const* str, wchar_t const 
 #endif
 }
 
-template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
 __UTL_HIDE_FROM_ABI constexpr T* strchr(T const* str, T const ch) noexcept {
     return recursive::strchr(str, ch);
 }
@@ -221,7 +221,7 @@ __UTL_HIDE_FROM_ABI constexpr int strcmp(wchar_t const* left, wchar_t const* rig
 #endif
 }
 
-template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
 __UTL_HIDE_FROM_ABI constexpr int strcmp(T const* left, T const* right) noexcept {
     return recursive::strcmp(left, right);
 }
@@ -244,18 +244,18 @@ __UTL_HIDE_FROM_ABI constexpr int strncmp(
 #endif
 }
 
-template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
 __UTL_HIDE_FROM_ABI constexpr int strncmp(
     T const* left, T const* right, element_count_t len) noexcept {
     return recursive::strncmp(left, right, len);
 }
 
-template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
 __UTL_HIDE_FROM_ABI constexpr T* strnset(T* dst, T const val, element_count_t max_len) noexcept {
     return recursive::strnset(dst, val, max_len, dst);
 }
 
-template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
 __UTL_HIDE_FROM_ABI constexpr T* strnchr(
     T const* str, T const val, element_count_t max_len) noexcept {
     return recursive::strnchr(str, val, max_len);

--- a/src/utl/public/utl/string/utl_libc_runtime.h
+++ b/src/utl/public/utl/string/utl_libc_runtime.h
@@ -22,7 +22,7 @@ namespace standard {
 #  pragma intrinsic(memcpy)
 #endif
 
-template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_REQUIRES_CXX11(is_trivially_copyable<T>::value)>
+template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_CONSTRAINT_CXX11(is_trivially_copyable<T>::value)>
 UTL_ATTRIBUTES(ALWAYS_INLINE,_HIDE_FROM_ABI) inline T* memcpy(
     T* UTL_RESTRICT dst, T const* UTL_RESTRICT src, element_count_t count) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_memcpy)
@@ -32,7 +32,7 @@ UTL_ATTRIBUTES(ALWAYS_INLINE,_HIDE_FROM_ABI) inline T* memcpy(
 #endif
 }
 
-template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_REQUIRES_CXX11(is_trivially_copyable<T>::value)>
+template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_CONSTRAINT_CXX11(is_trivially_copyable<T>::value)>
 UTL_ATTRIBUTES(ALWAYS_INLINE,_HIDE_FROM_ABI) inline T* memmove(
     T* dst, T const* src, element_count_t count) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_memcpy)
@@ -46,9 +46,9 @@ UTL_ATTRIBUTES(ALWAYS_INLINE,_HIDE_FROM_ABI) inline T* memmove(
 #  pragma intrinsic(memset)
 #endif
 
-template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_CONSTRAINT_CXX11(
     is_trivially_copyable<T>::value && exact_size<T, 1>::value)>
-UTL_REQUIRES_CXX20(exact_size<T, 1>)
+UTL_CONSTRAINT_CXX20(exact_size<T, 1>)
 UTL_ATTRIBUTES(ALWAYS_INLINE, _HIDE_FROM_ABI) inline T* memset(
     T* dst, T const value, element_count_t count) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_memcpy)
@@ -58,7 +58,7 @@ UTL_ATTRIBUTES(ALWAYS_INLINE, _HIDE_FROM_ABI) inline T* memset(
 #endif
 }
 
-template <UTL_CONCEPT_CXX20(exact_size<1>) T, UTL_CONCEPT_CXX20(exact_size<1>) U UTL_REQUIRES_CXX11(
+template <UTL_CONCEPT_CXX20(exact_size<1>) T, UTL_CONCEPT_CXX20(exact_size<1>) U UTL_CONSTRAINT_CXX11(
     exact_size<T, 1>::value && exact_size<U, 1>::value)>
 UTL_ATTRIBUTES(LIBC_INLINE_PURE) inline T* memchr(T const* ptr, U value, size_t bytes) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_char_memchr)
@@ -103,7 +103,7 @@ UTL_ATTRIBUTES(LIBC_INLINE_PURE) inline size_t strlen(wchar_t const* str) noexce
 #endif
 }
 
-template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
 UTL_ATTRIBUTES(LIBC_PURE) inline size_t strlen(T const* str) noexcept {
     size_t count = 0;
     while (*str) {
@@ -130,7 +130,7 @@ UTL_ATTRIBUTES(LIBC_INLINE_PURE) inline wchar_t* strchr(wchar_t const* str, wcha
 #endif
 }
 
-template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
 UTL_ATTRIBUTES(LIBC_PURE) inline T* strnchr(T const* str, T const ch, element_count_t count) noexcept {
     size_t len = size_t(count);
     while (len) {
@@ -148,7 +148,7 @@ UTL_ATTRIBUTES(LIBC_PURE) inline T* strnchr(T const* str, T const ch, element_co
     return nullptr;
 }
 
-template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
 UTL_ATTRIBUTES(LIBC_PURE) inline T* strchr(T const* str, T const ch) noexcept {
     while (*str != ch) {
         if (!*str) {
@@ -180,7 +180,7 @@ UTL_ATTRIBUTES(LIBC_INLINE_PURE) inline int strcmp(wchar_t const* left, wchar_t 
 #endif
 }
 
-template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
 UTL_ATTRIBUTES(LIBC_PURE) inline int strcmp(T const* left, T const* right) noexcept {
     while (*left == *right) {
         if (!*left && !*right) {
@@ -212,7 +212,7 @@ UTL_ATTRIBUTES(LIBC_INLINE_PURE) inline int strncmp(
 #endif
 }
 
-template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
 UTL_ATTRIBUTES(LIBC_PURE) inline int strncmp(T const* left, T const* right, element_count_t elements) noexcept {
     size_t len = (size_t)elements;
     while (len && *left == *right) {
@@ -232,7 +232,7 @@ UTL_ATTRIBUTES(LIBC_PURE) inline int strncmp(T const* left, T const* right, elem
 #  pragma intrinsic(memcpy)
 #endif
 
-template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
 UTL_ATTRIBUTES(LIBC_PURE) inline T* strnset(T* dst, T const val, element_count_t elements) noexcept {
     size_t len = (size_t)elements;
     if (!len) {

--- a/src/utl/public/utl/string/utl_string_details.h
+++ b/src/utl/public/utl/string/utl_string_details.h
@@ -29,7 +29,7 @@ namespace string {
 
 UTL_INLINE_CXX17 constexpr size_t npos = numeric::maximum<size_t>::value;
 
-template <UTL_CONCEPT_CXX20(string_char) T UTL_REQUIRES_CXX11(is_string_char<T>::value)>
+template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
 UTL_ATTRIBUTE(CONST_FUNCTION) constexpr size_t to_index(T const* base, T const* ptr) noexcept {
     return ptr ? ptr - base : __UTL details::string::npos;
 }

--- a/src/utl/public/utl/tuple/utl_tuple_details.h
+++ b/src/utl/public/utl/tuple/utl_tuple_details.h
@@ -42,16 +42,16 @@ struct variadic_traits;
 
 namespace details {
 namespace tuple {
-template <size_t I, typename T UTL_REQUIRES_CXX11((I < tuple_size_v<T>))>
-UTL_REQUIRES_CXX20(requires {
+template <size_t I, typename T UTL_CONSTRAINT_CXX11((I < tuple_size_v<T>))>
+UTL_CONSTRAINT_CXX20(requires {
     __UTL get_element<I>(__UTL declval<T>()); })
 auto decl_element() noexcept -> decltype(__UTL get_element<I>(__UTL declval<T>()));
 
-template <size_t I, typename T UTL_REQUIRES_CXX11((I >= tuple_size_v<T>))>
+template <size_t I, typename T UTL_CONSTRAINT_CXX11((I >= tuple_size_v<T>))>
 void decl_element() noexcept = delete;
 
-template <size_t I, typename T UTL_REQUIRES_CXX11((I < tuple_size_v<T>))>
-UTL_REQUIRES_CXX20(requires {
+template <size_t I, typename T UTL_CONSTRAINT_CXX11((I < tuple_size_v<T>))>
+UTL_CONSTRAINT_CXX20(requires {
     __UTL get_element<I>(__UTL declval<T>()); })
 using get_type_t = decltype(__UTL get_element<I>(__UTL declval<T>()));
 
@@ -164,59 +164,59 @@ public:
         UTL_TRAIT_is_nothrow_move_assignable(T)) = default;
 #endif
 
-    template <UTL_CONCEPT_CXX20(constructible_as<T>) U UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(constructible_as<T>) U UTL_CONSTRAINT_CXX11(
         !__UTL is_same<U, storage>::value && __UTL is_constructible<T, U>::value)>
-    UTL_REQUIRES_CXX20(!same_as<remove_reference_t<U>, storage>)
+    UTL_CONSTRAINT_CXX20(!same_as<remove_reference_t<U>, storage>)
     __UTL_HIDE_FROM_ABI constexpr storage(U&& head) noexcept(
         UTL_TRAIT_is_nothrow_constructible(T, U))
         : head(__UTL forward<U>(head)) {}
 
-    template <UTL_CONCEPT_CXX20(allocator_usable_with<T>) Alloc UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(allocator_usable_with<T>) Alloc UTL_CONSTRAINT_CXX11(
         conjunction<__UTL uses_allocator<T, Alloc>,
             __UTL is_constructible<T, allocator_arg_t, Alloc const&>>::value)>
-    UTL_REQUIRES_CXX20(constructible_from<T, allocator_arg_t, Alloc const&>)
+    UTL_CONSTRAINT_CXX20(constructible_from<T, allocator_arg_t, Alloc const&>)
     __UTL_HIDE_FROM_ABI constexpr storage(allocator_arg_t, Alloc const& alloc) noexcept(
         UTL_TRAIT_is_nothrow_constructible(T, allocator_arg_t, Alloc const&))
         : head(allocator_arg, alloc) {}
 
-    template <UTL_CONCEPT_CXX20(allocator_usable_with<T>) Alloc UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(allocator_usable_with<T>) Alloc UTL_CONSTRAINT_CXX11(
         conjunction<__UTL uses_allocator<T, Alloc>,
             negation<__UTL is_constructible<T, allocator_arg_t, Alloc const&>>,
             __UTL is_constructible<T, Alloc const&>>::value)>
-    UTL_REQUIRES_CXX20(!constructible_from<T, allocator_arg_t, Alloc const&> &&
+    UTL_CONSTRAINT_CXX20(!constructible_from<T, allocator_arg_t, Alloc const&> &&
         constructible_from<T, Alloc const&>)
     __UTL_HIDE_FROM_ABI constexpr storage(allocator_arg_t, Alloc const& alloc) noexcept(
         UTL_TRAIT_is_nothrow_constructible(T, Alloc const&))
         : head(alloc) {}
 
-    template <UTL_CONCEPT_CXX20(allocator_type) Alloc UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(allocator_type) Alloc UTL_CONSTRAINT_CXX11(
         !UTL_TRAIT_uses_allocator(T, Alloc))>
-    UTL_REQUIRES_CXX20(constructible_from<T>)
+    UTL_CONSTRAINT_CXX20(constructible_from<T>)
     __UTL_HIDE_FROM_ABI constexpr storage(allocator_arg_t, Alloc const& alloc) noexcept(
         UTL_TRAIT_is_nothrow_constructible(T))
         : head() {}
 
     template <UTL_CONCEPT_CXX20(allocator_usable_with<T>) Alloc,
-        typename U UTL_REQUIRES_CXX11(conjunction<__UTL uses_allocator<T, Alloc>,
+        typename U UTL_CONSTRAINT_CXX11(conjunction<__UTL uses_allocator<T, Alloc>,
             __UTL is_constructible<T, allocator_arg_t, Alloc const&, U>>::value)>
-    UTL_REQUIRES_CXX20(constructible_from<T, allocator_arg_t, Alloc const&, U>)
+    UTL_CONSTRAINT_CXX20(constructible_from<T, allocator_arg_t, Alloc const&, U>)
     __UTL_HIDE_FROM_ABI constexpr storage(allocator_arg_t, Alloc const& alloc, U&& u) noexcept(
         UTL_TRAIT_is_nothrow_constructible(T, allocator_arg_t, Alloc const&, U))
         : head(allocator_arg, alloc, __UTL forward<U>(u)) {}
 
     template <UTL_CONCEPT_CXX20(allocator_usable_with<T>) Alloc,
-        typename U UTL_REQUIRES_CXX11(conjunction<__UTL uses_allocator<T, Alloc>,
+        typename U UTL_CONSTRAINT_CXX11(conjunction<__UTL uses_allocator<T, Alloc>,
             negation<__UTL is_constructible<T, allocator_arg_t, Alloc const&, U>>,
             __UTL is_constructible<T, U, Alloc const&>>::value)>
-    UTL_REQUIRES_CXX20(!constructible_from<T, allocator_arg_t, Alloc const&, U> &&
+    UTL_CONSTRAINT_CXX20(!constructible_from<T, allocator_arg_t, Alloc const&, U> &&
         constructible_from<T, U, Alloc const&>)
     __UTL_HIDE_FROM_ABI constexpr storage(allocator_arg_t, Alloc const& alloc, U&& u) noexcept(
         UTL_TRAIT_is_nothrow_constructible(T, U, Alloc const&))
         : head(__UTL forward<U>(u), alloc) {}
 
-    template <UTL_CONCEPT_CXX20(allocator_usable_with<T>) Alloc, typename U UTL_REQUIRES_CXX11(
+    template <UTL_CONCEPT_CXX20(allocator_usable_with<T>) Alloc, typename U UTL_CONSTRAINT_CXX11(
         !UTL_TRAIT_uses_allocator(T, Alloc))>
-    UTL_REQUIRES_CXX20(constructible_from<T, U>)
+    UTL_CONSTRAINT_CXX20(constructible_from<T, U>)
     __UTL_HIDE_FROM_ABI constexpr storage(allocator_arg_t, Alloc const& alloc, U&& u) noexcept(
         UTL_TRAIT_is_nothrow_constructible(T, U))
         : head(__UTL forward<U>(u)) {}
@@ -260,27 +260,27 @@ public:
     }
 
     template <size_t I>
-    UTL_REQUIRES_CXX20(I == 0)
+    UTL_CONSTRAINT_CXX20(I == 0)
     UTL_ATTRIBUTES(NODISCARD, CONST, _HIDE_FROM_ABI) UTL_CONSTEXPR_CXX14 auto get() && noexcept UTL_LIFETIMEBOUND
     -> UTL_ENABLE_IF_CXX11(T&&, I == 0) {
         return __UTL move(head);
     }
 
     template <size_t I>
-    UTL_REQUIRES_CXX20(I == 0)
+    UTL_CONSTRAINT_CXX20(I == 0)
     UTL_ATTRIBUTES(NODISCARD, CONST, _HIDE_FROM_ABI) UTL_CONSTEXPR_CXX14 auto get() & noexcept UTL_LIFETIMEBOUND
     -> UTL_ENABLE_IF_CXX11(T&, I == 0) {
         return head;
     }
 
     template <size_t I>
-    UTL_REQUIRES_CXX20(I == 0)
+    UTL_CONSTRAINT_CXX20(I == 0)
     UTL_ATTRIBUTES(NODISCARD, CONST, _HIDE_FROM_ABI) constexpr auto get() const&& noexcept UTL_LIFETIMEBOUND -> UTL_ENABLE_IF_CXX11(T const&&, I == 0) {
         return __UTL move(head);
     }
 
     template <size_t I>
-    UTL_REQUIRES_CXX20(I == 0)
+    UTL_CONSTRAINT_CXX20(I == 0)
     UTL_ATTRIBUTES(NODISCARD, CONST, _HIDE_FROM_ABI) constexpr auto get() const& noexcept UTL_LIFETIMEBOUND -> UTL_ENABLE_IF_CXX11(T const&, I == 0) {
         return head;
     }

--- a/src/utl/public/utl/tuple/utl_tuple_get.h
+++ b/src/utl/public/utl/tuple/utl_tuple_get.h
@@ -12,32 +12,32 @@
 
 UTL_NAMESPACE_BEGIN
 
-template <size_t I, typename... U UTL_REQUIRES_CXX11((I < sizeof...(U)))>
-UTL_REQUIRES_CXX20(I < sizeof...(U))
+template <size_t I, typename... U UTL_CONSTRAINT_CXX11((I < sizeof...(U)))>
+UTL_CONSTRAINT_CXX20(I < sizeof...(U))
 UTL_ATTRIBUTES(NODISCARD, CONST, _HIDE_FROM_ABI) UTL_CONSTEXPR_CXX14 auto get(
     tuple<U...>&& target UTL_LIFETIMEBOUND) noexcept -> tuple_element_t<I, tuple<U...>>&& {
     static_assert(is_base_of<details::tuple::storage<U...>, tuple<U...>>::value, "Invalid tuple");
     return ((details::tuple::storage<U...>&&)__UTL move(target)).template get<I>();
 }
 
-template <size_t I, typename... U UTL_REQUIRES_CXX11((I < sizeof...(U)))>
-UTL_REQUIRES_CXX20(I < sizeof...(U))
+template <size_t I, typename... U UTL_CONSTRAINT_CXX11((I < sizeof...(U)))>
+UTL_CONSTRAINT_CXX20(I < sizeof...(U))
 UTL_ATTRIBUTES(NODISCARD, CONST, _HIDE_FROM_ABI) UTL_CONSTEXPR_CXX14 auto get(
     tuple<U...>& target UTL_LIFETIMEBOUND) noexcept -> tuple_element_t<I, tuple<U...>>& {
     static_assert(is_base_of<details::tuple::storage<U...>, tuple<U...>>::value, "Invalid tuple");
     return ((details::tuple::storage<U...>&)target).template get<I>();
 }
 
-template <size_t I, typename... U UTL_REQUIRES_CXX11((I < sizeof...(U)))>
-UTL_REQUIRES_CXX20(I < sizeof...(U))
+template <size_t I, typename... U UTL_CONSTRAINT_CXX11((I < sizeof...(U)))>
+UTL_CONSTRAINT_CXX20(I < sizeof...(U))
 UTL_ATTRIBUTES(NODISCARD, CONST, _HIDE_FROM_ABI) constexpr auto get(tuple<U...> const&& target
         UTL_LIFETIMEBOUND) noexcept -> tuple_element_t<I, tuple<U...>> const&& {
     static_assert(is_base_of<details::tuple::storage<U...>, tuple<U...>>::value, "Invalid tuple");
     return ((details::tuple::storage<U...> const&&)__UTL move(target)).template get<I>();
 }
 
-template <size_t I, typename... U UTL_REQUIRES_CXX11((I < sizeof...(U)))>
-UTL_REQUIRES_CXX20(I < sizeof...(U))
+template <size_t I, typename... U UTL_CONSTRAINT_CXX11((I < sizeof...(U)))>
+UTL_CONSTRAINT_CXX20(I < sizeof...(U))
 UTL_ATTRIBUTES(NODISCARD, CONST, _HIDE_FROM_ABI) constexpr auto get(tuple<U...> const& target
         UTL_LIFETIMEBOUND) noexcept -> tuple_element_t<I, tuple<U...>> const& {
     static_assert(is_base_of<details::tuple::storage<U...>, tuple<U...>>::value, "Invalid tuple");

--- a/src/utl/public/utl/tuple/utl_tuple_get_element.h
+++ b/src/utl/public/utl/tuple/utl_tuple_get_element.h
@@ -61,8 +61,9 @@ public:
         return get<I>(__UTL forward<T>(t));
     }
 
-    template <UTL_CONCEPT_CXX20(has_member_get<I>) T UTL_REQUIRES_CXX11(!has_adl_get<T, I>::value)>
-    UTL_REQUIRES_CXX20(!has_adl_get<T, I>)
+    template <UTL_CONCEPT_CXX20(has_member_get<I>) T UTL_CONSTRAINT_CXX11(
+        !has_adl_get<T, I>::value)>
+    UTL_CONSTRAINT_CXX20(!has_adl_get<T, I>)
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) inline constexpr auto operator()(
         T&& t UTL_LIFETIMEBOUND) const noexcept(nothrow_member_get<T>::value)
         -> decltype(__UTL declval<T>().template get<I>()) {

--- a/src/utl/public/utl/tuple/utl_tuple_traits.h
+++ b/src/utl/public/utl/tuple/utl_tuple_traits.h
@@ -51,18 +51,18 @@ namespace details {
 namespace tuple {
 struct invalid_size_t {};
 
-template <typename T UTL_REQUIRES_CXX11(sizeof(::std::tuple_size<T>))>
-UTL_REQUIRES_CXX20(sizeof(::std::tuple_size<T>) > 0)
+template <typename T UTL_CONSTRAINT_CXX11(sizeof(::std::tuple_size<T>))>
+UTL_CONSTRAINT_CXX20(sizeof(::std::tuple_size<T>) > 0)
 __UTL_HIDE_FROM_ABI auto size_impl(int) noexcept -> ::std::tuple_size<T>;
 
-template <typename T UTL_REQUIRES_CXX11(is_same<remove_cvref_t<T>, T>::value)>
-UTL_REQUIRES_CXX20(is_same<remove_cvref_t<T>, T>::value)
+template <typename T UTL_CONSTRAINT_CXX11(is_same<remove_cvref_t<T>, T>::value)>
+UTL_CONSTRAINT_CXX20(is_same<remove_cvref_t<T>, T>::value)
 __UTL_HIDE_FROM_ABI auto size_impl(...) noexcept -> invalid_size_t;
 
 struct invalid_element_t {};
 
-template <size_t I, typename T UTL_REQUIRES_CXX11(sizeof(::std::tuple_element<I, T>))>
-UTL_REQUIRES_CXX20(sizeof(::std::tuple_element<I, T>) > 0)
+template <size_t I, typename T UTL_CONSTRAINT_CXX11(sizeof(::std::tuple_element<I, T>))>
+UTL_CONSTRAINT_CXX20(sizeof(::std::tuple_element<I, T>) > 0)
 __UTL_HIDE_FROM_ABI auto element_impl(int) noexcept -> ::std::tuple_element<I, T>;
 
 template <size_t I, typename T>

--- a/src/utl/public/utl/type_traits/utl_invoke.h
+++ b/src/utl/public/utl/type_traits/utl_invoke.h
@@ -49,18 +49,18 @@ struct class_type<R C::*> {
     using type = C;
 };
 
-template <typename T UTL_REQUIRES_CXX11(UTL_TRAIT_is_reference_wrapper(T))>
-UTL_REQUIRES_CXX20(UTL_TRAIT_is_reference_wrapper(T))
+template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_reference_wrapper(T))>
+UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_reference_wrapper(T))
 __UTL_HIDE_FROM_ABI constexpr auto unwrap(T&& t) noexcept(noexcept(t.get())) -> decltype(t.get()) {
     return t.get();
 }
 
-template <typename T UTL_REQUIRES_CXX11(!UTL_TRAIT_is_reference_wrapper(T))>
+template <typename T UTL_CONSTRAINT_CXX11(!UTL_TRAIT_is_reference_wrapper(T))>
 __UTL_HIDE_FROM_ABI constexpr T&& unwrap(T&& t) noexcept {
     return __UTL forward(t);
 }
 
-template <typename T UTL_REQUIRES_CXX11(UTL_TRAIT_is_dereferenceable(T))>
+template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_dereferenceable(T))>
 __UTL_HIDE_FROM_ABI constexpr auto unwrap(T&& t) noexcept(UTL_TRAIT_is_nothrow_dereferenceable(T))
     -> decltype(*t) {
     return *t;

--- a/src/utl/public/utl/type_traits/utl_is_equality_comparable.h
+++ b/src/utl/public/utl/type_traits/utl_is_equality_comparable.h
@@ -15,14 +15,15 @@ namespace equality_comparable {
 template <typename T, typename U>
 using result_t UTL_NODEBUG = decltype(__UTL declval<T>() == __UTL declval<U>());
 
-template <typename T, typename U UTL_REQUIRES_CXX11(UTL_TRAIT_is_boolean_testable(result_t<T, U>))>
-UTL_REQUIRES_CXX20(UTL_TRAIT_is_boolean_testable(result_t<T, U>))
+template <typename T, typename U UTL_CONSTRAINT_CXX11(
+    UTL_TRAIT_is_boolean_testable(result_t<T, U>))>
+UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_boolean_testable(result_t<T, U>))
 __UTL_HIDE_FROM_ABI __UTL true_type impl(int) noexcept;
 template <typename T, typename U>
 __UTL_HIDE_FROM_ABI __UTL false_type impl(float) noexcept;
-template <typename T, typename U UTL_REQUIRES_CXX11(
+template <typename T, typename U UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_nothrow_boolean_testable(result_t<T, U>))>
-UTL_REQUIRES_CXX20(UTL_TRAIT_is_nothrow_boolean_testable(result_t<T, U>))
+UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_nothrow_boolean_testable(result_t<T, U>))
 __UTL_HIDE_FROM_ABI __UTL true_type nothrow_check(int) noexcept;
 template <typename T, typename U>
 __UTL_HIDE_FROM_ABI __UTL false_type nothrow_check(float) noexcept;

--- a/src/utl/public/utl/type_traits/utl_is_inequality_comparable.h
+++ b/src/utl/public/utl/type_traits/utl_is_inequality_comparable.h
@@ -15,14 +15,15 @@ namespace inequality_comparable {
 template <typename T, typename U>
 using result_t UTL_NODEBUG = decltype(__UTL declval<T>() != __UTL declval<U>());
 
-template <typename T, typename U UTL_REQUIRES_CXX11(UTL_TRAIT_is_boolean_testable(result_t<T, U>))>
-UTL_REQUIRES_CXX20(UTL_TRAIT_is_boolean_testable(result_t<T, U>))
+template <typename T, typename U UTL_CONSTRAINT_CXX11(
+    UTL_TRAIT_is_boolean_testable(result_t<T, U>))>
+UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_boolean_testable(result_t<T, U>))
 __UTL_HIDE_FROM_ABI __UTL true_type impl(int) noexcept;
 template <typename T, typename U>
 __UTL_HIDE_FROM_ABI __UTL false_type impl(float) noexcept;
-template <typename T, typename U UTL_REQUIRES_CXX11(
+template <typename T, typename U UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_nothrow_boolean_testable(result_t<T, U>))>
-UTL_REQUIRES_CXX20(UTL_TRAIT_is_nothrow_boolean_testable(result_t<T, U>))
+UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_nothrow_boolean_testable(result_t<T, U>))
 __UTL_HIDE_FROM_ABI __UTL true_type nothrow_check(int) noexcept;
 template <typename T, typename U>
 __UTL_HIDE_FROM_ABI __UTL false_type nothrow_check(float) noexcept;

--- a/src/utl/public/utl/type_traits/utl_is_subordinate_comparable.h
+++ b/src/utl/public/utl/type_traits/utl_is_subordinate_comparable.h
@@ -15,15 +15,15 @@ namespace subordinate_comparable {
 template <typename T, typename U>
 using strict_result_t UTL_NODEBUG = decltype(__UTL declval<T>() < __UTL declval<U>());
 
-template <typename T, typename U UTL_REQUIRES_CXX11(
+template <typename T, typename U UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_boolean_testable(strict_result_t<T, U>))>
-UTL_REQUIRES_CXX20(UTL_TRAIT_is_boolean_testable(strict_result_t<T, U>))
+UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_boolean_testable(strict_result_t<T, U>))
 __UTL_HIDE_FROM_ABI __UTL true_type strict_impl(int) noexcept;
 template <typename T, typename U>
 __UTL_HIDE_FROM_ABI __UTL false_type strict_impl(float) noexcept;
-template <typename T, typename U UTL_REQUIRES_CXX11(
+template <typename T, typename U UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_nothrow_boolean_testable(strict_result_t<T, U>))>
-UTL_REQUIRES_CXX20(UTL_TRAIT_is_nothrow_boolean_testable(strict_result_t<T, U>))
+UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_nothrow_boolean_testable(strict_result_t<T, U>))
 __UTL_HIDE_FROM_ABI __UTL true_type strict_nothrow_check(int) noexcept;
 template <typename T, typename U>
 __UTL_HIDE_FROM_ABI __UTL false_type strict_nothrow_check(float) noexcept;
@@ -36,15 +36,16 @@ using strict_nothrow_t UTL_NODEBUG = decltype(strict_nothrow_check<T, U>(0));
 template <typename T, typename U>
 using result_t UTL_NODEBUG = decltype(__UTL declval<T>() <= __UTL declval<U>());
 
-template <typename T, typename U UTL_REQUIRES_CXX11(UTL_TRAIT_is_boolean_testable(result_t<T, U>))>
-UTL_REQUIRES_CXX20(UTL_TRAIT_is_boolean_testable(result_t<T, U>))
+template <typename T, typename U UTL_CONSTRAINT_CXX11(
+    UTL_TRAIT_is_boolean_testable(result_t<T, U>))>
+UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_boolean_testable(result_t<T, U>))
 __UTL_HIDE_FROM_ABI __UTL true_type impl(int) noexcept;
 template <typename T, typename U>
 __UTL_HIDE_FROM_ABI __UTL false_type impl(float) noexcept;
 
-template <typename T, typename U UTL_REQUIRES_CXX11(
+template <typename T, typename U UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_nothrow_boolean_testable(result_t<T, U>))>
-UTL_REQUIRES_CXX20(UTL_TRAIT_is_nothrow_boolean_testable(result_t<T, U>))
+UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_nothrow_boolean_testable(result_t<T, U>))
 __UTL_HIDE_FROM_ABI __UTL true_type nothrow_check(int) noexcept;
 template <typename T, typename U>
 __UTL_HIDE_FROM_ABI __UTL false_type nothrow_check(float) noexcept;

--- a/src/utl/public/utl/type_traits/utl_is_superordinate_comparable.h
+++ b/src/utl/public/utl/type_traits/utl_is_superordinate_comparable.h
@@ -15,15 +15,15 @@ namespace superordinate_comparable {
 template <typename T, typename U>
 using strict_result_t = decltype(__UTL declval<T>() > __UTL declval<U>());
 
-template <typename T, typename U UTL_REQUIRES_CXX11(
+template <typename T, typename U UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_boolean_testable(strict_result_t<T, U>))>
-UTL_REQUIRES_CXX20(UTL_TRAIT_is_boolean_testable(strict_result_t<T, U>))
+UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_boolean_testable(strict_result_t<T, U>))
 __UTL_HIDE_FROM_ABI __UTL_HIDE_FROM_ABI __UTL true_type strict_impl(int) noexcept;
 template <typename T, typename U>
 __UTL_HIDE_FROM_ABI __UTL false_type strict_impl(float) noexcept;
-template <typename T, typename U UTL_REQUIRES_CXX11(
+template <typename T, typename U UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_nothrow_boolean_testable(strict_result_t<T, U>))>
-UTL_REQUIRES_CXX20(UTL_TRAIT_is_nothrow_boolean_testable(strict_result_t<T, U>))
+UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_nothrow_boolean_testable(strict_result_t<T, U>))
 __UTL_HIDE_FROM_ABI __UTL true_type strict_nothrow_check(int) noexcept;
 template <typename T, typename U>
 __UTL_HIDE_FROM_ABI __UTL false_type strict_nothrow_check(float) noexcept;
@@ -36,15 +36,16 @@ using strict_nothrow_t UTL_NODEBUG = decltype(strict_nothrow_check<T, U>(0));
 template <typename T, typename U>
 using result_t UTL_NODEBUG = decltype(__UTL declval<T>() >= __UTL declval<U>());
 
-template <typename T, typename U UTL_REQUIRES_CXX11(UTL_TRAIT_is_boolean_testable(result_t<T, U>))>
-UTL_REQUIRES_CXX20(UTL_TRAIT_is_boolean_testable(result_t<T, U>))
+template <typename T, typename U UTL_CONSTRAINT_CXX11(
+    UTL_TRAIT_is_boolean_testable(result_t<T, U>))>
+UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_boolean_testable(result_t<T, U>))
 __UTL_HIDE_FROM_ABI __UTL true_type impl(int) noexcept;
 template <typename T, typename U>
 __UTL_HIDE_FROM_ABI __UTL false_type impl(float) noexcept;
 
-template <typename T, typename U UTL_REQUIRES_CXX11(
+template <typename T, typename U UTL_CONSTRAINT_CXX11(
     UTL_TRAIT_is_nothrow_boolean_testable(result_t<T, U>))>
-UTL_REQUIRES_CXX20(UTL_TRAIT_is_nothrow_boolean_testable(result_t<T, U>))
+UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_nothrow_boolean_testable(result_t<T, U>))
 __UTL_HIDE_FROM_ABI __UTL true_type nothrow_check(int) noexcept;
 template <typename T, typename U>
 __UTL_HIDE_FROM_ABI __UTL false_type nothrow_check(float) noexcept;

--- a/src/utl/public/utl/type_traits/utl_is_three_way_comparable.h
+++ b/src/utl/public/utl/type_traits/utl_is_three_way_comparable.h
@@ -20,11 +20,11 @@ namespace three_way_comparable {
 template <typename T, typename U>
 using result_t UTL_NODEBUG = decltype(__UTL declval<T>() <=> __UTL declval<U>());
 
-template <typename T, typename U UTL_REQUIRES_CXX11((sizeof(result_t<T, U>) > 0))>
+template <typename T, typename U UTL_CONSTRAINT_CXX11((sizeof(result_t<T, U>) > 0))>
 __UTL_HIDE_FROM_ABI __UTL true_type possible(int) noexcept;
-template <typename T, typename U, typename Cat UTL_REQUIRES_CXX11( UTL_TRAIT_is_convertible(result_t<T, U>, Cat))>
+template <typename T, typename U, typename Cat UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_convertible(result_t<T, U>, Cat))>
 __UTL_HIDE_FROM_ABI __UTL true_type impl(int) noexcept;
-template <typename T, typename U, typename Cat UTL_REQUIRES_CXX11( UTL_TRAIT_is_nothrow_convertible(result_t<T, U>, Cat))>
+template <typename T, typename U, typename Cat UTL_CONSTRAINT_CXX11( UTL_TRAIT_is_nothrow_convertible(result_t<T, U>, Cat))>
 __UTL_HIDE_FROM_ABI __UTL true_type nothrow_check(int) noexcept;
 
 #endif // UTL_CXX20

--- a/src/utl/public/utl/type_traits/utl_variadic_traits.h
+++ b/src/utl/public/utl/type_traits/utl_variadic_traits.h
@@ -112,11 +112,11 @@ struct __UTL_PUBLIC_TEMPLATE variadic_traits {
             __UTL is_implicit_constructible<Types>>... // disjunction
             > {};
 
-    template <typename... UTypes UTL_REQUIRES_CXX11(sizeof...(Types) != sizeof...(UTypes))>
-    UTL_REQUIRES_CXX20(sizeof...(Types) != sizeof...(UTypes))
+    template <typename... UTypes UTL_CONSTRAINT_CXX11(sizeof...(Types) != sizeof...(UTypes))>
+    UTL_CONSTRAINT_CXX20(sizeof...(Types) != sizeof...(UTypes))
     static auto is_explicit_constructible_impl() noexcept -> false_type;
-    template <typename... UTypes UTL_REQUIRES_CXX11(sizeof...(Types) == sizeof...(UTypes))>
-    UTL_REQUIRES_CXX20(sizeof...(Types) == sizeof...(UTypes))
+    template <typename... UTypes UTL_CONSTRAINT_CXX11(sizeof...(Types) == sizeof...(UTypes))>
+    UTL_CONSTRAINT_CXX20(sizeof...(Types) == sizeof...(UTypes))
     static auto is_explicit_constructible_impl() noexcept
         -> disjunction<__UTL is_explicit_constructible<Types, UTypes>...>;
     template <typename... UTypes>

--- a/src/utl/public/utl/utility/utl_pair_cpp17.h
+++ b/src/utl/public/utl/utility/utl_pair_cpp17.h
@@ -191,7 +191,7 @@ public:
         UTL_TRAIT_is_explicit_constructible(T1)) constexpr pair() noexcept = default;
     UTL_DISABLE_WARNING_POP()
 #else
-    template <typename U0 = T0, typename U1 = T1 UTL_REQUIRES_CXX11(defer<bool_constant<
+    template <typename U0 = T0, typename U1 = T1 UTL_CONSTRAINT_CXX11(defer<bool_constant<
             UTL_TRAIT_is_implicit_constructible(T0) && UTL_TRAIT_is_implicit_constructible(T1)>,
         U0, U1>::value)>
     __UTL_HIDE_FROM_ABI constexpr pair() noexcept(UTL_TRAIT_is_nothrow_default_constructible(T0) &&
@@ -199,7 +199,7 @@ public:
         : first()
         , second() {}
 
-    template <typename U0 = T0, typename U1 = T1 UTL_REQUIRES_CXX11(defer<bool_constant<
+    template <typename U0 = T0, typename U1 = T1 UTL_CONSTRAINT_CXX11(defer<bool_constant<
             UTL_TRAIT_is_explicit_constructible(T0) || UTL_TRAIT_is_explicit_constructible(T1)>,
         U0, U1>::value)>
     __UTL_HIDE_FROM_ABI explicit constexpr pair() noexcept(

--- a/src/utl/public/utl/utility/utl_pair_details.h
+++ b/src/utl/public/utl/utility/utl_pair_details.h
@@ -53,7 +53,7 @@ make_pair(T&& t, U&& u) {
 
 namespace details {
 namespace pair {
-template <size_t I, typename P> UTL_REQUIRES_CXX20(I == 0 && requires(P&& p) {
+template <size_t I, typename P> UTL_CONSTRAINT_CXX20(I == 0 && requires(P&& p) {
         requires is_pair<P>::value;
         __UTL forward<P>(p).first;
     })
@@ -62,7 +62,7 @@ UTL_ATTRIBUTES(NODISCARD, CONST, _HIDE_FROM_ABI) constexpr auto get(P&& p UTL_LI
     return __UTL forward<P>(p).first;
 }
 
-template <size_t I, typename P> UTL_REQUIRES_CXX20(I == 1 && requires(P&& p) {
+template <size_t I, typename P> UTL_CONSTRAINT_CXX20(I == 1 && requires(P&& p) {
         requires is_pair<P>::value;
         __UTL forward<P>(p).second;
     })


### PR DESCRIPTION
Rename `UTL_REQUIRES_CXX??` to `UTL_CONSTRAINT_CXX??` so that it doesn't sound like we need a specific standard for the entity template to be instantiated. 