### PR TITLE
Consteval Invalid Duration

### DIFF
--- a/NOTES
+++ b/NOTES
@@ -1,5 +1,7 @@
 * Supporting modules will probably be a massive PITA
-# TODO: Moduels doesn't play well with forward declarations, if using modules, just import std modules that we need
+# TODO: Modules doesn't play well with forward declarations, if using modules, just import std modules that we need
 * TODO: Maybe move all the type_traits builtins to a single file?
 # TODO: Fix for C++11 T.T
 # TODO: define CONSTEXPR_ASSERT for C++11
+# TODO: Investigate consteval bugs
+# TODO: Enable UTL keywords (utl_standard.h) based on features instead of standard


### PR DESCRIPTION
The original implementation used a `consteval` to return the invalid function; however, it failed to compile due to a clang/apple clang bug (which I was unaware of at the time).

Updated notes to investigate consteval bugs. Also maybe best to switch to feature-based keyword macros instead of standard-based.