### PR TITLE
Rename message format functions and class

### DIFF
--- a/src/utl/public/utl/exception/utl_message_format.h
+++ b/src/utl/public/utl/exception/utl_message_format.h
@@ -14,26 +14,26 @@ namespace exceptions {
  *
  * This struct facilitates the handling of message formatting with integrated support for
  * source location information. On compilers that fully support source location intrinsics,
- * string literals can be implicitly converted to a message_format, with the default source
+ * string literals can be implicitly converted to a message_vformat, with the default source
  * location argument providing the precise location of the conversion site. For compilers
  * that do not fully support these intrinsics, the `UTL_MESSAGE_FORMAT` macro is available,
  * which uses preprocessor tokens to construct a source location.
  *
  * Use `UTL_COMPILER_SUPPORTS_SOURCE_LOCATION` to check for source location intrinsic support
  */
-struct __UTL_ABI_PUBLIC message_format {
+struct __UTL_ABI_PUBLIC message_vformat {
     /**
      * Internal use only to prevent assignment
      */
-    __UTL_HIDE_FROM_ABI static constexpr message_format&& forward(
-        message_format&& src UTL_LIFETIMEBOUND) noexcept {
-        return static_cast<message_format&&>(src);
+    __UTL_HIDE_FROM_ABI static constexpr message_vformat&& forward(
+        message_vformat&& src UTL_LIFETIMEBOUND) noexcept {
+        return static_cast<message_vformat&&>(src);
     }
 #if UTL_COMPILER_SUPPORTS_SOURCE_LOCATION
     /**
-     * @brief Constructs a message_format object with format string and source location.
+     * @brief Constructs a message_vformat object with format string and source location.
      *
-     * This constructor initializes the message_format with a format string and
+     * This constructor initializes the message_vformat with a format string and
      * optionally with source location information if supported by the compiler.
      *
      * @tparam N - The size of the byte array containing the format string.
@@ -41,15 +41,15 @@ struct __UTL_ABI_PUBLIC message_format {
      * @param src - The source location information, defaulting to the current location.
      */
     template <size_t N>
-    __UTL_HIDE_FROM_ABI message_format(char const (&fmt)[N] UTL_LIFETIMEBOUND,
+    __UTL_HIDE_FROM_ABI message_vformat(char const (&fmt)[N] UTL_LIFETIMEBOUND,
         __UTL source_location src = UTL_SOURCE_LOCATION()) noexcept
         : format(fmt)
         , location(src) {}
 #else
     /**
-     * @brief Constructs a message_format object with format string and source location.
+     * @brief Constructs a message_vformat object with format string and source location.
      *
-     * This constructor initializes the message_format with a format string and
+     * This constructor initializes the message_vformat with a format string and
      * source location information.
      *
      * @tparam N - The size of the byte array containing the format string.
@@ -57,7 +57,7 @@ struct __UTL_ABI_PUBLIC message_format {
      * @param src - The source location information.
      */
     template <size_t N>
-    __UTL_HIDE_FROM_ABI message_format(
+    __UTL_HIDE_FROM_ABI message_vformat(
         char const (&fmt)[N] UTL_LIFETIMEBOUND, __UTL source_location src) noexcept
         : format(fmt)
         , location(src) {}
@@ -70,4 +70,4 @@ struct __UTL_ABI_PUBLIC message_format {
 UTL_NAMESPACE_END
 
 #define UTL_MESSAGE_FORMAT(FORMAT) \
-    __UTL exceptions::message_format::forward({FORMAT, UTL_SOURCE_LOCATION()})
+    __UTL exceptions::message_vformat::forward({FORMAT, UTL_SOURCE_LOCATION()})

--- a/src/utl/public/utl/exception/utl_message_header.h
+++ b/src/utl/public/utl/exception/utl_message_header.h
@@ -93,11 +93,11 @@ public:
      * @return A pointer to the header of the newly created message.
      * @throws std::bad_alloc on memory allocation failure.
      */
-    UTL_NODISCARD static message_header* create(message_format fmt, ...) UTL_THROWS {
+    UTL_NODISCARD static message_header* createf(message_vformat fmt, ...) UTL_THROWS {
         va_list args;
         va_start(args, fmt);
         UTL_TRY {
-            auto ptr = create(fmt, args);
+            auto ptr = vcreatef(fmt, args);
             va_end(args);
             return ptr;
         } UTL_CATCH(...) {
@@ -109,7 +109,7 @@ public:
     /**
      * @brief Creates a new message using a pre-initialized va_list.
      *
-     * This static function creates a new message by accepting a `message_format` object and a
+     * This static function creates a new message by accepting a `message_vformat` object and a
      * `va_list` of arguments. The provided arguments are used to generate the message string, which
      * is then stored alongside a message header. This function allows for more controlled argument
      * forwarding using an existing `va_list`.
@@ -119,7 +119,7 @@ public:
      * @return A pointer to the newly created message's header.
      * @throws std::bad_alloc if memory allocation fails.
      */
-    UTL_NODISCARD static message_header* create(message_format fmt, va_list args1) UTL_THROWS {
+    UTL_NODISCARD static message_header* vcreatef(message_vformat fmt, va_list args1) UTL_THROWS {
         static constexpr auto header_size = sizeof(message_header);
         va_list args2;
         va_copy(args2, args1);

--- a/src/utl/public/utl/exception/utl_message_stack.h
+++ b/src/utl/public/utl/exception/utl_message_stack.h
@@ -138,11 +138,11 @@ public:
         return const_iterator();
     }
 
-    __UTL_HIDE_FROM_ABI void emplace(message_format fmt, ...) UTL_THROWS {
+    __UTL_HIDE_FROM_ABI void emplacef(message_vformat fmt, ...) UTL_THROWS {
         va_list args;
         va_start(args, fmt);
         UTL_TRY {
-            emplace(fmt, args);
+            vemplacef(fmt, args);
             va_end(args);
         } UTL_CATCH(...) {
             va_end(args);
@@ -150,9 +150,9 @@ public:
         }
     }
 
-    __UTL_HIDE_FROM_ABI void emplace(message_format fmt, va_list args) UTL_THROWS {
+    __UTL_HIDE_FROM_ABI void vemplacef(message_vformat fmt, va_list args) UTL_THROWS {
         // could throw
-        auto header = message_header::create(__UTL move(fmt), args);
+        auto header = message_header::vcreatef(__UTL move(fmt), args);
 
         // noexcept
         set_next(*header, head_);

--- a/src/utl/public/utl/exception/utl_program_exception.h
+++ b/src/utl/public/utl/exception/utl_program_exception.h
@@ -37,11 +37,11 @@ public:
      * @param fmt The message format object containing the format string and source location.
      * @param ... Variadic arguments for the message format.
      */
-    __UTL_HIDE_FROM_ABI explicit basic_exception(exceptions::message_format fmt, ...)
+    __UTL_HIDE_FROM_ABI explicit basic_exception(exceptions::message_vformat fmt, ...)
         : location_(fmt.location) {
         va_list args;
         va_start(args, fmt);
-        messages_.emplace(__UTL move(fmt), args);
+        messages_.emplacef(__UTL move(fmt), args);
         va_end(args);
     }
 
@@ -67,10 +67,10 @@ public:
      * @param fmt The message format object containing the format string.
      * @param ... Variadic arguments for the message format.
      */
-    __UTL_HIDE_FROM_ABI void emplace_message(exceptions::message_format fmt, ...) {
+    __UTL_HIDE_FROM_ABI void emplace_messagef(exceptions::message_vformat fmt, ...) {
         va_list args;
         va_start(args, fmt);
-        messages_.emplace(__UTL move(fmt), args);
+        messages_.vemplacef(__UTL move(fmt), args);
         va_end(args);
     }
 
@@ -120,7 +120,7 @@ public:
      */
     template <UTL_CONCEPT_CXX20(constructible_as<T>) U, typename... Args UTL_CONSTRAINT_CXX11(
         is_constructible<T, U>::value)>
-    __UTL_HIDE_FROM_ABI basic_exception(U&& u, exceptions::message_format fmt,
+    __UTL_HIDE_FROM_ABI basic_exception(U&& u, exceptions::message_vformat fmt,
         Args... args) noexcept(UTL_TRAIT_is_nothrow_constructible(T, U))
         : base_type(__UTL move(fmt), args...)
         , data_(__UTL forward<U>(u)) {}

--- a/src/utl/public/utl/string/utl_basic_short_string.h
+++ b/src/utl/public/utl/string/utl_basic_short_string.h
@@ -1414,7 +1414,7 @@ private:
                 grow_heap(new_capacity);
             }
         } UTL_CATCH(program_exception& exception) {
-            exception.emplace_message(
+            exception.emplace_messagef(
                 UTL_MESSAGE_FORMAT("[UTL] `basic_short_string::reserve` operation failed, "
                                    "Reason=[Allocation failed]"));
             UTL_RETHROW();
@@ -1436,7 +1436,7 @@ private:
             traits_type::copy(heap.data_, src.data(), src.size() + 1);
             return heap;
         } UTL_CATCH(program_exception& exception) {
-            exception.emplace_message(UTL_MESSAGE_FORMAT(
+            exception.emplace_messagef(UTL_MESSAGE_FORMAT(
                 "[UTL] basic_short_string operation failed, Reason=[Allocation failed]"));
             UTL_RETHROW();
         }

--- a/src/utl/public/utl/string/utl_basic_string_view.h
+++ b/src/utl/public/utl/string/utl_basic_string_view.h
@@ -378,8 +378,8 @@ public:
 private:
     UTL_ATTRIBUTES(NORETURN, NOINLINE, _HIDE_FROM_ABI) static basic_string_view substr_throw(
         __UTL source_location src, size_t pos, size_t size) UTL_THROWS {
-        exceptions::message_format format = {"[UTL] `basic_string_view::substr` operation failed, "
-                                             "Reason=[index out of range], pos=[%zu], size=[%zu]",
+        exceptions::message_vformat format = {"[UTL] `basic_string_view::substr` operation failed, "
+                                              "Reason=[index out of range], pos=[%zu], size=[%zu]",
             src};
         UTL_THROW(out_of_range(format, pos, size));
     }

--- a/src/utl/public/utl/string/utl_basic_zstring_view.h
+++ b/src/utl/public/utl/string/utl_basic_zstring_view.h
@@ -138,8 +138,9 @@ public:
 private:
     UTL_ATTRIBUTES(NORETURN, NOINLINE, _HIDE_FROM_ABI) static basic_zstring_view substr_throw(
         __UTL source_location src, size_t pos, size_t size) UTL_THROWS {
-        exceptions::message_format format = {"[UTL] `basic_zstring_view::substr` operation failed, "
-                                             "Reason=[index out of range], pos=[%zu], size=[%zu]",
+        exceptions::message_vformat format = {
+            "[UTL] `basic_zstring_view::substr` operation failed, "
+            "Reason=[index out of range], pos=[%zu], size=[%zu]",
             src};
         UTL_THROW(out_of_range(format, pos, size));
     }


### PR DESCRIPTION
Reason:
* So that C++20 style formatting may be implemented later on