### PR TITLE
UTL Atomics

### DIFF
--- a/src/utl/makefile
+++ b/src/utl/makefile
@@ -13,7 +13,7 @@ MODULE_INCLUDES := $(shell find $(PRIVATE_DIR) $(PUBLIC_DIR) -name '*.h')
 
 .PHONY = all clean print preprocess compile
 CXX := c++
-CXX_FLAGS := -std=c++20 -fPIC -O1 -I$(PUBLIC_DIR) -I$(PRIVATE_DIR) -DUTL_BUILD_TESTS -DUTL_BUILDING_LIBRARY=1 -Wall -Wpedantic -Wno-gnu-zero-variadic-macro-arguments
+CXX_FLAGS := -std=c++17 -fPIC -O1 -I$(PUBLIC_DIR) -I$(PRIVATE_DIR) -DUTL_BUILD_TESTS -DUTL_BUILDING_LIBRARY=1 -Wall -Wpedantic -Wno-gnu-zero-variadic-macro-arguments
 LINKER_FLAGS := -lm
 OBJECTS := $(addsuffix .o, $(MODULE_SRCS:$(MODULE_ROOT)/%=%))
 OBJECT_PATHS := $(addprefix $(INTERMEDIATE_DIR)/,$(OBJECTS))

--- a/src/utl/makefile
+++ b/src/utl/makefile
@@ -13,7 +13,7 @@ MODULE_INCLUDES := $(shell find $(PRIVATE_DIR) $(PUBLIC_DIR) -name '*.h')
 
 .PHONY = all clean print preprocess compile
 CXX := c++
-CXX_FLAGS := -std=c++17 -fPIC -O1 -I$(PUBLIC_DIR) -I$(PRIVATE_DIR) -DUTL_BUILD_TESTS -DUTL_BUILDING_LIBRARY=1 -Wall -Wpedantic -Wno-gnu-zero-variadic-macro-arguments
+CXX_FLAGS := -std=c++20 -fPIC -O1 -I$(PUBLIC_DIR) -I$(PRIVATE_DIR) -DUTL_BUILD_TESTS -DUTL_BUILDING_LIBRARY=1 -Wall -Wpedantic -Wno-gnu-zero-variadic-macro-arguments
 LINKER_FLAGS := -lm
 OBJECTS := $(addsuffix .o, $(MODULE_SRCS:$(MODULE_ROOT)/%=%))
 OBJECT_PATHS := $(addprefix $(INTERMEDIATE_DIR)/,$(OBJECTS))

--- a/src/utl/private/tests/atomic/syntax.cpp
+++ b/src/utl/private/tests/atomic/syntax.cpp
@@ -32,6 +32,18 @@ struct Enum {
     };
 };
 
+struct alignas(4) Struct {
+    char data[4];
+};
+
+Enum<int>::Type func(Enum<int>::Type* ptr) {
+    return utl::atomic_acquire::load(ptr);
+}
+
+Struct func(Struct* ptr) {
+    return utl::atomic_acquire::load(ptr);
+}
+
 using native_types = utl::type_list<bool, char, signed char, unsigned char, short, unsigned short,
     int, unsigned int, long, unsigned long, long long, unsigned long long, void*>;
 

--- a/src/utl/private/tests/atomic/syntax.cpp
+++ b/src/utl/private/tests/atomic/syntax.cpp
@@ -1,0 +1,232 @@
+// Copyright 2023-2024 Bryan Wong
+
+#include "utl/atomic/utl_atomic.h"
+#include "utl/type_traits/utl_declval.h"
+#include "utl/type_traits/utl_is_complete.h"
+#include "utl/type_traits/utl_is_enum.h"
+#include "utl/type_traits/utl_is_same.h"
+#include "utl/type_traits/utl_is_void.h"
+#include "utl/type_traits/utl_logical_traits.h"
+#include "utl/type_traits/utl_template_list.h"
+#include "utl/type_traits/utl_underlying_type.h"
+
+namespace atomic_tests {
+using load_operations = utl::type_list<utl::atomic_operations<utl::memory_order::relaxed>,
+    utl::atomic_operations<utl::memory_order::acquire>,
+    utl::atomic_operations<utl::memory_order::consume>,
+    utl::atomic_operations<utl::memory_order::seq_cst>>;
+using store_operations = utl::type_list<utl::atomic_operations<utl::memory_order::relaxed>,
+    utl::atomic_operations<utl::memory_order::release>,
+    utl::atomic_operations<utl::memory_order::seq_cst>>;
+
+using atomic_operations = utl::type_list<utl::atomic_operations<utl::memory_order::relaxed>,
+    utl::atomic_operations<utl::memory_order::acquire>,
+    utl::atomic_operations<utl::memory_order::consume>,
+    utl::atomic_operations<utl::memory_order::release>,
+    utl::atomic_operations<utl::memory_order::acq_rel>,
+    utl::atomic_operations<utl::memory_order::seq_cst>>;
+
+template <typename Native>
+struct Enum {
+    enum class Type : Native {
+    };
+};
+
+using native_types = utl::type_list<bool, char, signed char, unsigned char, short, unsigned short,
+    int, unsigned int, long, unsigned long, long long, unsigned long long, void*>;
+
+using enum_types = utl::type_list<Enum<bool>::Type, Enum<char>::Type, Enum<signed char>::Type,
+    Enum<unsigned char>::Type, Enum<short>::Type, Enum<unsigned short>::Type, Enum<int>::Type,
+    Enum<unsigned int>::Type, Enum<long>::Type, Enum<unsigned long>::Type, Enum<long long>::Type,
+    Enum<unsigned long long>::Type>;
+
+template <typename TYPE, typename OP>
+struct LoadAssertions {
+    static_assert(utl::is_same<TYPE, decltype(OP::load((TYPE*)(0)))>::value, "");
+    static_assert(utl::is_same<TYPE, decltype(OP::load((TYPE volatile*)(0)))>::value, "");
+    static_assert(utl::is_same<TYPE, decltype(OP::load((TYPE const*)(0)))>::value, "");
+    static_assert(utl::is_same<TYPE, decltype(OP::load((TYPE const volatile*)(0)))>::value, "");
+};
+
+template <typename TYPE, typename OP>
+struct StoreAssertions {
+    static_assert(utl::is_void<decltype(OP::store((TYPE*)(0), utl::declval<TYPE>()))>::value, "");
+    static_assert(
+        utl::is_void<decltype(OP::store((TYPE volatile*)(0), utl::declval<TYPE>()))>::value, "");
+};
+
+template <typename TYPE, typename OP>
+struct ExchangeAssertions {
+    static_assert(
+        utl::is_same<TYPE, decltype(OP::exchange((TYPE*)(0), utl::declval<TYPE>()))>::value, "");
+    static_assert(utl::is_same<TYPE,
+                      decltype(OP::exchange((TYPE volatile*)(0), utl::declval<TYPE>()))>::value,
+        "");
+};
+
+template <typename... Ts>
+struct Complete {
+    static_assert(utl::conjunction<utl::is_complete<Ts>...>::value, "");
+};
+
+template <template <typename, typename> class Assertion, typename T, typename L>
+struct EachType;
+
+template <template <typename, typename> class Assertion, typename T, typename... Ops>
+struct EachType<Assertion, T, utl::type_list<Ops...>> {
+    static_assert(utl::conjunction<utl::is_complete<Assertion<T, Ops>>...>::value, "");
+};
+
+template <template <typename, typename> class Assertion, typename... Types, typename... Operations>
+Complete<EachType<Assertion, Types, utl::type_list<Operations...>>...> instantiate(
+    utl::type_list<Types...>, utl::type_list<Operations...>) noexcept;
+
+static_assert(utl::is_complete<decltype(instantiate<LoadAssertions>(
+        native_types{}, load_operations{}))>::value);
+static_assert(utl::is_complete<decltype(instantiate<StoreAssertions>(
+        native_types{}, store_operations{}))>::value);
+static_assert(utl::is_complete<decltype(instantiate<ExchangeAssertions>(
+        native_types{}, atomic_operations{}))>::value);
+static_assert(utl::is_complete<decltype(instantiate<LoadAssertions>(
+        enum_types{}, load_operations{}))>::value);
+static_assert(utl::is_complete<decltype(instantiate<StoreAssertions>(
+        enum_types{}, store_operations{}))>::value);
+static_assert(utl::is_complete<decltype(instantiate<ExchangeAssertions>(
+        enum_types{}, atomic_operations{}))>::value);
+
+template <typename From, typename = void>
+struct BitwiseArg {
+    using type = From;
+};
+template <typename From>
+struct BitwiseArg<From, utl::enable_if_t<utl::is_pointer<From>::value>> {
+    using type = uintptr_t;
+};
+template <typename From>
+struct BitwiseArg<From, utl::enable_if_t<utl::is_enum<From>::value>> {
+    using type = utl::underlying_type_t<From>;
+};
+template <typename T>
+using BitwiseArg_t = typename BitwiseArg<T>::type;
+template <typename From, typename = void>
+struct ArithmeticArg {
+    using type = From;
+};
+template <typename From>
+struct ArithmeticArg<From, utl::enable_if_t<utl::is_pointer<From>::value>> {
+    using type = ptrdiff_t;
+};
+template <typename From>
+struct ArithmeticArg<From, utl::enable_if_t<utl::is_enum<From>::value>> {
+    using type = utl::underlying_type_t<From>;
+};
+template <typename T>
+using ArithmeticArg_t = typename ArithmeticArg<T>::type;
+
+template <typename TYPE, typename OP>
+struct FetchBitwiseAssertions {
+    static_assert(
+        utl::is_same<TYPE,
+            decltype(OP::fetch_and((TYPE*)(0), utl::declval<BitwiseArg_t<TYPE>>()))>::value,
+        "");
+    static_assert(utl::is_same<TYPE,
+                      decltype(OP::fetch_and(
+                          (TYPE volatile*)(0), utl::declval<BitwiseArg_t<TYPE>>()))>::value,
+        "");
+    static_assert(
+        utl::is_same<TYPE,
+            decltype(OP::fetch_or((TYPE*)(0), utl::declval<BitwiseArg_t<TYPE>>()))>::value,
+        "");
+    static_assert(
+        utl::is_same<TYPE,
+            decltype(OP::fetch_or((TYPE volatile*)(0), utl::declval<BitwiseArg_t<TYPE>>()))>::value,
+        "");
+    static_assert(
+        utl::is_same<TYPE,
+            decltype(OP::fetch_xor((TYPE*)(0), utl::declval<BitwiseArg_t<TYPE>>()))>::value,
+        "");
+    static_assert(utl::is_same<TYPE,
+                      decltype(OP::fetch_xor(
+                          (TYPE volatile*)(0), utl::declval<BitwiseArg_t<TYPE>>()))>::value,
+        "");
+};
+
+template <typename TYPE, typename OP>
+struct FetchArithmeticAssertions {
+    static_assert(
+        utl::is_same<TYPE,
+            decltype(OP::fetch_add((TYPE*)(0), utl::declval<ArithmeticArg_t<TYPE>>()))>::value,
+        "");
+    static_assert(utl::is_same<TYPE,
+                      decltype(OP::fetch_add(
+                          (TYPE volatile*)(0), utl::declval<ArithmeticArg_t<TYPE>>()))>::value,
+        "");
+    static_assert(
+        utl::is_same<TYPE,
+            decltype(OP::fetch_sub((TYPE*)(0), utl::declval<ArithmeticArg_t<TYPE>>()))>::value,
+        "");
+    static_assert(utl::is_same<TYPE,
+                      decltype(OP::fetch_sub(
+                          (TYPE volatile*)(0), utl::declval<ArithmeticArg_t<TYPE>>()))>::value,
+        "");
+};
+
+static_assert(utl::is_complete<decltype(instantiate<FetchBitwiseAssertions>(
+        native_types{}, atomic_operations{}))>::value);
+static_assert(utl::is_complete<decltype(instantiate<FetchArithmeticAssertions>(
+        native_types{}, atomic_operations{}))>::value);
+static_assert(utl::is_complete<decltype(instantiate<FetchBitwiseAssertions>(
+        enum_types{}, atomic_operations{}))>::value);
+static_assert(utl::is_complete<decltype(instantiate<FetchArithmeticAssertions>(
+        enum_types{}, atomic_operations{}))>::value);
+
+template <typename Failure>
+struct CompareExchangeAssertions {
+    template <typename TYPE, typename OP>
+    struct Assert {
+        static_assert(utl::is_boolean<decltype(OP::compare_exchange_strong(
+                          (TYPE*)(0), (TYPE*)(0), utl::declval<TYPE>(), Failure{}))>::value,
+            "");
+        static_assert(utl::is_boolean<decltype(OP::compare_exchange_strong((TYPE volatile*)(0),
+                          (TYPE*)(0), utl::declval<TYPE>(), Failure{}))>::value,
+            "");
+    };
+};
+
+static_assert(utl::is_complete<
+    decltype(instantiate<CompareExchangeAssertions<decltype(utl::memory_order_relaxed)>::Assert>(
+        native_types{}, atomic_operations{}))>::value);
+
+static_assert(utl::is_complete<decltype(instantiate<
+        CompareExchangeAssertions<decltype(utl::memory_order_acquire)>::Assert>(native_types{},
+        utl::type_list<utl::atomic_acquire, utl::atomic_release, utl::atomic_acq_rel,
+            utl::atomic_seq_cst>{}))>::value);
+
+static_assert(utl::is_complete<decltype(instantiate<
+        CompareExchangeAssertions<decltype(utl::memory_order_consume)>::Assert>(native_types{},
+        utl::type_list<utl::atomic_acquire, utl::atomic_consume, utl::atomic_release,
+            utl::atomic_acq_rel, utl::atomic_seq_cst>{}))>::value);
+
+static_assert(utl::is_complete<
+    decltype(instantiate<CompareExchangeAssertions<decltype(utl::memory_order_seq_cst)>::Assert>(
+        native_types{}, utl::type_list<utl::atomic_seq_cst>{}))>::value);
+
+static_assert(utl::is_complete<
+    decltype(instantiate<CompareExchangeAssertions<decltype(utl::memory_order_relaxed)>::Assert>(
+        enum_types{}, atomic_operations{}))>::value);
+
+static_assert(utl::is_complete<decltype(instantiate<
+        CompareExchangeAssertions<decltype(utl::memory_order_acquire)>::Assert>(enum_types{},
+        utl::type_list<utl::atomic_acquire, utl::atomic_release, utl::atomic_acq_rel,
+            utl::atomic_seq_cst>{}))>::value);
+
+static_assert(utl::is_complete<decltype(instantiate<
+        CompareExchangeAssertions<decltype(utl::memory_order_consume)>::Assert>(enum_types{},
+        utl::type_list<utl::atomic_acquire, utl::atomic_consume, utl::atomic_release,
+            utl::atomic_acq_rel, utl::atomic_seq_cst>{}))>::value);
+
+static_assert(utl::is_complete<
+    decltype(instantiate<CompareExchangeAssertions<decltype(utl::memory_order_seq_cst)>::Assert>(
+        enum_types{}, utl::type_list<utl::atomic_seq_cst>{}))>::value);
+
+} // namespace atomic_tests

--- a/src/utl/public/utl/atomic.h
+++ b/src/utl/public/utl/atomic.h
@@ -2,22 +2,4 @@
 
 #pragma once
 
-#include "utl/utl_config.h"
-
-#if UTL_CXX20
-
-#  include <atomic>
-
-UTL_NAMESPACE_BEGIN
-
-using std::atomic;
-using std::atomic_signal_fence;
-using std::atomic_thread_fence;
-using std::memory_order_acq_rel;
-using std::memory_order_acquire;
-using std::memory_order_relaxed;
-using std::memory_order_release;
-
-UTL_NAMESPACE_END
-
-#endif
+#include "utl/atomic/utl_atomic.h"

--- a/src/utl/public/utl/atomic/gnu/utl_atomic.h
+++ b/src/utl/public/utl/atomic/gnu/utl_atomic.h
@@ -25,6 +25,7 @@
 #include "utl/type_traits/utl_is_trivially_destructible.h"
 #include "utl/type_traits/utl_is_trivially_move_constructible.h"
 #include "utl/type_traits/utl_make_unsigned.h"
+#include "utl/type_traits/utl_remove_cv.h"
 #include "utl/type_traits/utl_underlying_type.h"
 
 #include <stdint.h>
@@ -67,8 +68,8 @@ struct interpreted_type<T, 16> {
 #if UTL_CXX20
 template <typename T>
 concept interpretable_type = (UTL_TRAIT_is_class(T) && UTL_TRAIT_is_trivially_destructible(T) &&
-    (UTL_TRAIT_is_trivially_copy_constructible(T) ||
-        UTL_TRAIT_is_trivially_move_constructible(T)) &&
+    (UTL_TRAIT_is_trivially_copy_constructible(remove_cv_t<T>) ||
+        UTL_TRAIT_is_trivially_move_constructible(remove_cv_t<T>)) &&
     requires { typename interpreted_type<T>::type; });
 
 template <typename T>

--- a/src/utl/public/utl/atomic/gnu/utl_atomic.h
+++ b/src/utl/public/utl/atomic/gnu/utl_atomic.h
@@ -38,28 +38,28 @@ using interpreted_type_t UTL_NODEBUG = typename interpreted_type<T>::type;
 
 template <typename T>
 struct interpreted_type<T, 1> {
-    using type = uint8_t;
+    using type UTL_NODEBUG = uint8_t;
 };
 
 template <typename T>
 struct interpreted_type<T, 2> {
-    using type = uint16_t;
+    using type UTL_NODEBUG = uint16_t;
 };
 
 template <typename T>
 struct interpreted_type<T, 4> {
-    using type = uint32_t;
+    using type UTL_NODEBUG = uint32_t;
 };
 
 template <typename T>
 struct interpreted_type<T, 8> {
-    using type = uint64_t;
+    using type UTL_NODEBUG = uint64_t;
 };
 
 #if UTL_SUPPORTS_INT128
 template <typename T>
 struct interpreted_type<T, 16> {
-    using type = __uint128_t;
+    using type UTL_NODEBUG = __uint128_t;
 };
 #endif
 
@@ -122,7 +122,7 @@ public:
 
     template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> load(T const* ctx) noexcept {
-        using type = copy_cv_t<T const, underlying_type_t<T>>;
+        using type UTL_NODEBUG = copy_cv_t<T const, underlying_type_t<T>>;
         return (value_type<T>)load((type*)ctx);
     }
 
@@ -134,7 +134,7 @@ public:
     template <UTL_CONCEPT_CXX20(interpretable_type) T UTL_CONSTRAINT_CXX11(is_interpretable<T>::value)>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> load(T const* ctx) noexcept {
         // Since the pointer isn't actually dereferenced, this __may__ not be UB
-        using type = copy_cv_t<T const, interpreted_type_t<T>>;
+        using type UTL_NODEBUG = copy_cv_t<T const, interpreted_type_t<T>>;
         auto const val = load((type*)ctx);
         alignas(T) unsigned char buffer[sizeof(T)];
         return *((value_type<T>*)__UTL_MEMCPY(buffer, &val, sizeof(T)));
@@ -162,7 +162,7 @@ public:
     template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
         T* ctx, value_type<T> value) noexcept {
-        using type = copy_cv_t<T, underlying_type_t<T>>;
+        using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
         store((type*)ctx, (underlying_type_t<T>)value, order);
     }
 
@@ -174,7 +174,7 @@ public:
     template <UTL_CONCEPT_CXX20(interpretable_type) T UTL_CONSTRAINT_CXX11(is_interpretable<T>::value)>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
         T* ctx, value_type<T> value) noexcept {
-        using type = copy_cv_t<T, interpreted_type_t<T>>;
+        using type UTL_NODEBUG = copy_cv_t<T, interpreted_type_t<T>>;
         alignas(T) unsigned char buffer[sizeof(T)];
         store((type*)ctx, *((interpreted_type_t<T>*)__UTL_MEMCPY(buffer, &value, sizeof(T))));
     }
@@ -206,14 +206,14 @@ public:
     template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
         T* ctx, value_type<T> value) noexcept {
-        using type = copy_cv_t<T, underlying_type_t<T>>;
+        using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
         return (value_type<T>)exchange((type*)ctx, (underlying_type_t<T>)value);
     }
 
     template <UTL_CONCEPT_CXX20(interpretable_type) T UTL_CONSTRAINT_CXX11(is_interpretable<T>::value)>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
         T* ctx, value_type<T> value) noexcept {
-        using type = copy_cv_t<T, interpreted_type_t<T>>;
+        using type UTL_NODEBUG = copy_cv_t<T, interpreted_type_t<T>>;
         alignas(T) unsigned char buffer[sizeof(T)];
         auto const val = exchange(
             (type*)ctx, *((interpreted_type_t<T>*)__UTL_MEMCPY(buffer, &value, sizeof(T))));
@@ -229,7 +229,7 @@ public:
     template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
         T* ctx, underlying_type_t<T> delta) noexcept {
-        using type = copy_cv_t<T, underlying_type_t<T>>;
+        using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
         return (value_type<T>)fetch_add((type*)ctx, (underlying_type_t<T>)delta);
     }
 
@@ -249,7 +249,7 @@ public:
     template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_sub(
         T* ctx, underlying_type_t<T> delta) noexcept {
-        using type = copy_cv_t<T, underlying_type_t<T>>;
+        using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
         return (value_type<T>)fetch_sub((type*)ctx, delta);
     }
 
@@ -269,7 +269,7 @@ public:
     template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
         T* ctx, underlying_type_t<T> mask) noexcept {
-        using type = copy_cv_t<T, underlying_type_t<T>>;
+        using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
         return (value_type<T>)fetch_and((type*)ctx, mask);
     }
 
@@ -289,7 +289,7 @@ public:
     template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
         T* ctx, underlying_type_t<T> mask) noexcept {
-        using type = copy_cv_t<T, underlying_type_t<T>>;
+        using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
         return (value_type<T>)fetch_or((type*)ctx, (underlying_type_t<T>)mask);
     }
 
@@ -309,7 +309,7 @@ public:
     template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
         T* ctx, underlying_type_t<T> mask) noexcept {
-        using type = copy_cv_t<T, underlying_type_t<T>>;
+        using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
         return (value_type<T>)fetch_xor((type*)ctx, mask);
     }
 
@@ -367,7 +367,7 @@ private:
     template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange_strong_(
         T* ctx, pointer<T> expected, value_type<T> value) noexcept {
-        using type = copy_cv_t<T, underlying_type_t<T>>;
+        using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
         return compare_exchange_strong_(
             (type*)ctx, (underlying_type_t<T>*)expected, (underlying_type_t<T>)value);
     }
@@ -375,7 +375,7 @@ private:
     template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange_weak_(
         T* ctx, pointer<T> expected, value_type<T> value) noexcept {
-        using type = copy_cv_t<T, underlying_type_t<T>>;
+        using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
         return compare_exchange_weak_(
             (type*)ctx, (underlying_type_t<T>*)expected, (underlying_type_t<T>)value);
     }
@@ -383,7 +383,7 @@ private:
     template <UTL_CONCEPT_CXX20(interpretable_type) T UTL_CONSTRAINT_CXX11(is_interpretable<T>::value)>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange_strong_(
         T* ctx, pointer<T> expected, value_type<T> value) noexcept {
-        using type = copy_cv_t<T, interpreted_type_t<T>>;
+        using type UTL_NODEBUG = copy_cv_t<T, interpreted_type_t<T>>;
         alignas(T) unsigned char buffer[sizeof(T)];
         return compare_exchange_strong_((type*)ctx, (interpreted_type_t<T>*)expected,
             *((interpreted_type_t<T>*)__UTL_MEMCPY(buffer, &value, sizeof(T))));
@@ -392,7 +392,7 @@ private:
     template <UTL_CONCEPT_CXX20(interpretable_type) T UTL_CONSTRAINT_CXX11(is_interpretable<T>::value)>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange_weak_(
         T* ctx, pointer<T> expected, value_type<T> value) noexcept {
-        using type = copy_cv_t<T, interpreted_type_t<T>>;
+        using type UTL_NODEBUG = copy_cv_t<T, interpreted_type_t<T>>;
         alignas(T) unsigned char buffer[sizeof(T)];
         return compare_exchange_weak_((type*)ctx, (interpreted_type_t<T>*)expected,
             *((interpreted_type_t<T>*)__UTL_MEMCPY(buffer, &value, sizeof(T))));

--- a/src/utl/public/utl/atomic/gnu/utl_atomic.h
+++ b/src/utl/public/utl/atomic/gnu/utl_atomic.h
@@ -179,7 +179,10 @@ public:
     template <UTL_CONCEPT_CXX20(interpretable_type) T UTL_CONSTRAINT_CXX11(is_interpretable<T>::value)>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
         T* ctx, value_type<T> const& value) noexcept {
-        __atomic_store(ctx, __UTL addressof(value), order);
+        alignas(T) unsigned char buffer[sizeof(T)];
+        auto ptr = reinterpret_cast<value_type<T>*>(
+            __UTL_MEMCPY(buffer, __UTL addressof(value), sizeof(T)));
+        __atomic_store(ctx, ptr, order);
     }
 };
 
@@ -228,13 +231,6 @@ public:
         return __atomic_fetch_add(ctx, delta, order);
     }
 
-    template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
-    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
-        T* ctx, underlying_type_t<T> delta) noexcept {
-        using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
-        return (value_type<T>)fetch_add((type*)ctx, (underlying_type_t<T>)delta);
-    }
-
     template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
     UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
@@ -246,13 +242,6 @@ public:
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_sub(
         T* ctx, value_type<T> delta) noexcept {
         return __atomic_fetch_sub(ctx, delta, order);
-    }
-
-    template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
-    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_sub(
-        T* ctx, underlying_type_t<T> delta) noexcept {
-        using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
-        return (value_type<T>)fetch_sub((type*)ctx, delta);
     }
 
     template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
@@ -268,57 +257,15 @@ public:
         return __atomic_fetch_and(ctx, mask, order);
     }
 
-    template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
-    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
-        T* ctx, underlying_type_t<T> mask) noexcept {
-        using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
-        return (value_type<T>)fetch_and((type*)ctx, mask);
-    }
-
-    template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
-    UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
-    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
-        T* ctx, uintptr_t mask) noexcept {
-        return __atomic_fetch_and(ctx, mask, order);
-    }
-
     template <UTL_CONCEPT_CXX20(integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
         T* ctx, value_type<T> mask) noexcept {
         return __atomic_fetch_or(ctx, mask, order);
     }
 
-    template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
-    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
-        T* ctx, underlying_type_t<T> mask) noexcept {
-        using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
-        return (value_type<T>)fetch_or((type*)ctx, (underlying_type_t<T>)mask);
-    }
-
-    template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
-    UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
-    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
-        T* ctx, uintptr_t mask) noexcept {
-        return __atomic_fetch_or(ctx, mask, order);
-    }
-
     template <UTL_CONCEPT_CXX20(integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
         T* ctx, value_type<T> mask) noexcept {
-        return __atomic_fetch_xor(ctx, mask, order);
-    }
-
-    template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
-    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
-        T* ctx, underlying_type_t<T> mask) noexcept {
-        using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
-        return (value_type<T>)fetch_xor((type*)ctx, mask);
-    }
-
-    template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
-    UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
-    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
-        T* ctx, uintptr_t mask) noexcept {
         return __atomic_fetch_xor(ctx, mask, order);
     }
 };

--- a/src/utl/public/utl/atomic/gnu/utl_atomic.h
+++ b/src/utl/public/utl/atomic/gnu/utl_atomic.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#if !defined(UTL_PLATFORM_ATOMIC_PRIVATE_HEADER_GUARD)
+#if !defined(UTL_ATOMIC_PRIVATE_HEADER_GUARD)
 #  error "Private header accessed"
 #endif
 
@@ -220,7 +220,8 @@ public:
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
         T* ctx, value_type<T> const& value) noexcept {
         alignas(T) unsigned char buffer[sizeof(T)];
-        auto ptr = (value_type<T>*)__UTL_MEMCPY(buffer, __UTL addressof(value), sizeof(T));
+        auto ptr = reinterpret_cast<value_type<T>*>(
+            __UTL_MEMCPY(buffer, __UTL addressof(value), sizeof(T)));
         __atomic_exchange(ctx, ptr, ptr, order);
         return *ptr;
     }

--- a/src/utl/public/utl/atomic/gnu/utl_atomic.h
+++ b/src/utl/public/utl/atomic/gnu/utl_atomic.h
@@ -31,7 +31,7 @@
 UTL_NAMESPACE_BEGIN
 
 namespace atomics {
-template <typename T, size_t = sizeof(T)>
+template <typename T, size_t = (alignof(T) == sizeof(T)) * sizeof(T)>
 struct interpreted_type;
 template <typename T>
 using interpreted_type_t UTL_NODEBUG = typename interpreted_type<T>::type;

--- a/src/utl/public/utl/atomic/gnu/utl_atomic.h
+++ b/src/utl/public/utl/atomic/gnu/utl_atomic.h
@@ -1,0 +1,311 @@
+// Copyright 2023-2024 Bryan Wong
+
+#pragma once
+
+#if !defined(UTL_PLATFORM_ATOMIC_PRIVATE_HEADER_GUARD)
+#  error "Private header accessed"
+#endif
+
+#include "utl/utl_config.h"
+
+#if !UTL_COMPILER_GNU_BASED
+#  error Invalid compiler
+#endif
+
+#include "utl/atomic/gnu/utl_memory_barriers.h"
+#include "utl/concepts/utl_boolean_type.h"
+#include "utl/numeric/utl_sized_integral.h"
+#include "utl/type_traits/utl_constants.h"
+#include "utl/type_traits/utl_copy_cv.h"
+#include "utl/type_traits/utl_enable_if.h"
+#include "utl/type_traits/utl_is_boolean.h"
+#include "utl/type_traits/utl_make_unsigned.h"
+#include "utl/type_traits/utl_underlying_type.h"
+
+#include <cstdint>
+
+UTL_NAMESPACE_BEGIN
+
+namespace atomics {
+template <memory_order O>
+struct fence_operations {
+protected:
+    static constexpr int order = (int)O;
+    UTL_CONSTEXPR_CXX20 ~fence_operations() noexcept = default;
+
+public:
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void thread_fence() noexcept {
+        __atomic_thread_fence(order);
+    }
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void signal_fence() noexcept {
+        __atomic_signal_fence(order);
+    }
+};
+
+template <memory_order O>
+struct load_operations {
+protected:
+    template <typename T>
+    using value_type = remove_cv_t<T>;
+    static_assert(is_load_order<O>(), "Invalid order");
+    static constexpr int order = (int)O;
+    UTL_CONSTEXPR_CXX20 ~load_operations() noexcept = default;
+
+public:
+    template <UTL_CONCEPT_CXX20(native_atomic_type) T UTL_CONSTRAINT_CXX11(is_native_atomic_type<T>::value)>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> load(T const* ctx) noexcept {
+        return __atomic_load_n(ctx, order);
+    }
+
+    template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> load(T const* ctx) noexcept {
+        using type = copy_cv_t<T const, underlying_type_t<T>>;
+        return (value_type<T>)load((type*)ctx);
+    }
+
+    template <UTL_CONCEPT_CXX20(boolean_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_boolean(T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool load(T const* ctx) noexcept {
+        return __atomic_load_n(ctx, order);
+    }
+};
+
+template <memory_order O>
+struct store_operations {
+private:
+    template <typename T>
+    using value_type = remove_cv_t<T>;
+
+protected:
+    static_assert(is_store_order<O>(), "Invalid order");
+    static constexpr int order = (int)O;
+    UTL_CONSTEXPR_CXX20 ~store_operations() noexcept = default;
+
+public:
+    template <UTL_CONCEPT_CXX20(native_atomic_type) T UTL_CONSTRAINT_CXX11(is_native_atomic_type<T>::value)>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
+        T* ctx, value_type<T> value) noexcept {
+        __atomic_store(ctx, __UTL addressof(value), order);
+    }
+
+    template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
+        T* ctx, value_type<T> value) noexcept {
+        using type = copy_cv_t<T, underlying_type_t<T>>;
+        store((type*)ctx, (underlying_type_t<T>)value, order);
+    }
+
+    template <UTL_CONCEPT_CXX20(boolean_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_boolean(T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(T const* ctx, bool value) noexcept {
+        __atomic_store(ctx, __UTL addressof(value), order);
+    }
+};
+
+template <memory_order O>
+struct exchange_operations {
+private:
+    template <typename T>
+    using value_type = remove_cv_t<T>;
+
+protected:
+    static constexpr int order = (int)O;
+    UTL_CONSTEXPR_CXX20 ~exchange_operations() noexcept = default;
+
+public:
+    template <UTL_CONCEPT_CXX20(native_atomic_type) T UTL_CONSTRAINT_CXX11(is_native_atomic_type<T>::value)>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+        T* ctx, value_type<T> value) noexcept {
+        return __atomic_exchange_n(ctx, value, order);
+    }
+
+    template <UTL_CONCEPT_CXX20(boolean_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_boolean(T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+        T* ctx, bool value) noexcept {
+        return __atomic_exchange_n(ctx, value, order);
+    }
+
+    template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+        T* ctx, value_type<T> value) noexcept {
+        using type = copy_cv_t<T, underlying_type_t<T>>;
+        return (value_type<T>)exchange((type*)ctx, (underlying_type_t<T>)value);
+    }
+
+    template <UTL_CONCEPT_CXX20(integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
+        T* ctx, value_type<T> delta) noexcept {
+        return __atomic_fetch_add(ctx, delta, order);
+    }
+
+    template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
+        T* ctx, underlying_type_t<T> delta) noexcept {
+        using type = copy_cv_t<T, underlying_type_t<T>>;
+        return (value_type<T>)fetch_add((type*)ctx, (underlying_type_t<T>)delta);
+    }
+
+    template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
+    UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
+        T* ctx, ptrdiff_t offset) noexcept {
+        return __atomic_fetch_add(ctx, offset * sizeof(T), order);
+    }
+
+    template <UTL_CONCEPT_CXX20(integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_sub(
+        T* ctx, value_type<T> delta) noexcept {
+        return __atomic_fetch_sub(ctx, delta, order);
+    }
+
+    template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_sub(
+        T* ctx, underlying_type_t<T> delta) noexcept {
+        using type = copy_cv_t<T, underlying_type_t<T>>;
+        return (value_type<T>)fetch_sub((type*)ctx, delta);
+    }
+
+    template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
+    UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_sub(
+        T* ctx, ptrdiff_t offset) noexcept {
+        return __atomic_fetch_sub(ctx, offset * sizeof(T), order);
+    }
+
+    template <UTL_CONCEPT_CXX20(integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
+        T* ctx, value_type<T> mask) noexcept {
+        return __atomic_fetch_and(ctx, mask, order);
+    }
+
+    template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
+        T* ctx, underlying_type_t<T> mask) noexcept {
+        using type = copy_cv_t<T, underlying_type_t<T>>;
+        return (value_type<T>)fetch_and((type*)ctx, mask);
+    }
+
+    template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
+    UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
+        T* ctx, uintptr_t mask) noexcept {
+        return __atomic_fetch_and(ctx, mask, order);
+    }
+
+    template <UTL_CONCEPT_CXX20(integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
+        T* ctx, value_type<T> mask) noexcept {
+        return __atomic_fetch_or(ctx, mask, order);
+    }
+
+    template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
+        T* ctx, underlying_type_t<T> mask) noexcept {
+        using type = copy_cv_t<T, underlying_type_t<T>>;
+        return (value_type<T>)fetch_or((type*)ctx, (underlying_type_t<T>)mask);
+    }
+
+    template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
+    UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
+        T* ctx, uintptr_t mask) noexcept {
+        return __atomic_fetch_or(ctx, mask, order);
+    }
+
+    template <UTL_CONCEPT_CXX20(integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
+        T* ctx, value_type<T> mask) noexcept {
+        return __atomic_fetch_xor(ctx, mask, order);
+    }
+
+    template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
+        T* ctx, underlying_type_t<T> mask) noexcept {
+        using type = copy_cv_t<T, underlying_type_t<T>>;
+        return (value_type<T>)fetch_xor((type*)ctx, mask);
+    }
+
+    template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
+    UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
+        T* ctx, uintptr_t mask) noexcept {
+        return __atomic_fetch_xor(ctx, mask, order);
+    }
+};
+
+template <memory_order S, memory_order F>
+struct compare_exchange_operations {
+private:
+    template <typename T>
+    using value_type = remove_cv_t<T>;
+    template <typename T>
+    using pointer = value_type<T>*;
+
+protected:
+    static_assert(is_load_order<F>(), "Invalid order");
+    static constexpr int success = (int)S;
+    static constexpr int fail = (int)F;
+    static constexpr bool strong = false;
+    static constexpr bool weak = true;
+    UTL_CONSTEXPR_CXX20 ~compare_exchange_operations() noexcept = default;
+
+private:
+    template <UTL_CONCEPT_CXX20(integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange_strong_(
+        T* ctx, pointer<T> expected, value_type<T> value) noexcept {
+        return __atomic_compare_exchange_n(ctx, expected, value, strong, success, fail);
+    }
+
+    template <UTL_CONCEPT_CXX20(integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange_weak_(
+        T* ctx, pointer<T> expected, value_type<T> value) noexcept {
+        return __atomic_compare_exchange_n(ctx, expected, value, weak, success, fail);
+    }
+
+    template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
+    UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_pointer(T))
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange_strong_(
+        T* ctx, pointer<T> expected, value_type<T> value) noexcept {
+        return __atomic_compare_exchange_n(ctx, expected, value, strong, success, fail);
+    }
+
+    template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
+    UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_pointer(T))
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange_weak_(
+        T* ctx, pointer<T> expected, value_type<T> value) noexcept {
+        return __atomic_compare_exchange_n(ctx, expected, value, weak, success, fail);
+    }
+
+    template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange_strong_(
+        T* ctx, pointer<T> expected, value_type<T> value) noexcept {
+        using type = copy_cv_t<T, underlying_type_t<T>>;
+        return compare_exchange_strong(
+            (type*)ctx, (underlying_type_t<T>*)expected, (underlying_type_t<T>)value);
+    }
+
+    template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange_weak_(
+        T* ctx, pointer<T> expected, value_type<T> value) noexcept {
+        using type = copy_cv_t<T, underlying_type_t<T>>;
+        return compare_exchange_weak(
+            (type*)ctx, (underlying_type_t<T>*)expected, (underlying_type_t<T>)value);
+    }
+
+public:
+    template <typename T>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline auto compare_exchange_strong(
+        T* ctx, pointer<T> expected, value_type<T> value, compare_exchange_failure<F>)
+        -> decltype(compare_exchange_strong_(ctx, expected, value)) {
+        return compare_exchange_strong_(ctx, expected, value);
+    }
+
+    template <typename T>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline auto compare_exchange_weak(
+        T* ctx, pointer<T> expected, value_type<T> value, compare_exchange_failure<F>)
+        -> decltype(compare_exchange_weak_(ctx, expected, value)) {
+        return compare_exchange_weak_(ctx, expected, value);
+    }
+};
+
+} // namespace atomics
+
+UTL_NAMESPACE_END

--- a/src/utl/public/utl/atomic/gnu/utl_memory_barriers.h
+++ b/src/utl/public/utl/atomic/gnu/utl_memory_barriers.h
@@ -1,0 +1,35 @@
+// Copyright 2023-2024 Bryan Wong
+
+#pragma once
+
+#if !defined(UTL_PLATFORM_ATOMIC_PRIVATE_HEADER_GUARD)
+#  error "Private header accessed"
+#endif
+
+#include "utl/utl_config.h"
+
+#if !UTL_COMPILER_GNU_BASED
+#  error Invalid compiler
+#endif
+
+#if UTL_ARCH_ARM
+#  include "utl/hardware/arm/utl_barrier.h"
+#  if UTL_HAS_BUILTIN(__builtin_arm_dmb)
+#    define __UTL_ACQUIRE_BARRIER() __builtin_arm_dmb(arm::barrier::ISHLD)
+#    define __UTL_MEMORY_BARRIER() __builtin_arm_dmb(arm::barrier::ISH)
+#    define __UTL_STORE_BARRIER() __builtin_arm_dmb(arm::barrier::ISHST)
+#  else
+#    define __UTL_ACQUIRE_BARRIER() __asm__ volatile("dmb ishld" : : : "memory")
+#    define __UTL_MEMORY_BARRIER() __asm__ volatile("dmb ish" : : : "memory")
+#    define __UTL_STORE_BARRIER() __asm__ volatile("dmb ishst" : : : "memory")
+#  endif
+#  define __UTL_HW_MEMORY_BARRIER() __UTL_MEMORY_BARRIER()
+
+#elif UTL_ARCH_x86
+#  define __UTL_ACQUIRE_BARRIER() UTL_COMPILER_BARRIER()
+#  define __UTL_MEMORY_BARRIER() UTL_COMPILER_BARRIER()
+#  define __UTL_STORE_BARRIER() UTL_COMPILER_BARRIER()
+#  define __UTL_HW_MEMORY_BARRIER() __asm__ volatile("mfence" : : : "memory")
+#else
+#  error Unsupported architecture
+#endif

--- a/src/utl/public/utl/atomic/gnu/utl_memory_barriers.h
+++ b/src/utl/public/utl/atomic/gnu/utl_memory_barriers.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#if !defined(UTL_PLATFORM_ATOMIC_PRIVATE_HEADER_GUARD)
+#if !defined(UTL_ATOMIC_PRIVATE_HEADER_GUARD)
 #  error "Private header accessed"
 #endif
 

--- a/src/utl/public/utl/atomic/utl_atomic.h
+++ b/src/utl/public/utl/atomic/utl_atomic.h
@@ -20,16 +20,13 @@
 #endif
 
 /**
- * Atomic Standardization
+ * UTL Atomic
  * Current support:
  * * GNU based compilers that rely on the GNU atomic intrinsics
  * * MSVC using the Interlock intrinsics
  *
- * By default only fundamental objects are supported:
- * * Custom atomic types must specialize the platform::custom_atomic_type type
- * trait
- * * If data type is a class with padding bits, it is the user's responsibility
- * to zero them out
+ * * Class types must be trivially destructible and either trivially copyable or trivially movable
+ * * If data type is a class with padding bits, it is the user's responsibility to zero them out
  */
 
 #if UTL_COMPILER_GNU_BASED
@@ -126,7 +123,7 @@ UTL_CONSTEVAL bool is_store_order() noexcept {
 } // namespace atomics
 
 UTL_NAMESPACE_END
-#define UTL_PLATFORM_ATOMIC_PRIVATE_HEADER_GUARD
+#define UTL_ATOMIC_PRIVATE_HEADER_GUARD
 #if UTL_COMPILER_GNU_BASED
 #  include "utl/atomic/gnu/utl_atomic.h"
 #elif UTL_COMPILER_MSVC
@@ -134,7 +131,7 @@ UTL_NAMESPACE_END
 #else
 #  error Unsupported platform
 #endif
-#undef UTL_PLATFORM_ATOMIC_PRIVATE_HEADER_GUARD
+#undef UTL_ATOMIC_PRIVATE_HEADER_GUARD
 UTL_NAMESPACE_BEGIN
 
 template <>

--- a/src/utl/public/utl/atomic/utl_atomic.h
+++ b/src/utl/public/utl/atomic/utl_atomic.h
@@ -1,0 +1,263 @@
+// Copyright 2023-2024 Bryan Wong
+
+#pragma once
+
+#include "utl/utl_config.h"
+
+#include "utl/concepts/utl_boolean_type.h"
+#include "utl/memory/utl_addressof.h"
+#include "utl/type_traits/utl_constants.h"
+#include "utl/type_traits/utl_is_arithmetic.h"
+#include "utl/type_traits/utl_is_boolean.h"
+#include "utl/type_traits/utl_is_pointer.h"
+#include "utl/type_traits/utl_logical_traits.h"
+#include "utl/utility/utl_to_underlying.h"
+#if UTL_CXX20
+#  include "utl/concepts/utl_arithmetic_type.h"
+#  include "utl/concepts/utl_enum_type.h"
+#else
+#  include "utl/type_traits/utl_is_enum.h"
+#endif
+
+/**
+ * Atomic Standardization
+ * Current support:
+ * * GNU based compilers that rely on the GNU atomic intrinsics
+ * * MSVC using the Interlock intrinsics
+ *
+ * By default only fundamental objects are supported:
+ * * Custom atomic types must specialize the platform::custom_atomic_type type
+ * trait
+ * * If data type is a class with padding bits, it is the user's responsibility
+ * to zero them out
+ */
+
+#if UTL_COMPILER_GNU_BASED
+
+#  if !defined(__ATOMIC_RELAXED) || !defined(__ATOMIC_CONSUME) || !defined(__ATOMIC_ACQUIRE) || \
+      !defined(__ATOMIC_RELEASE) || !defined(__ATOMIC_ACQ_REL) || !defined(__ATOMIC_SEQ_CST)
+#    error Undefined atomic semantics
+#  endif
+
+UTL_NAMESPACE_BEGIN
+enum class memory_order : int {
+    relaxed = __ATOMIC_RELAXED,
+    consume = __ATOMIC_CONSUME,
+    acquire = __ATOMIC_ACQUIRE,
+    release = __ATOMIC_RELEASE,
+    acq_rel = __ATOMIC_ACQ_REL,
+    seq_cst = __ATOMIC_SEQ_CST,
+};
+UTL_NAMESPACE_END
+#else // UTL_COMPILER_GNU_BASED
+
+UTL_NAMESPACE_BEGIN
+enum class memory_order : int {
+    relaxed,
+    consume,
+    acquire,
+    release,
+    acq_rel,
+    seq_cst,
+};
+UTL_NAMESPACE_END
+
+#endif // UTL_COMPILER_GNU_BASED
+
+UTL_NAMESPACE_BEGIN
+
+template <memory_order O>
+using memory_order_type = value_constant<memory_order, O>;
+
+UTL_INLINE_CXX17 constexpr memory_order_type<memory_order::relaxed> memory_order_relaxed{};
+UTL_INLINE_CXX17 constexpr memory_order_type<memory_order::acquire> memory_order_acquire{};
+UTL_INLINE_CXX17 constexpr memory_order_type<memory_order::consume> memory_order_consume{};
+UTL_INLINE_CXX17 constexpr memory_order_type<memory_order::release> memory_order_release{};
+UTL_INLINE_CXX17 constexpr memory_order_type<memory_order::acq_rel> memory_order_acq_rel{};
+UTL_INLINE_CXX17 constexpr memory_order_type<memory_order::seq_cst> memory_order_seq_cst{};
+
+template <memory_order>
+struct atomic_operations;
+using atomic_relaxed = atomic_operations<memory_order::relaxed>;
+using atomic_consume = atomic_operations<memory_order::consume>;
+using atomic_acquire = atomic_operations<memory_order::acquire>;
+using atomic_release = atomic_operations<memory_order::release>;
+using atomic_acq_rel = atomic_operations<memory_order::acq_rel>;
+using atomic_seq_cst = atomic_operations<memory_order::seq_cst>;
+
+#if UTL_CXX20
+template <typename T>
+concept native_atomic_type = (arithmetic_type<T> && !boolean_type<T>) || is_pointer_v<T>;
+#endif
+
+template <typename T>
+struct is_native_atomic_type :
+    disjunction<bool_constant<is_arithmetic<T>::value && !is_boolean<T>::value>, is_pointer<T>> {};
+
+/**
+ * It's not supported on any compilers anyway
+ */
+template <typename T>
+T kill_dependency(T v) noexcept {
+    return v;
+}
+
+namespace atomics {
+template <memory_order O>
+using compare_exchange_failure = memory_order_type<O>;
+using relaxed_failure_t = compare_exchange_failure<memory_order::relaxed>;
+using acquire_failure_t = compare_exchange_failure<memory_order::acquire>;
+using consume_failure_t = compare_exchange_failure<memory_order::consume>;
+using seq_cst_failure_t = compare_exchange_failure<memory_order::seq_cst>;
+UTL_INLINE_CXX17 constexpr relaxed_failure_t relaxed_failure{};
+UTL_INLINE_CXX17 constexpr acquire_failure_t acquire_failure{};
+UTL_INLINE_CXX17 constexpr consume_failure_t consume_failure{};
+UTL_INLINE_CXX17 constexpr seq_cst_failure_t seq_cst_failure{};
+
+template <memory_order O>
+UTL_CONSTEVAL bool is_load_order() noexcept {
+    return O != memory_order::release || O != memory_order::acq_rel;
+}
+
+template <memory_order O>
+UTL_CONSTEVAL bool is_store_order() noexcept {
+    return O != memory_order::consume || O != memory_order::acquire || O != memory_order::acq_rel;
+}
+} // namespace atomics
+
+UTL_NAMESPACE_END
+#define UTL_PLATFORM_ATOMIC_PRIVATE_HEADER_GUARD
+#if UTL_COMPILER_GNU_BASED
+#  include "utl/atomic/gnu/utl_atomic.h"
+#elif UTL_COMPILER_MSVC
+#  include "utl/atomic/winapi/utl_atomic.h"
+#else
+#  error Unsupported platform
+#endif
+#undef UTL_PLATFORM_ATOMIC_PRIVATE_HEADER_GUARD
+UTL_NAMESPACE_BEGIN
+
+template <>
+struct atomic_operations<memory_order::relaxed> :
+    atomics::load_operations<memory_order::relaxed>,
+    atomics::store_operations<memory_order::relaxed>,
+    atomics::exchange_operations<memory_order::relaxed>,
+    atomics::fence_operations<memory_order::relaxed>,
+    atomics::compare_exchange_operations<memory_order::relaxed, memory_order::relaxed> {
+    using atomics::compare_exchange_operations<memory_order::relaxed,
+        memory_order::relaxed>::compare_exchange_strong;
+    using atomics::compare_exchange_operations<memory_order::relaxed,
+        memory_order::relaxed>::compare_exchange_weak;
+};
+
+template <>
+struct atomic_operations<memory_order::acquire> :
+    atomics::load_operations<memory_order::acquire>,
+    atomics::exchange_operations<memory_order::acquire>,
+    atomics::fence_operations<memory_order::acquire>,
+    atomics::compare_exchange_operations<memory_order::acquire, memory_order::acquire>,
+    atomics::compare_exchange_operations<memory_order::acquire, memory_order::consume>,
+    atomics::compare_exchange_operations<memory_order::acquire, memory_order::relaxed> {
+    using atomics::compare_exchange_operations<memory_order::acquire,
+        memory_order::acquire>::compare_exchange_strong;
+    using atomics::compare_exchange_operations<memory_order::acquire,
+        memory_order::consume>::compare_exchange_strong;
+    using atomics::compare_exchange_operations<memory_order::acquire,
+        memory_order::relaxed>::compare_exchange_strong;
+    using atomics::compare_exchange_operations<memory_order::acquire,
+        memory_order::acquire>::compare_exchange_weak;
+    using atomics::compare_exchange_operations<memory_order::acquire,
+        memory_order::consume>::compare_exchange_weak;
+    using atomics::compare_exchange_operations<memory_order::acquire,
+        memory_order::relaxed>::compare_exchange_weak;
+};
+
+template <>
+struct atomic_operations<memory_order::consume> :
+    atomics::load_operations<memory_order::consume>,
+    atomics::exchange_operations<memory_order::consume>,
+    atomics::fence_operations<memory_order::consume>,
+    atomics::compare_exchange_operations<memory_order::consume, memory_order::consume>,
+    atomics::compare_exchange_operations<memory_order::consume, memory_order::relaxed> {
+    using atomics::compare_exchange_operations<memory_order::consume,
+        memory_order::consume>::compare_exchange_strong;
+    using atomics::compare_exchange_operations<memory_order::consume,
+        memory_order::relaxed>::compare_exchange_strong;
+    using atomics::compare_exchange_operations<memory_order::consume,
+        memory_order::consume>::compare_exchange_weak;
+    using atomics::compare_exchange_operations<memory_order::consume,
+        memory_order::relaxed>::compare_exchange_weak;
+};
+
+template <>
+struct atomic_operations<memory_order::release> :
+    atomics::store_operations<memory_order::release>,
+    atomics::exchange_operations<memory_order::release>,
+    atomics::fence_operations<memory_order::release>,
+    atomics::compare_exchange_operations<memory_order::release, memory_order::acquire>,
+    atomics::compare_exchange_operations<memory_order::release, memory_order::consume>,
+    atomics::compare_exchange_operations<memory_order::release, memory_order::relaxed> {
+    using atomics::compare_exchange_operations<memory_order::release,
+        memory_order::acquire>::compare_exchange_strong;
+    using atomics::compare_exchange_operations<memory_order::release,
+        memory_order::consume>::compare_exchange_strong;
+    using atomics::compare_exchange_operations<memory_order::release,
+        memory_order::relaxed>::compare_exchange_strong;
+    using atomics::compare_exchange_operations<memory_order::release,
+        memory_order::acquire>::compare_exchange_weak;
+    using atomics::compare_exchange_operations<memory_order::release,
+        memory_order::consume>::compare_exchange_weak;
+    using atomics::compare_exchange_operations<memory_order::release,
+        memory_order::relaxed>::compare_exchange_weak;
+};
+
+template <>
+struct atomic_operations<memory_order::acq_rel> :
+    atomics::exchange_operations<memory_order::acq_rel>,
+    atomics::fence_operations<memory_order::acq_rel>,
+    atomics::compare_exchange_operations<memory_order::acq_rel, memory_order::acquire>,
+    atomics::compare_exchange_operations<memory_order::acq_rel, memory_order::consume>,
+    atomics::compare_exchange_operations<memory_order::acq_rel, memory_order::relaxed> {
+    using atomics::compare_exchange_operations<memory_order::acq_rel,
+        memory_order::acquire>::compare_exchange_strong;
+    using atomics::compare_exchange_operations<memory_order::acq_rel,
+        memory_order::consume>::compare_exchange_strong;
+    using atomics::compare_exchange_operations<memory_order::acq_rel,
+        memory_order::relaxed>::compare_exchange_strong;
+    using atomics::compare_exchange_operations<memory_order::acq_rel,
+        memory_order::acquire>::compare_exchange_weak;
+    using atomics::compare_exchange_operations<memory_order::acq_rel,
+        memory_order::consume>::compare_exchange_weak;
+    using atomics::compare_exchange_operations<memory_order::acq_rel,
+        memory_order::relaxed>::compare_exchange_weak;
+};
+
+template <>
+struct atomic_operations<memory_order::seq_cst> :
+    atomics::load_operations<memory_order::seq_cst>,
+    atomics::store_operations<memory_order::seq_cst>,
+    atomics::exchange_operations<memory_order::seq_cst>,
+    atomics::fence_operations<memory_order::seq_cst>,
+    atomics::compare_exchange_operations<memory_order::seq_cst, memory_order::seq_cst>,
+    atomics::compare_exchange_operations<memory_order::seq_cst, memory_order::acquire>,
+    atomics::compare_exchange_operations<memory_order::seq_cst, memory_order::consume>,
+    atomics::compare_exchange_operations<memory_order::seq_cst, memory_order::relaxed> {
+    using atomics::compare_exchange_operations<memory_order::seq_cst,
+        memory_order::seq_cst>::compare_exchange_strong;
+    using atomics::compare_exchange_operations<memory_order::seq_cst,
+        memory_order::acquire>::compare_exchange_strong;
+    using atomics::compare_exchange_operations<memory_order::seq_cst,
+        memory_order::consume>::compare_exchange_strong;
+    using atomics::compare_exchange_operations<memory_order::seq_cst,
+        memory_order::relaxed>::compare_exchange_strong;
+    using atomics::compare_exchange_operations<memory_order::seq_cst,
+        memory_order::seq_cst>::compare_exchange_weak;
+    using atomics::compare_exchange_operations<memory_order::seq_cst,
+        memory_order::acquire>::compare_exchange_weak;
+    using atomics::compare_exchange_operations<memory_order::seq_cst,
+        memory_order::consume>::compare_exchange_weak;
+    using atomics::compare_exchange_operations<memory_order::seq_cst,
+        memory_order::relaxed>::compare_exchange_weak;
+};
+
+UTL_NAMESPACE_END

--- a/src/utl/public/utl/atomic/winapi/utl_atomic.h
+++ b/src/utl/public/utl/atomic/winapi/utl_atomic.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#if !defined(UTL_PLATFORM_ATOMIC_PRIVATE_HEADER_GUARD)
+#if !defined(UTL_ATOMIC_PRIVATE_HEADER_GUARD)
 #  error "Private header accessed"
 #endif
 
@@ -459,6 +459,35 @@ private:
         __iso_volatile_store64((__int64 volatile*)ctx, value);
     }
 
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
+        T* ctx, value_type<T> value, seq_cst_typ) noexcept {
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedExchange8(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
+        T* ctx, value_type<T> value, seq_cst_typ) noexcept {
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
+        _InterlockedExchange16(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value));
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
+        T* ctx, value_type<T> value, seq_cst_typ) noexcept {
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
+        _InterlockedExchange32(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value));
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
+        T* ctx, value_type<T> value, seq_cst_typ) noexcept {
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
+        _InterlockedExchange64(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value));
+    }
+
 #if UTL_ARCH_ARM
     template <UTL_CONCEPT_CXX20(sized_integral<1>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
@@ -514,7 +543,7 @@ public:
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
             T* ctx, value_type<T> value) noexcept {
             using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
-            store((type*)ctx, (underlying_type_t<T>)value);
+            store((type*)ctx, (underlying_type_t<T>)value, this_order);
         }
 
         template <UTL_CONCEPT_CXX20(boolean_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_boolean(T))>

--- a/src/utl/public/utl/atomic/winapi/utl_atomic.h
+++ b/src/utl/public/utl/atomic/winapi/utl_atomic.h
@@ -1175,22 +1175,15 @@ public:
         }
         template <UTL_CONCEPT_CXX20(interpretable_type) T UTL_CONSTRAINT_CXX11(is_interpretable<T>::value)>
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
-            T* ctx, value_type<T> value) noexcept {
+            T* ctx, value_type<T> const& value) noexcept {
             using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
             return adaptor::to_value(
                 exchange(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value), this_order));
         }
-
         template <UTL_CONCEPT_CXX20(integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
             T* ctx, value_type<T> value) noexcept {
             return fetch_add(ctx, value, this_order);
-        }
-        template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
-        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
-            T* ctx, underlying_type_t<T> value) noexcept {
-            using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
-            return (value_type<T>)fetch_add((type*)ctx, value);
         }
         template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
         UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
@@ -1205,12 +1198,6 @@ public:
             T* ctx, value_type<T> value) noexcept {
             return fetch_sub(ctx, value, this_order);
         }
-        template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
-        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_sub(
-            T* ctx, underlying_type_t<T> value) noexcept {
-            using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
-            return (value_type<T>)fetch_sub((type*)ctx, value);
-        }
         template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
         UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_sub(
@@ -1224,35 +1211,15 @@ public:
             T* ctx, value_type<T> value) noexcept {
             return fetch_and(ctx, value, this_order);
         }
-        template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
-        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
-            T* ctx, underlying_type_t<T> value) noexcept {
-            using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
-            return (value_type<T>)fetch_and((type*)ctx, value);
-        }
-
         template <UTL_CONCEPT_CXX20(integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
             T* ctx, value_type<T> value) noexcept {
             return fetch_or(ctx, value, this_order);
         }
-        template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
-        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
-            T* ctx, underlying_type_t<T> value) noexcept {
-            using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
-            return (value_type<T>)fetch_or((type*)ctx, value);
-        }
-
         template <UTL_CONCEPT_CXX20(integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
             T* ctx, value_type<T> value) noexcept {
             return fetch_xor(ctx, value, this_order);
-        }
-        template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
-        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
-            T* ctx, underlying_type_t<T> value) noexcept {
-            using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
-            return (value_type<T>)fetch_xor((type*)ctx, value);
         }
     };
 };

--- a/src/utl/public/utl/atomic/winapi/utl_atomic.h
+++ b/src/utl/public/utl/atomic/winapi/utl_atomic.h
@@ -192,7 +192,7 @@ public:
 
     UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
     static inline constexpr interlocked_type to_interlocked(value_type value) noexcept {
-        return base_type::to_interlocked(to_underlying(value));
+        return base_type::to_interlocked(__UTL to_underlying(value));
     }
 
     UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
@@ -223,9 +223,10 @@ public:
     using interlocked_type = interpreted_type_t<T>;
 
     UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
-    static inline constexpr interlocked_type to_interlocked(value_type value) noexcept {
+    static inline constexpr interlocked_type to_interlocked(value_type const& value) noexcept {
         interlocked_type ret;
-        return *(interlocked_type*)__UTL_MEMCPY(&ret, &value, sizeof(value_type));
+        __UTL_MEMCPY(&ret, __UTL addressof(value), sizeof(value_type));
+        return ret;
     }
 
     UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
@@ -1466,7 +1467,7 @@ private:
         memory_order_type<F> failure) noexcept {
         using adaptor = interlocked_adaptor<T>;
         constexpr auto order = interlock_order(success, failure);
-        auto const comp = adaptor::to_interlocked(*expected);
+        auto const comp = adaptor::to_interlock(*expected);
         auto const prev = interlocked(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(desired), comp, order);
         if (comp == prev) {
@@ -1485,7 +1486,7 @@ private:
         memory_order_type<F> failure) noexcept {
         using adaptor = interlocked_adaptor<T>;
         constexpr auto order = interlock_order(success, failure);
-        auto const comp = adaptor::to_interlocked(*expected);
+        auto const comp = adaptor::to_interlock(*expected);
         auto const prev = interlocked(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(desired), comp, order);
         if (comp == prev) {
@@ -1504,7 +1505,7 @@ private:
         memory_order_type<F> failure) noexcept {
         using adaptor = interlocked_adaptor<T>;
         constexpr auto order = interlock_order(success, failure);
-        auto const comp = adaptor::to_interlocked(*expected);
+        auto const comp = adaptor::to_interlock(*expected);
         auto const prev = interlocked(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(desired), comp, order);
         if (comp == prev) {
@@ -1517,11 +1518,11 @@ private:
 
     template <UTL_CONCEPT_CXX20(interpretable_type) T, memory_order S, memory_order F UTL_CONSTRAINT_CXX11(is_interpretable<T>::value)>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(T* ctx,
-        pointer<T> expected, value_type<T> desired, memory_order_type<S> success,
+        pointer<T> expected, value_type<T> const& desired, memory_order_type<S> success,
         memory_order_type<F> failure) noexcept {
         using adaptor = interlocked_adaptor<T>;
         constexpr auto order = interlock_order(success, failure);
-        auto const comp = adaptor::to_interlocked(*expected);
+        auto const comp = adaptor::to_interlock(*expected);
         auto const prev = interlocked(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(desired), comp, order);
         if (comp == prev) {
@@ -1534,7 +1535,7 @@ private:
 
     template <UTL_CONCEPT_CXX20(sized_integral<16>) T, memory_order S, memory_order F UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(16, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(T* ctx,
-        pointer<T> expected, value_type<T> desired, memory_order_type<S> success,
+        pointer<T> expected, value_type<T> const& desired, memory_order_type<S> success,
         memory_order_type<F> failure) noexcept {
         constexpr auto order = interlock_order(success, failure);
         alignas(16) __int64 buffer[2];
@@ -1553,15 +1554,15 @@ public:
 
     public:
         template <typename T>
-        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline auto compare_exchange_strong(
-            T* ctx, pointer<T> expected, value_type<T> desired, failure_type failure) noexcept
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline auto compare_exchange_strong(T* ctx,
+            pointer<T> expected, value_type<T> const& desired, failure_type failure) noexcept
             -> decltype(compare_exchange(ctx, expected, desired, success_v, failure)) {
             return compare_exchange(ctx, expected, desired, success_v, failure);
         }
 
         template <typename T>
-        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline auto compare_exchange_weak(
-            T* ctx, pointer<T> expected, value_type<T> desired, failure_type failure) noexcept
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline auto compare_exchange_weak(T* ctx,
+            pointer<T> expected, value_type<T> const& desired, failure_type failure) noexcept
             -> decltype(compare_exchange(ctx, expected, desired, success_v, failure)) {
             // Only < ARMv8.1-a has no dedicated CAS instruction
             // But it requires exclusive load/store intrinsics to be exposed by MSVC to be supported

--- a/src/utl/public/utl/atomic/winapi/utl_atomic.h
+++ b/src/utl/public/utl/atomic/winapi/utl_atomic.h
@@ -1230,13 +1230,7 @@ public:
             using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
             return (value_type<T>)fetch_and((type*)ctx, value);
         }
-        template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
-        UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
-        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
-            T* ctx, uintptr_t value) noexcept {
-            using type UTL_NODEBUG = copy_cv_t<T, uintptr_t>;
-            return (value_type<T>)fetch_and((type*)ctx, value);
-        }
+
         template <UTL_CONCEPT_CXX20(integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
             T* ctx, value_type<T> value) noexcept {
@@ -1248,13 +1242,7 @@ public:
             using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
             return (value_type<T>)fetch_or((type*)ctx, value);
         }
-        template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
-        UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
-        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
-            T* ctx, uintptr_t value) noexcept {
-            using type UTL_NODEBUG = copy_cv_t<T, uintptr_t>;
-            return (value_type<T>)fetch_or((type*)ctx, value);
-        }
+
         template <UTL_CONCEPT_CXX20(integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
             T* ctx, value_type<T> value) noexcept {
@@ -1264,13 +1252,6 @@ public:
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
             T* ctx, underlying_type_t<T> value) noexcept {
             using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
-            return (value_type<T>)fetch_xor((type*)ctx, value);
-        }
-        template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
-        UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
-        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
-            T* ctx, uintptr_t value) noexcept {
-            using type UTL_NODEBUG = copy_cv_t<T, uintptr_t>;
             return (value_type<T>)fetch_xor((type*)ctx, value);
         }
     };

--- a/src/utl/public/utl/atomic/winapi/utl_atomic.h
+++ b/src/utl/public/utl/atomic/winapi/utl_atomic.h
@@ -32,7 +32,7 @@ UTL_NAMESPACE_BEGIN
 
 namespace atomics {
 
-template <typename T, size_t = sizeof(T)>
+template <typename T, size_t = (alignof(T) == sizeof(T)) * sizeof(T)>
 struct interpreted_type;
 template <typename T>
 using interpreted_type_t UTL_NODEBUG = typename interpreted_type<T>::type;

--- a/src/utl/public/utl/atomic/winapi/utl_atomic.h
+++ b/src/utl/public/utl/atomic/winapi/utl_atomic.h
@@ -39,22 +39,22 @@ using interpreted_type_t UTL_NODEBUG = typename interpreted_type<T>::type;
 
 template <typename T>
 struct interpreted_type<T, 1> {
-    using type = char;
+    using type UTL_NODEBUG = char;
 };
 
 template <typename T>
 struct interpreted_type<T, 2> {
-    using type = short;
+    using type UTL_NODEBUG = short;
 };
 
 template <typename T>
 struct interpreted_type<T, 4> {
-    using type = long;
+    using type UTL_NODEBUG = long;
 };
 
 template <typename T>
 struct interpreted_type<T, 8> {
-    using type = __int64;
+    using type UTL_NODEBUG = __int64;
 };
 
 // TODO: Could we support int128?
@@ -411,7 +411,7 @@ public:
         template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD) static inline value_type<T> load(
             T const* ctx) noexcept {
-            using type = copy_cv_t<T const, underlying_type_t<T>>;
+            using type UTL_NODEBUG = copy_cv_t<T const, underlying_type_t<T>>;
             return load((type*)ctx);
         }
 
@@ -424,7 +424,7 @@ public:
         template <UTL_CONCEPT_CXX20(interpretable_type) T UTL_CONSTRAINT_CXX11(is_interpretable<T>::value)>
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD) static inline value_type<T> load(
             T const* ctx) noexcept {
-            using type = copy_cv_t<T const, interpreted_type_t<T>>;
+            using type UTL_NODEBUG = copy_cv_t<T const, interpreted_type_t<T>>;
             return load((type*)ctx, this_order);
         }
     };
@@ -513,7 +513,7 @@ public:
         template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
             T* ctx, value_type<T> value) noexcept {
-            using type = copy_cv_t<T, underlying_type_t<T>>;
+            using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
             store((type*)ctx, (underlying_type_t<T>)value);
         }
 
@@ -526,7 +526,7 @@ public:
         template <UTL_CONCEPT_CXX20(interpretable_type) T UTL_CONSTRAINT_CXX11(is_interpretable<T>::value)>
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
             T* ctx, value_type<T> value) noexcept {
-            using type = copy_cv_t<T, interpreted_type_t<T>>;
+            using type UTL_NODEBUG = copy_cv_t<T, interpreted_type_t<T>>;
             alignas(T) unsigned char buffer[sizeof(T)];
             store((type*)ctx, *(interpreted_type_t<T>*)__UTL_MEMCPY(buffer, &value, sizeof(T)),
                 this_order);
@@ -552,28 +552,28 @@ private:
     template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
         T* ctx, value_type<T> value, relaxed_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedExchange8_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
         T* ctx, value_type<T> value, relaxed_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchange16_nf(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
         T* ctx, value_type<T> value, relaxed_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchange32_nf(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
         T* ctx, value_type<T> value, relaxed_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchange64_nf(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
@@ -581,7 +581,7 @@ private:
     UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_pointer(T))
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
         T* ctx, value_type<T> value, relaxed_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchangePointer_nf(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
@@ -589,28 +589,28 @@ private:
     template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
         T* ctx, value_type<T> value, acquire_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchange8_acq(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
         T* ctx, value_type<T> value, acquire_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchange16_acq(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
         T* ctx, value_type<T> value, acquire_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchange32_acq(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
         T* ctx, value_type<T> value, acquire_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchange64_acq(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
@@ -618,7 +618,7 @@ private:
     UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_pointer(T))
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
         T* ctx, value_type<T> value, acquire_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchangePointer_acq(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
@@ -626,28 +626,28 @@ private:
     template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
         T* ctx, value_type<T> value, release_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchange8_rel(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
         T* ctx, value_type<T> value, release_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchange16_rel(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
         T* ctx, value_type<T> value, release_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchange32_rel(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
         T* ctx, value_type<T> value, release_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchange64_rel(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
@@ -655,7 +655,7 @@ private:
     UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_pointer(T))
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
         T* ctx, value_type<T> value, release_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchangePointer_rel(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
@@ -663,28 +663,28 @@ private:
     template <UTL_CONCEPT_CXX20(sized_integral<1>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
         T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedExchange8(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<2>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
         T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedExchange16(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<4>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
         T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedExchange32(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<8>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
         T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedExchange64(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
@@ -692,7 +692,7 @@ private:
     UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_pointer(T))
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
         T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchangePointer(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
@@ -700,84 +700,84 @@ private:
     template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
         T* ctx, value_type<T> value, relaxed_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchangeAdd8_nf(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
         T* ctx, value_type<T> value, relaxed_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchangeAdd16_nf(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
         T* ctx, value_type<T> value, relaxed_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchangeAdd32_nf(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
         T* ctx, value_type<T> value, relaxed_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchangeAdd64_nf(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
         T* ctx, value_type<T> value, acquire_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchangeAdd8_acq(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
         T* ctx, value_type<T> value, acquire_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchangeAdd16_acq(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
         T* ctx, value_type<T> value, acquire_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchangeAdd32_acq(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
         T* ctx, value_type<T> value, acquire_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchangeAdd64_acq(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
         T* ctx, value_type<T> value, release_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchangeAdd8_rel(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
         T* ctx, value_type<T> value, release_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchangeAdd16_rel(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
         T* ctx, value_type<T> value, release_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchangeAdd32_rel(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
         T* ctx, value_type<T> value, release_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchangeAdd64_rel(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
@@ -785,28 +785,28 @@ private:
     template <UTL_CONCEPT_CXX20(sized_integral<1>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
         T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedExchangeAdd8(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<2>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
         T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchangeAdd16(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<4>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
         T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchangeAdd32(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<8>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
         T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(_InterlockedExchangeAdd64(
             adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
@@ -818,336 +818,336 @@ private:
     template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
         T* ctx, value_type<T> value, relaxed_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedAnd8_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
         T* ctx, value_type<T> value, relaxed_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedAnd16_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
         T* ctx, value_type<T> value, relaxed_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedAnd32_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
         T* ctx, value_type<T> value, relaxed_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedAnd64_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
         T* ctx, value_type<T> value, release_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedAnd8_rel(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
         T* ctx, value_type<T> value, release_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedAnd16_rel(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
         T* ctx, value_type<T> value, release_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedAnd32_rel(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
         T* ctx, value_type<T> value, release_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedAnd64_rel(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
         T* ctx, value_type<T> value, acquire_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedAnd8_acq(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
         T* ctx, value_type<T> value, acquire_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedAnd16_acq(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
         T* ctx, value_type<T> value, acquire_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedAnd32_acq(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
         T* ctx, value_type<T> value, acquire_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedAnd64_acq(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<1>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
         T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedAnd8(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<2>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
         T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedAnd16(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<4>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
         T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedAnd32(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<8>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
         T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedAnd64(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
         T* ctx, value_type<T> value, relaxed_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedOr8_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
         T* ctx, value_type<T> value, relaxed_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedOr16_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
         T* ctx, value_type<T> value, relaxed_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedOr32_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
         T* ctx, value_type<T> value, relaxed_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedOr64_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
         T* ctx, value_type<T> value, release_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedOr8_rel(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
         T* ctx, value_type<T> value, release_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedOr16_rel(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
         T* ctx, value_type<T> value, release_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedOr32_rel(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
         T* ctx, value_type<T> value, release_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedOr64_rel(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
         T* ctx, value_type<T> value, acquire_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedOr8_acq(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
         T* ctx, value_type<T> value, acquire_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedOr16_acq(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
         T* ctx, value_type<T> value, acquire_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedOr32_acq(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
         T* ctx, value_type<T> value, acquire_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedOr64_acq(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<1>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
         T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedOr8(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<2>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
         T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedOr16(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<4>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
         T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedOr32(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<8>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
         T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedOr64(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
         T* ctx, value_type<T> value, relaxed_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedXor8_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
         T* ctx, value_type<T> value, relaxed_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedXor16_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
         T* ctx, value_type<T> value, relaxed_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedXor32_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
         T* ctx, value_type<T> value, relaxed_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedXor64_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
         T* ctx, value_type<T> value, release_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedXor8_rel(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
         T* ctx, value_type<T> value, release_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedXor16_rel(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
         T* ctx, value_type<T> value, release_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedXor32_rel(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
         T* ctx, value_type<T> value, release_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedXor64_rel(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
         T* ctx, value_type<T> value, acquire_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedXor8_acq(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
         T* ctx, value_type<T> value, acquire_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedXor16_acq(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
         T* ctx, value_type<T> value, acquire_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedXor32_acq(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
         T* ctx, value_type<T> value, acquire_type) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedXor64_acq(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<1>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
         T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedXor8(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<2>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
         T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedXor16(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<4>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
         T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedXor32(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
     template <UTL_CONCEPT_CXX20(sized_integral<8>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
         T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         return adaptor::to_value(
             _InterlockedXor64(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
     }
@@ -1170,13 +1170,13 @@ public:
         template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
             T* ctx, value_type<T> value) noexcept {
-            using type = copy_cv_t<T, underlying_type_t<T>>;
+            using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
             return (value_type<T>)exchange((type*)ctx, (underlying_type_t<T>)value);
         }
         template <UTL_CONCEPT_CXX20(interpretable_type) T UTL_CONSTRAINT_CXX11(is_interpretable<T>::value)>
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
             T* ctx, value_type<T> value) noexcept {
-            using adaptor = interlocked_adaptor<T>;
+            using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
             return adaptor::to_value(
                 exchange(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value), this_order));
         }
@@ -1189,7 +1189,7 @@ public:
         template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
             T* ctx, underlying_type_t<T> value) noexcept {
-            using type = copy_cv_t<T, underlying_type_t<T>>;
+            using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
             return (value_type<T>)fetch_add((type*)ctx, value);
         }
         template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
@@ -1197,7 +1197,7 @@ public:
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
             T* ctx, ptrdiff_t value) noexcept {
             static constexpr intptr_t stride = sizeof(T);
-            using type = copy_cv_t<T, intptr_t>;
+            using type UTL_NODEBUG = copy_cv_t<T, intptr_t>;
             return (value_type<T>)fetch_add((type*)ctx, (intptr_t)value * stride);
         }
         template <UTL_CONCEPT_CXX20(integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
@@ -1208,7 +1208,7 @@ public:
         template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_sub(
             T* ctx, underlying_type_t<T> value) noexcept {
-            using type = copy_cv_t<T, underlying_type_t<T>>;
+            using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
             return (value_type<T>)fetch_sub((type*)ctx, value);
         }
         template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
@@ -1216,7 +1216,7 @@ public:
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_sub(
             T* ctx, ptrdiff_t value) noexcept {
             static constexpr intptr_t stride = sizeof(T);
-            using type = copy_cv_t<T, intptr_t>;
+            using type UTL_NODEBUG = copy_cv_t<T, intptr_t>;
             return (value_type<T>)fetch_sub((type*)ctx, (intptr_t)value * stride);
         }
         template <UTL_CONCEPT_CXX20(integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
@@ -1227,14 +1227,14 @@ public:
         template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
             T* ctx, underlying_type_t<T> value) noexcept {
-            using type = copy_cv_t<T, underlying_type_t<T>>;
+            using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
             return (value_type<T>)fetch_and((type*)ctx, value);
         }
         template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
         UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
             T* ctx, uintptr_t value) noexcept {
-            using type = copy_cv_t<T, uintptr_t>;
+            using type UTL_NODEBUG = copy_cv_t<T, uintptr_t>;
             return (value_type<T>)fetch_and((type*)ctx, value);
         }
         template <UTL_CONCEPT_CXX20(integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
@@ -1245,14 +1245,14 @@ public:
         template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
             T* ctx, underlying_type_t<T> value) noexcept {
-            using type = copy_cv_t<T, underlying_type_t<T>>;
+            using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
             return (value_type<T>)fetch_or((type*)ctx, value);
         }
         template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
         UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
             T* ctx, uintptr_t value) noexcept {
-            using type = copy_cv_t<T, uintptr_t>;
+            using type UTL_NODEBUG = copy_cv_t<T, uintptr_t>;
             return (value_type<T>)fetch_or((type*)ctx, value);
         }
         template <UTL_CONCEPT_CXX20(integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
@@ -1263,14 +1263,14 @@ public:
         template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
             T* ctx, underlying_type_t<T> value) noexcept {
-            using type = copy_cv_t<T, underlying_type_t<T>>;
+            using type UTL_NODEBUG = copy_cv_t<T, underlying_type_t<T>>;
             return (value_type<T>)fetch_xor((type*)ctx, value);
         }
         template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
         UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
         UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
             T* ctx, uintptr_t value) noexcept {
-            using type = copy_cv_t<T, uintptr_t>;
+            using type UTL_NODEBUG = copy_cv_t<T, uintptr_t>;
             return (value_type<T>)fetch_xor((type*)ctx, value);
         }
     };
@@ -1286,15 +1286,15 @@ using exchange_operations = exchange_traits::operations<O>;
 struct compare_exchange_traits {
 private:
     template <typename T>
-    using value_type = typename interlocked_adaptor<T>::value_type;
+    using value_type UTL_NODEBUG = typename interlocked_adaptor<T>::value_type;
     template <typename T>
-    using pointer = typename interlocked_adaptor<T>::pointer;
-    using relaxed_type = memory_order_type<memory_order::relaxed>;
-    using acquire_type = memory_order_type<memory_order::acquire>;
-    using release_type = memory_order_type<memory_order::release>;
-    using consume_type = memory_order_type<memory_order::consume>;
-    using seq_cst_type = memory_order_type<memory_order::seq_cst>;
-    using acq_rel_type = memory_order_type<memory_order::acq_rel>;
+    using pointer UTL_NODEBUG = typename interlocked_adaptor<T>::pointer;
+    using relaxed_type UTL_NODEBUG = memory_order_type<memory_order::relaxed>;
+    using acquire_type UTL_NODEBUG = memory_order_type<memory_order::acquire>;
+    using release_type UTL_NODEBUG = memory_order_type<memory_order::release>;
+    using consume_type UTL_NODEBUG = memory_order_type<memory_order::consume>;
+    using seq_cst_type UTL_NODEBUG = memory_order_type<memory_order::seq_cst>;
+    using acq_rel_type UTL_NODEBUG = memory_order_type<memory_order::acq_rel>;
     static constexpr release_type release_v{};
     static constexpr acquire_type acquire_v{};
 
@@ -1465,7 +1465,7 @@ private:
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
         T* ctx, pointer<T> expected, value_type<T> desired, memory_order_type<S> success,
         memory_order_type<F> failure) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         constexpr auto order = interlock_order(success, failure);
         auto const comp = adaptor::to_interlock(*expected);
         auto const prev = interlocked(
@@ -1484,7 +1484,7 @@ private:
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
         T* ctx, pointer<T> expected, value_type<T> desired, memory_order_type<S> success,
         memory_order_type<F> failure) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         constexpr auto order = interlock_order(success, failure);
         auto const comp = adaptor::to_interlock(*expected);
         auto const prev = interlocked(
@@ -1503,7 +1503,7 @@ private:
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(T* ctx,
         pointer<T> expected, value_type<T> desired, memory_order_type<S> success,
         memory_order_type<F> failure) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         constexpr auto order = interlock_order(success, failure);
         auto const comp = adaptor::to_interlock(*expected);
         auto const prev = interlocked(
@@ -1520,7 +1520,7 @@ private:
     UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(T* ctx,
         pointer<T> expected, value_type<T> const& desired, memory_order_type<S> success,
         memory_order_type<F> failure) noexcept {
-        using adaptor = interlocked_adaptor<T>;
+        using adaptor UTL_NODEBUG = interlocked_adaptor<T>;
         constexpr auto order = interlock_order(success, failure);
         auto const comp = adaptor::to_interlock(*expected);
         auto const prev = interlocked(
@@ -1549,7 +1549,7 @@ public:
     struct operations {
     protected:
         static constexpr memory_order_type<S> success_v{};
-        using failure_type = compare_exchange_failure<F>;
+        using failure_type UTL_NODEBUG = compare_exchange_failure<F>;
         UTL_CONSTEXPR_CXX20 ~operations() noexcept = default;
 
     public:

--- a/src/utl/public/utl/atomic/winapi/utl_atomic.h
+++ b/src/utl/public/utl/atomic/winapi/utl_atomic.h
@@ -1,0 +1,1707 @@
+// Copyright 2023-2024 Bryan Wong
+
+#pragma once
+
+#if !defined(UTL_PLATFORM_ATOMIC_PRIVATE_HEADER_GUARD)
+#  error "Private header accessed"
+#endif
+
+#include "utl/utl_config.h"
+
+#if !UTL_COMPILER_MSVC
+#  error Invalid compiler
+#endif
+
+#include "utl/atomic/winapi/utl_interlocked.h"
+#include "utl/atomic/winapi/utl_memory_access.h"
+#include "utl/atomic/winapi/utl_memory_barriers.h"
+#include "utl/numeric/utl_sized_integral.h"
+#include "utl/type_traits/utl_constants.h"
+#include "utl/type_traits/utl_copy_cv.h"
+#include "utl/type_traits/utl_enable_if.h"
+#include "utl/type_traits/utl_make_unsigned.h"
+#include "utl/type_traits/utl_remove_cv.h"
+#include "utl/type_traits/utl_underlying_type.h"
+#include "utl/utility/utl_to_underlying.h"
+
+UTL_NAMESPACE_BEGIN
+
+namespace atomics {
+#if UTL_CXX20
+template <typename T>
+struct interlocked_adaptor;
+#else
+template <typename T, typename = void>
+struct interlocked_adaptor;
+#endif
+
+#if UTL_CXX20
+template <sized_integral<1> T>
+struct interlocked_adaptor<T> {
+#else
+template <typename T>
+struct interlocked_adaptor<T, enable_if_t<UTL_TRAIT_is_sized_integral(1, T)>> {
+#endif
+    using value_type = remove_cv_t<T>;
+    using pointer = value_type*;
+    using volatile_pointer = value_type volatile*;
+    using const_pointer = value_type const*;
+    using const_volatile_pointer = value_type const volatile*;
+    using interlocked_type = char;
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr interlocked_type to_interlocked(value_type value) noexcept {
+        return (interlocked_type)value;
+    }
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr interlocked_type const volatile* to_interlocked(
+        const_volatile_pointer value) noexcept {
+        return value;
+    }
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr value_type to_value(interlocked_type value) noexcept {
+        return (value_type)value;
+    }
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr bool equal(value_type l, value_type r) noexcept { return l == r; }
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr void assign(pointer dst, value_type src) noexcept { *dst = src; }
+};
+
+#if UTL_CXX20
+template <sized_integral<2> T>
+struct interlocked_adaptor<T> {
+#else
+template <typename T>
+struct interlocked_adaptor<T, enable_if_t<UTL_TRAIT_is_sized_integral(2, T)>> {
+#endif
+    using value_type = remove_cv_t<T>;
+    using pointer = value_type*;
+    using volatile_pointer = value_type volatile*;
+    using const_pointer = value_type const*;
+    using const_volatile_pointer = value_type const volatile*;
+    using interlocked_type = short;
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr interlocked_type to_interlocked(value_type value) noexcept {
+        return (interlocked_type)value;
+    }
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr interlocked_type const volatile* to_interlocked(
+        const_volatile_pointer value) noexcept {
+        return value;
+    }
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr value_type to_value(interlocked_type value) noexcept {
+        return (value_type)value;
+    }
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr bool equal(value_type l, value_type r) noexcept { return l == r; }
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr void assign(pointer dst, value_type src) noexcept { *dst = src; }
+};
+
+#if UTL_CXX20
+template <sized_integral<4> T>
+struct interlocked_adaptor<T> {
+#else
+template <typename T>
+struct interlocked_adaptor<T, enable_if_t<UTL_TRAIT_is_sized_integral(4, T)>> {
+#endif
+    using value_type = remove_cv_t<T>;
+    using pointer = value_type*;
+    using volatile_pointer = value_type volatile*;
+    using const_pointer = value_type const*;
+    using const_volatile_pointer = value_type const volatile*;
+    using interlocked_type = long;
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr interlocked_type to_interlocked(value_type value) noexcept {
+        return (interlocked_type)value;
+    }
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr interlocked_type const volatile* to_interlocked(
+        const_volatile_pointer value) noexcept {
+        return value;
+    }
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr value_type to_value(interlocked_type value) noexcept {
+        return (value_type)value;
+    }
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr bool equal(value_type l, value_type r) noexcept { return l == r; }
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr void assign(pointer dst, value_type src) noexcept { *dst = src; }
+};
+
+#if UTL_CXX20
+template <sized_integral<8> T>
+struct interlocked_adaptor<T> {
+#else
+template <typename T>
+struct interlocked_adaptor<T, enable_if_t<UTL_TRAIT_is_sized_integral(8, T)>> {
+#endif
+    using value_type = remove_cv_t<T>;
+    using pointer = value_type*;
+    using volatile_pointer = value_type volatile*;
+    using const_pointer = value_type const*;
+    using const_volatile_pointer = value_type const volatile*;
+    using interlocked_type = __int64;
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr interlocked_type to_interlocked(value_type value) noexcept {
+        return (interlocked_type)value;
+    }
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr interlocked_type const volatile* to_interlocked(
+        const_volatile_pointer value) noexcept {
+        return value;
+    }
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr value_type to_value(interlocked_type value) noexcept {
+        return (value_type)value;
+    }
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr bool equal(value_type l, value_type r) noexcept { return l == r; }
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr void assign(pointer dst, value_type src) noexcept { *dst = src; }
+};
+
+#if UTL_CXX20
+template <typename T>
+requires is_pointer_v<T>
+struct interlocked_adaptor<T> {
+#else
+template <typename T>
+struct interlocked_adaptor<T, enable_if_t<UTL_TRAIT_is_pointer(T)>> {
+#endif
+    using value_type = remove_cv_t<T>;
+    using pointer = value_type*;
+    using volatile_pointer = value_type volatile*;
+    using const_pointer = value_type const*;
+    using const_volatile_pointer = value_type const volatile*;
+    using interlocked_type = void*;
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr interlocked_type to_interlocked(value_type value) noexcept {
+        return (interlocked_type)value;
+    }
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr interlocked_type const volatile* to_interlocked(
+        const_volatile_pointer value) noexcept {
+        return value;
+    }
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr value_type to_value(interlocked_type value) noexcept {
+        return (value_type)value;
+    }
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr bool equal(value_type l, value_type r) noexcept { return l == r; }
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr void assign(pointer dst, value_type src) noexcept { *dst = src; }
+};
+
+#if UTL_CXX20
+template <enum_type T>
+struct interlocked_adaptor<T> : private interlocked_adaptor<underlying_type_t<T>> {
+#else
+template <typename T>
+struct interlocked_adaptor<T, enable_if_t<UTL_TRAIT_is_enum(T)>> :
+    private interlocked_adaptor<underlying_type_t<T>> {
+#endif
+private:
+    using base_type = interlocked_adaptor<underlying_type_t<T>>;
+
+public:
+    using value_type = remove_cv_t<T>;
+    using pointer = value_type*;
+    using volatile_pointer = value_type volatile*;
+    using const_pointer = value_type const*;
+    using const_volatile_pointer = value_type const volatile*;
+    using typename base_type::interlocked_type;
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr interlocked_type to_interlocked(value_type value) noexcept {
+        return base_type::to_interlocked(to_underlying(value));
+    }
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr interlocked_type const volatile* to_interlocked(
+        const_volatile_pointer value) noexcept {
+        return base_type::to_interlocked(to_underlying(value));
+    }
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr value_type to_value(interlocked_type value) noexcept {
+        return (value_type)base_type::to_value(value);
+    }
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr bool equal(value_type l, value_type r) noexcept {
+        return base_type::equal(to_underlying(l), to_underlying(r));
+    }
+
+    UTL_ATTRIBUTE(__HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+    static inline constexpr void assign(pointer dst, value_type src) noexcept { *dst = src; }
+};
+
+struct fence_traits {
+private:
+    using relaxed_type = memory_order_type<memory_order::relaxed>;
+    using acquire_type = memory_order_type<memory_order::acquire>;
+    using consume_type = memory_order_type<memory_order::consume>;
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void thread_fence(relaxed_type) noexcept {}
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void signal_fence(relaxed_type) noexcept {}
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void thread_fence(acquire_type) noexcept {
+        __UTL_ACQUIRE_BARRIER();
+    }
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void thread_fence(consume_type) noexcept {
+        __UTL_ACQUIRE_BARRIER();
+    }
+    template <memory_order O>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void thread_fence(
+        memory_order_type<O>) noexcept {
+        __UTL_MEMORY_BARRIER();
+    }
+    template <memory_order O>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void signal_fence(
+        memory_order_type<O>) noexcept {
+        UTL_COMPILER_BARRIER();
+    }
+
+public:
+    template <memory_order O>
+    struct operations {
+    protected:
+        static constexpr memory_order_type<O> this_order{};
+        UTL_CONSTEXPR_CXX20 ~operations() noexcept = default;
+
+    public:
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void thread_fence() noexcept {
+            thread_fence(this_order);
+        }
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void signal_fence() noexcept {
+            signal_fence(this_order);
+        }
+    };
+};
+
+struct load_traits {
+private:
+    template <typename T>
+    using value_type = typename interlocked_adaptor<T>::value_type;
+    using relaxed_type = memory_order_type<memory_order::relaxed>;
+    using seq_cst_type = memory_order_type<memory_order::seq_cst>;
+
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> load(
+        T const* ctx, relaxed_type) noexcept {
+        return (value_type<T>)__iso_volatile_load8((__int8 const volatile*)ctx);
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> load(
+        T const* ctx, relaxed_type) noexcept {
+        return (value_type<T>)__iso_volatile_load16((__int16 const volatile*)ctx);
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> load(
+        T const* ctx, relaxed_type) noexcept {
+        return (value_type<T>)__iso_volatile_load32((__int32 const volatile*)ctx);
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> load(
+        T const* ctx, relaxed_type) noexcept {
+        return (value_type<T>)__iso_volatile_load64((__int64 const volatile*)ctx);
+    }
+#if UTL_ARCH_ARM
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> load(
+        T const* ctx, seq_cst_type) noexcept {
+        auto const val = (value_type<T>)__ldar8((unsigned __int8 const volatile*)ctx);
+        UTL_COMPILER_BARRIER();
+        return val;
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> load(
+        T const* ctx, seq_cst_type) noexcept {
+        auto const val = (value_type<T>)__ldar16((unsigned __int16 const volatile*)ctx);
+        UTL_COMPILER_BARRIER();
+        return val;
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> load(
+        T const* ctx, seq_cst_type) noexcept {
+        auto const val = (value_type<T>)__ldar32((unsigned __int32 const volatile*)ctx);
+        UTL_COMPILER_BARRIER();
+        return val;
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> load(
+        T const* ctx, seq_cst_type) noexcept {
+        auto const val = (value_type<T>)__ldar64((unsigned __int64 const volatile*)ctx);
+        UTL_COMPILER_BARRIER();
+        return val;
+    }
+#  ifdef UTL_ENABLE_RCPC_LOAD
+#    define __UTL_LOAD_ACQ(WIDTH, TARGET) \
+        __ldapr##WIDTH((unsigned __int##WIDTH const volatile*)TARGET)
+#  else
+#    define __UTL_LOAD_ACQ(WIDTH, TARGET) \
+        __ldar##WIDTH((unsigned __int##WIDTH const volatile*)TARGET)
+#  endif
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> load(
+        T const* ctx, memory_order_type<O>) noexcept {
+        auto const val = (value_type<T>)__UTL_LOAD_ACQ(8, ctx);
+        UTL_COMPILER_BARRIER();
+        return val;
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> load(
+        T const* ctx, memory_order_type<O>) noexcept {
+        auto const val = (value_type<T>)__UTL_LOAD_ACQ(16, ctx);
+        UTL_COMPILER_BARRIER();
+        return val;
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> load(
+        T const* ctx, memory_order_type<O>) noexcept {
+        auto const val = (value_type<T>)__UTL_LOAD_ACQ(32, ctx);
+        UTL_COMPILER_BARRIER();
+        return val;
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> load(
+        T const* ctx, memory_order_type<O>) noexcept {
+        auto const val = (value_type<T>)__UTL_LOAD_ACQ(64, ctx);
+        UTL_COMPILER_BARRIER();
+        return val;
+    }
+#  undef __UTL_LOAD_ACQ
+#else
+    template <UTL_CONCEPT_CXX20(integral) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> load(
+        T const* ctx, memory_order_type<O>) noexcept {
+        auto val = load((__int64 const volatile*)ctx, memory_order_relaxed);
+        UTL_COMPILER_BARRIER();
+        return val;
+    }
+#endif
+public:
+    template <memory_order O>
+    struct operations {
+    protected:
+        static_assert(is_load_order<O>(), "Invalid order");
+        static constexpr memory_order_type<O> this_order{};
+        UTL_CONSTEXPR_CXX20 ~operations() noexcept = default;
+
+    public:
+        template <UTL_CONCEPT_CXX20(native_atomic_type) T UTL_CONSTRAINT_CXX11(is_native_atomic_type<T>::value)>
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> load(T* ctx) noexcept {
+            return load(ctx, this_order);
+        }
+
+        template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> load(T* ctx) noexcept {
+            return load((underlying_type_t<T>*)ctx);
+        }
+
+        template <UTL_CONCEPT_CXX20(boolean_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_boolean(T))>
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> load(T* ctx) noexcept {
+            return load(ctx, this_order);
+        }
+    };
+};
+
+struct store_traits {
+private:
+    template <typename T>
+    using value_type = typename interlocked_adaptor<T>::value_type;
+    using relaxed_type = value_constant<memory_order, memory_order::relaxed>;
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        __iso_volatile_store8((__int8 volatile*)ctx, value);
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        __iso_volatile_store16((__int16 volatile*)ctx, value);
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        __iso_volatile_store32((__int32 volatile*)ctx, value);
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        __iso_volatile_store64((__int64 volatile*)ctx, value);
+    }
+
+#if UTL_ARCH_ARM
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
+        T* ctx, value_type<T> value, value_constant<memory_order, O>) noexcept {
+        UTL_COMPILER_BARRIER();
+        __stlr8((unsigned __int8 volatile*)ctx, value);
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
+        T* ctx, value_type<T> value, value_constant<memory_order, O>) noexcept {
+        UTL_COMPILER_BARRIER();
+        __stlr16((unsigned __int16 volatile*)ctx, value);
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
+        T* ctx, value_type<T> value, value_constant<memory_order, O>) noexcept {
+        UTL_COMPILER_BARRIER();
+        __stlr32((unsigned __int32 volatile*)ctx, value);
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
+        T* ctx, value_type<T> value, value_constant<memory_order, O>) noexcept {
+        UTL_COMPILER_BARRIER();
+        __stlr64((unsigned __int64 volatile*)ctx, value);
+    }
+#else
+    template <UTL_CONCEPT_CXX20(integral) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
+        T* ctx, value_type<T> value, value_constant<memory_order, O>) noexcept {
+        UTL_COMPILER_BARRIER();
+        store(ctx, value, memory_order_relaxed);
+    }
+#endif
+public:
+    template <memory_order O>
+    struct operations {
+    protected:
+        static_assert(is_store_order<O>(), "Invalid order");
+        static constexpr value_constant<memory_order, O> this_order{};
+        UTL_CONSTEXPR_CXX20 ~operations() noexcept = default;
+
+    public:
+        template <UTL_CONCEPT_CXX20(native_atomic_type) T UTL_CONSTRAINT_CXX11(is_native_atomic_type<T>::value)>
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
+            T* ctx, value_type<T> value) noexcept {
+            store(ctx, value, this_order);
+        }
+
+        template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
+            T* ctx, value_type<T> value) noexcept {
+            store((underlying_type_t<T>*)ctx, (underlying_type_t<T>)value);
+        }
+
+        template <UTL_CONCEPT_CXX20(boolean_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_boolean(T))>
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline void store(
+            T* ctx, value_type<T> value) noexcept {
+            store(ctx, value, this_order);
+        }
+    };
+};
+
+template <memory_order O>
+using fence_operations = fence_traits::operations<O>;
+template <memory_order O>
+using load_operations = load_traits::operations<O>;
+template <memory_order O>
+using store_operations = store_traits::operations<O>;
+
+struct exchange_traits {
+private:
+    template <typename T>
+    using value_type = typename interlocked_adaptor<T>::value_type;
+    using relaxed_type = memory_order_type<memory_order::relaxed>;
+    using acquire_type = memory_order_type<memory_order::acquire>;
+    using release_type = memory_order_type<memory_order::release>;
+    using consume_type = memory_order_type<memory_order::consume>;
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedExchange8_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchange16_nf(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchange32_nf(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchange64_nf(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <typename T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
+    UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_pointer(T))
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchangePointer_nf(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+        T* ctx, value_type<T> value, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchange8_acq(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+        T* ctx, value_type<T> value, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchange16_acq(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+        T* ctx, value_type<T> value, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchange32_acq(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+        T* ctx, value_type<T> value, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchange64_acq(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <typename T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
+    UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_pointer(T))
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+        T* ctx, value_type<T> value, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchangePointer_acq(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+        T* ctx, value_type<T> value, release_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchange8_rel(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+        T* ctx, value_type<T> value, release_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchange16_rel(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+        T* ctx, value_type<T> value, release_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchange32_rel(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+        T* ctx, value_type<T> value, release_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchange64_rel(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <typename T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
+    UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_pointer(T))
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+        T* ctx, value_type<T> value, release_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchangePointer_rel(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+        T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedExchange8(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+        T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedExchange16(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+        T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedExchange32(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+        T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedExchange64(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <typename T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
+    UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_pointer(T))
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+        T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchangePointer(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchangeAdd8_nf(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchangeAdd16_nf(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchangeAdd32_nf(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchangeAdd64_nf(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
+        T* ctx, value_type<T> value, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchangeAdd8_acq(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
+        T* ctx, value_type<T> value, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchangeAdd16_acq(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
+        T* ctx, value_type<T> value, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchangeAdd32_acq(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
+        T* ctx, value_type<T> value, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchangeAdd64_acq(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
+        T* ctx, value_type<T> value, release_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchangeAdd8_rel(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
+        T* ctx, value_type<T> value, release_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchangeAdd16_rel(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
+        T* ctx, value_type<T> value, release_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchangeAdd32_rel(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
+        T* ctx, value_type<T> value, release_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchangeAdd64_rel(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
+        T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedExchangeAdd8(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
+        T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchangeAdd16(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
+        T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchangeAdd32(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
+        T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(_InterlockedExchangeAdd64(
+            adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(integral) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_sub(
+        T* ctx, value_type<T> value, memory_order_type<O> order) noexcept {
+        return fetch_add(ctx, (T)(0u - (make_unsigned_t<T>)value), order);
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedAnd8_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedAnd16_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedAnd32_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedAnd64_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
+        T* ctx, value_type<T> value, release_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedAnd8_rel(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
+        T* ctx, value_type<T> value, release_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedAnd16_rel(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
+        T* ctx, value_type<T> value, release_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedAnd32_rel(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
+        T* ctx, value_type<T> value, release_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedAnd64_rel(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
+        T* ctx, value_type<T> value, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedAnd8_acq(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
+        T* ctx, value_type<T> value, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedAnd16_acq(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
+        T* ctx, value_type<T> value, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedAnd32_acq(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
+        T* ctx, value_type<T> value, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedAnd64_acq(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
+        T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedAnd8(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
+        T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedAnd16(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
+        T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedAnd32(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
+        T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedAnd64(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedOr8_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedOr16_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedOr32_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedOr64_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
+        T* ctx, value_type<T> value, release_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedOr8_rel(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
+        T* ctx, value_type<T> value, release_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedOr16_rel(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
+        T* ctx, value_type<T> value, release_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedOr32_rel(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
+        T* ctx, value_type<T> value, release_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedOr64_rel(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
+        T* ctx, value_type<T> value, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedOr8_acq(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
+        T* ctx, value_type<T> value, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedOr16_acq(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
+        T* ctx, value_type<T> value, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedOr32_acq(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
+        T* ctx, value_type<T> value, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedOr64_acq(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
+        T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedOr8(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
+        T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedOr16(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
+        T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedOr32(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
+        T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedOr64(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedXor8_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedXor16_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedXor32_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
+        T* ctx, value_type<T> value, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedXor64_nf(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
+        T* ctx, value_type<T> value, release_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedXor8_rel(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
+        T* ctx, value_type<T> value, release_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedXor16_rel(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
+        T* ctx, value_type<T> value, release_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedXor32_rel(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
+        T* ctx, value_type<T> value, release_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedXor64_rel(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
+        T* ctx, value_type<T> value, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedXor8_acq(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
+        T* ctx, value_type<T> value, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedXor16_acq(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
+        T* ctx, value_type<T> value, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedXor32_acq(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
+        T* ctx, value_type<T> value, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedXor64_acq(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
+        T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedXor8(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
+        T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedXor16(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
+        T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedXor32(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T, memory_order O UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
+        T* ctx, value_type<T> value, memory_order_type<O>) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        return adaptor::to_value(
+            _InterlockedXor64(adaptor::to_interlocked(ctx), adaptor::to_interlocked(value)));
+    }
+
+public:
+    template <memory_order O>
+    struct operations {
+    protected:
+        static constexpr value_constant<memory_order, O> this_order{};
+        UTL_CONSTEXPR_CXX20 ~operations() noexcept = default;
+
+    public:
+        template <typename T UTL_CONSTRAINT_CXX11(
+            UTL_TRAIT_is_integral(T) || UTL_TRAIT_is_pointer(T))>
+        UTL_CONSTRAINT_CXX20(integral<T> || is_pointer_v<T>)
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+            T* ctx, value_type<T> value) noexcept {
+            return exchange(ctx, value, this_order);
+        }
+        template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> exchange(
+            T* ctx, value_type<T> value) noexcept {
+            using type = copy_cv_t<T, underlying_type_t<T>>;
+            return (value_type<T>)exchange((type*)ctx, (underlying_type_t<T>)value);
+        }
+        template <UTL_CONCEPT_CXX20(integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
+            T* ctx, value_type<T> value) noexcept {
+            return fetch_add(ctx, value, this_order);
+        }
+        template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
+            T* ctx, underlying_type_t<T> value) noexcept {
+            using type = copy_cv_t<T, underlying_type_t<T>>;
+            return (value_type<T>)fetch_add((type*)ctx, value);
+        }
+        template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
+        UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_add(
+            T* ctx, ptrdiff_t value) noexcept {
+            static constexpr intptr_t stride = sizeof(T);
+            using type = copy_cv_t<T, intptr_t>;
+            return (value_type<T>)fetch_add((type*)ctx, (intptr_t)value * stride);
+        }
+        template <UTL_CONCEPT_CXX20(integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_sub(
+            T* ctx, value_type<T> value) noexcept {
+            return fetch_sub(ctx, value, this_order);
+        }
+        template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_sub(
+            T* ctx, underlying_type_t<T> value) noexcept {
+            using type = copy_cv_t<T, underlying_type_t<T>>;
+            return (value_type<T>)fetch_sub((type*)ctx, value);
+        }
+        template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
+        UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_sub(
+            T* ctx, ptrdiff_t value) noexcept {
+            static constexpr intptr_t stride = sizeof(T);
+            using type = copy_cv_t<T, intptr_t>;
+            return (value_type<T>)fetch_sub((type*)ctx, (intptr_t)value * stride);
+        }
+        template <UTL_CONCEPT_CXX20(integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
+            T* ctx, value_type<T> value) noexcept {
+            return fetch_and(ctx, value, this_order);
+        }
+        template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
+            T* ctx, underlying_type_t<T> value) noexcept {
+            using type = copy_cv_t<T, underlying_type_t<T>>;
+            return (value_type<T>)fetch_and((type*)ctx, value);
+        }
+        template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
+        UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_and(
+            T* ctx, uintptr_t value) noexcept {
+            using type = copy_cv_t<T, uintptr_t>;
+            return (value_type<T>)fetch_and((type*)ctx, value);
+        }
+        template <UTL_CONCEPT_CXX20(integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
+            T* ctx, value_type<T> value) noexcept {
+            return fetch_or(ctx, value, this_order);
+        }
+        template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
+            T* ctx, underlying_type_t<T> value) noexcept {
+            using type = copy_cv_t<T, underlying_type_t<T>>;
+            return (value_type<T>)fetch_or((type*)ctx, value);
+        }
+        template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
+        UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_or(
+            T* ctx, uintptr_t value) noexcept {
+            using type = copy_cv_t<T, uintptr_t>;
+            return (value_type<T>)fetch_or((type*)ctx, value);
+        }
+        template <UTL_CONCEPT_CXX20(integral) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T))>
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
+            T* ctx, value_type<T> value) noexcept {
+            return fetch_xor(ctx, value, this_order);
+        }
+        template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
+            T* ctx, underlying_type_t<T> value) noexcept {
+            using type = copy_cv_t<T, underlying_type_t<T>>;
+            return (value_type<T>)fetch_xor((type*)ctx, value);
+        }
+        template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
+        UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline value_type<T> fetch_xor(
+            T* ctx, uintptr_t value) noexcept {
+            using type = copy_cv_t<T, uintptr_t>;
+            return (value_type<T>)fetch_xor((type*)ctx, value);
+        }
+    };
+};
+
+template <>
+struct exchange_traits::operations<memory_order::consume> :
+    exchange_traits::operations<memory_order::acquire> {};
+
+template <memory_order O>
+using exchange_operations = exchange_traits::operations<O>;
+
+struct compare_exchange_traits {
+private:
+    template <typename T>
+    using value_type = typename interlocked_adaptor<T>::value_type;
+    template <typename T>
+    using pointer = typename interlocked_adaptor<T>::pointer;
+    using relaxed_type = memory_order_type<memory_order::relaxed>;
+    using acquire_type = memory_order_type<memory_order::acquire>;
+    using release_type = memory_order_type<memory_order::release>;
+    using consume_type = memory_order_type<memory_order::consume>;
+    using seq_cst_type = memory_order_type<memory_order::seq_cst>;
+    using acq_rel_type = memory_order_type<memory_order::acq_rel>;
+    static constexpr release_type release_v{};
+    static constexpr acquire_type acquire_v{};
+
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, relaxed_type, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        auto comp = *expected;
+        auto prev = adaptor::to_value(_InterlockedCompareExchange8_nf(adaptor::to_interlocked(ctx),
+            adaptor::to_interlocked(desired), adaptor::to_interlocked(comp)));
+        if (!adaptor::equal(comp, prev)) {
+            adaptor::assign(expected, prev);
+            return false;
+        }
+        return true;
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, relaxed_type, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        auto comp = *expected;
+        auto prev = adaptor::to_value(_InterlockedCompareExchange16_nf(adaptor::to_interlocked(ctx),
+            adaptor::to_interlocked(desired), adaptor::to_interlocked(comp)));
+        if (!adaptor::equal(comp, prev)) {
+            adaptor::assign(expected, prev);
+            return false;
+        }
+        return true;
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, relaxed_type, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        auto comp = *expected;
+        auto prev = adaptor::to_value(_InterlockedCompareExchange32_nf(adaptor::to_interlocked(ctx),
+            adaptor::to_interlocked(desired), adaptor::to_interlocked(comp)));
+        if (!adaptor::equal(comp, prev)) {
+            adaptor::assign(expected, prev);
+            return false;
+        }
+        return true;
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, relaxed_type, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        auto comp = *expected;
+        auto prev = adaptor::to_value(_InterlockedCompareExchange64_nf(adaptor::to_interlocked(ctx),
+            adaptor::to_interlocked(desired), adaptor::to_interlocked(comp)));
+        if (!adaptor::equal(comp, prev)) {
+            adaptor::assign(expected, prev);
+            return false;
+        }
+        return true;
+    }
+
+    template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
+    UTL_CONSTRAINT_CXX20(UTL_TRAIT_is_pointer(T))
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, relaxed_type, relaxed_type) noexcept {
+        auto comp = *expected;
+        auto prev =
+            adaptor::to_value(_InterlockedCompareExchangePointer_nf(adaptor::to_interlocked(ctx),
+                adaptor::to_interlocked(desired), adaptor::to_interlocked(comp)));
+        if (!adaptor::equal(comp, prev)) {
+            adaptor::assign(expected, prev);
+            return false;
+        }
+        return true;
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<16>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(16, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, relaxed_type, relaxed_type) noexcept {
+        alignas(16) __int64 buf[2];
+        ::memcpy(buf, &desired, 16);
+        return _InterlockedCompareExchange128_nf(
+            (__int64 volatile*)ctx, buf[1], buf[0], (__int64*)expected);
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, release_type, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        auto comp = *expected;
+        auto prev = adaptor::to_value(_InterlockedCompareExchange8_rel(adaptor::to_interlocked(ctx),
+            adaptor::to_interlocked(desired), adaptor::to_interlocked(comp)));
+        if (!adaptor::equal(comp, prev)) {
+            adaptor::assign(expected, prev);
+            return false;
+        }
+        return true;
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, release_type, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        auto comp = *expected;
+        auto prev =
+            adaptor::to_value(_InterlockedCompareExchange16_rel(adaptor::to_interlocked(ctx),
+                adaptor::to_interlocked(desired), adaptor::to_interlocked(comp)));
+        if (!adaptor::equal(comp, prev)) {
+            adaptor::assign(expected, prev);
+            return false;
+        }
+        return true;
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, release_type, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        auto comp = *expected;
+        auto prev =
+            adaptor::to_value(_InterlockedCompareExchange32_rel(adaptor::to_interlocked(ctx),
+                adaptor::to_interlocked(desired), adaptor::to_interlocked(comp)));
+        if (!adaptor::equal(comp, prev)) {
+            adaptor::assign(expected, prev);
+            return false;
+        }
+        return true;
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, release_type, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        auto comp = *expected;
+        auto prev =
+            adaptor::to_value(_InterlockedCompareExchange64_rel(adaptor::to_interlocked(ctx),
+                adaptor::to_interlocked(desired), adaptor::to_interlocked(comp)));
+        if (!adaptor::equal(comp, prev)) {
+            adaptor::assign(expected, prev);
+            return false;
+        }
+        return true;
+    }
+
+    template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
+    UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, release_type, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        auto comp = *expected;
+        auto prev =
+            adaptor::to_value(_InterlockedCompareExchangePointer_rel(adaptor::to_interlocked(ctx),
+                adaptor::to_interlocked(desired), adaptor::to_interlocked(comp)));
+        if (!adaptor::equal(comp, prev)) {
+            adaptor::assign(expected, prev);
+            return false;
+        }
+        return true;
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<16>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(16, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, release_type, relaxed_type) noexcept {
+        alignas(16) __int64 buf[2];
+        ::memcpy(buf, &desired, 16);
+        return _InterlockedCompareExchange128_rel(
+            (__int64 volatile*)ctx, buf[1], buf[0], (__int64*)expected);
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, acquire_type, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        auto comp = *expected;
+        auto prev = adaptor::to_value(_InterlockedCompareExchange8_acq(adaptor::to_interlocked(ctx),
+            adaptor::to_interlocked(desired), adaptor::to_interlocked(comp)));
+        if (!adaptor::equal(comp, prev)) {
+            adaptor::assign(expected, prev);
+            return false;
+        }
+        return true;
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, acquire_type, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        auto comp = *expected;
+        auto prev =
+            adaptor::to_value(_InterlockedCompareExchange16_acq(adaptor::to_interlocked(ctx),
+                adaptor::to_interlocked(desired), adaptor::to_interlocked(comp)));
+        if (!adaptor::equal(comp, prev)) {
+            adaptor::assign(expected, prev);
+            return false;
+        }
+        return true;
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, acquire_type, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        auto comp = *expected;
+        auto prev =
+            adaptor::to_value(_InterlockedCompareExchange32_acq(adaptor::to_interlocked(ctx),
+                adaptor::to_interlocked(desired), adaptor::to_interlocked(comp)));
+        if (!adaptor::equal(comp, prev)) {
+            adaptor::assign(expected, prev);
+            return false;
+        }
+        return true;
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, acquire_type, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        auto comp = *expected;
+        auto prev =
+            adaptor::to_value(_InterlockedCompareExchange64_acq(adaptor::to_interlocked(ctx),
+                adaptor::to_interlocked(desired), adaptor::to_interlocked(comp)));
+        if (!adaptor::equal(comp, prev)) {
+            adaptor::assign(expected, prev);
+            return false;
+        }
+        return true;
+    }
+
+    template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
+    UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, acquire_type, relaxed_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        auto comp = *expected;
+        auto prev =
+            adaptor::to_value(_InterlockedCompareExchangePointer_acq(adaptor::to_interlocked(ctx),
+                adaptor::to_interlocked(desired), adaptor::to_interlocked(comp)));
+        if (!adaptor::equal(comp, prev)) {
+            adaptor::assign(expected, prev);
+            return false;
+        }
+        return true;
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<16>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(16, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, acquire_type, relaxed_type) noexcept {
+        alignas(16) __int64 buf[2];
+        ::memcpy(buf, &desired, 16);
+        return _InterlockedCompareExchange128_acq(
+            (__int64 volatile*)ctx, buf[1], buf[0], (__int64*)expected);
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<1>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(1, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, release_type, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        auto comp = *expected;
+        auto prev = adaptor::to_value(_InterlockedCompareExchange8(adaptor::to_interlocked(ctx),
+            adaptor::to_interlocked(desired), adaptor::to_interlocked(comp)));
+        if (!adaptor::equal(comp, prev)) {
+            adaptor::assign(expected, prev);
+            return false;
+        }
+        return true;
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<2>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(2, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, release_type, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        auto comp = *expected;
+        auto prev = adaptor::to_value(_InterlockedCompareExchange16(adaptor::to_interlocked(ctx),
+            adaptor::to_interlocked(desired), adaptor::to_interlocked(comp)));
+        if (!adaptor::equal(comp, prev)) {
+            adaptor::assign(expected, prev);
+            return false;
+        }
+        return true;
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<4>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(4, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, release_type, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        auto comp = *expected;
+        auto prev = adaptor::to_value(_InterlockedCompareExchange32(adaptor::to_interlocked(ctx),
+            adaptor::to_interlocked(desired), adaptor::to_interlocked(comp)));
+        if (!adaptor::equal(comp, prev)) {
+            adaptor::assign(expected, prev);
+            return false;
+        }
+        return true;
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<8>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(8, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, release_type, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        auto comp = *expected;
+        auto prev = adaptor::to_value(_InterlockedCompareExchange64(adaptor::to_interlocked(ctx),
+            adaptor::to_interlocked(desired), adaptor::to_interlocked(comp)));
+        if (!adaptor::equal(comp, prev)) {
+            adaptor::assign(expected, prev);
+            return false;
+        }
+        return true;
+    }
+
+    template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_pointer(T))>
+    UTL_CONSTRAINT_CXX20(is_pointer_v<T>)
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, release_type, acquire_type) noexcept {
+        using adaptor = interlocked_adaptor<T>;
+        auto comp = *expected;
+        auto prev =
+            adaptor::to_value(_InterlockedCompareExchangePointer(adaptor::to_interlocked(ctx),
+                adaptor::to_interlocked(desired), adaptor::to_interlocked(comp)));
+        if (!adaptor::equal(comp, prev)) {
+            adaptor::assign(expected, prev);
+            return false;
+        }
+        return true;
+    }
+
+    template <UTL_CONCEPT_CXX20(sized_integral<16>) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_sized_integral(16, T))>
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, release_type, acquire_type) noexcept {
+        alignas(16) __int64 buf[2];
+        ::memcpy(buf, &desired, 16);
+        return _InterlockedCompareExchange128(
+            (__int64 volatile*)ctx, buf[1], buf[0], (__int64*)expected);
+    }
+
+    template <typename T, memory_order O UTL_CONSTRAINT_CXX11(
+        UTL_TRAIT_is_integral(T) || UTL_TRAIT_is_pointer(T))>
+    UTL_CONSTRAINT_CXX20(integral<T> || is_pointer_v<T>)
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(T* ctx,
+        pointer<T> expected, value_type<T> desired, acq_rel_type, memory_order_type<O>) noexcept {
+        return compare_exchange(ctx, expected, desired, release_v, acquire_v);
+    }
+
+    template <typename T, memory_order O UTL_CONSTRAINT_CXX11(
+        UTL_TRAIT_is_integral(T) || UTL_TRAIT_is_pointer(T))>
+    UTL_CONSTRAINT_CXX20(integral<T> || is_pointer_v<T>)
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(T* ctx,
+        pointer<T> expected, value_type<T> desired, seq_cst_type, memory_order_type<O>) noexcept {
+        return compare_exchange(ctx, expected, desired, release_v, acquire_v);
+    }
+
+    template <typename T, memory_order O UTL_CONSTRAINT_CXX11(
+        UTL_TRAIT_is_integral(T) || UTL_TRAIT_is_pointer(T))>
+    UTL_CONSTRAINT_CXX20(integral<T> || is_pointer_v<T>)
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(T* ctx,
+        pointer<T> expected, value_type<T> desired, consume_type, memory_order_type<O> f) noexcept {
+        return compare_exchange(ctx, expected, desired, acquire_v, f);
+    }
+
+    template <typename T, memory_order O UTL_CONSTRAINT_CXX11(
+        UTL_TRAIT_is_integral(T) || UTL_TRAIT_is_pointer(T))>
+    UTL_CONSTRAINT_CXX20(integral<T> || is_pointer_v<T>)
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(T* ctx,
+        pointer<T> expected, value_type<T> desired, memory_order_type<O> s, consume_type) noexcept {
+        return compare_exchange(ctx, expected, desired, s, acquire_v);
+    }
+
+    template <typename T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_integral(T) || UTL_TRAIT_is_pointer(T))>
+    UTL_CONSTRAINT_CXX20(integral<T> || is_pointer_v<T>)
+    UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange(
+        T* ctx, pointer<T> expected, value_type<T> desired, consume_type, consume_type) noexcept {
+        return compare_exchange(ctx, expected, desired, acquire_v, acquire_v);
+    }
+
+public:
+    template <memory_order S, memory_order F>
+    struct operations {
+    protected:
+        static constexpr memory_order_type<S> success_v{};
+        UTL_CONSTEXPR_CXX20 ~operations() noexcept = default;
+
+    public:
+        template <typename T UTL_CONSTRAINT_CXX11(
+            UTL_TRAIT_is_integral(T) || UTL_TRAIT_is_pointer(T))>
+        UTL_CONSTRAINT_CXX20(integral<T> || is_pointer_v<T>)
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange_strong(T* ctx,
+            pointer<T> expected, value_type<T> desired, compare_exchange_failure<F> f) noexcept {
+            return compare_exchange(ctx, expected, desired, success_v, f);
+        }
+
+        template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange_strong(T* ctx,
+            pointer<T> expected, value_type<T> desired, compare_exchange_failure<F> f) noexcept {
+            using type = copy_cv_t<T, underlying_type_t<T>>;
+            return compare_exchange((type*)ctx, (underlying_type_t<T>*)expected,
+                (underlying_type_t<T>)desired, success_v, f);
+        }
+
+        template <typename T UTL_CONSTRAINT_CXX11(
+            UTL_TRAIT_is_integral(T) || UTL_TRAIT_is_pointer(T))>
+        UTL_CONSTRAINT_CXX20(integral<T> || is_pointer_v<T>)
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange_weak(T* ctx,
+            pointer<T> expected, value_type<T> desired, compare_exchange_failure<F> f) noexcept {
+            // Only < ARMv8.1-a has no dedicated CAS instruction
+            // But it requires exclusive load/store intrinsics to be exposed by MSVC to be supported
+            return compare_exchange(ctx, expected, desired, success_v, f);
+        }
+
+        template <UTL_CONCEPT_CXX20(enum_type) T UTL_CONSTRAINT_CXX11(UTL_TRAIT_is_enum(T))>
+        UTL_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE) static inline bool compare_exchange_weak(T* ctx,
+            pointer<T> expected, value_type<T> desired, compare_exchange_failure<F> f) noexcept {
+            using type = copy_cv_t<T, underlying_type_t<T>>;
+            return compare_exchange((type*)ctx, (underlying_type_t<T>*)expected,
+                (underlying_type_t<T>)desired, success_v, f);
+        }
+    };
+};
+
+template <memory_order S, memory_order F>
+using compare_exchange_operations = compare_exchange_traits::operations<S, F>;
+
+} // namespace atomics
+
+UTL_NAMESPACE_END

--- a/src/utl/public/utl/atomic/winapi/utl_interlocked.h
+++ b/src/utl/public/utl/atomic/winapi/utl_interlocked.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#if !defined(UTL_PLATFORM_ATOMIC_PRIVATE_HEADER_GUARD)
+#if !defined(UTL_ATOMIC_PRIVATE_HEADER_GUARD)
 #  error "Private header accessed"
 #endif
 

--- a/src/utl/public/utl/atomic/winapi/utl_interlocked.h
+++ b/src/utl/public/utl/atomic/winapi/utl_interlocked.h
@@ -1,0 +1,408 @@
+// Copyright 2023-2024 Bryan Wong
+
+#pragma once
+
+#if !defined(UTL_PLATFORM_ATOMIC_PRIVATE_HEADER_GUARD)
+#  error "Private header accessed"
+#endif
+
+#include "utl/utl_config.h"
+
+#if !UTL_COMPILER_MSVC
+#  error Invalid compiler
+#endif
+
+extern "C" char _InterlockedExchange8(char volatile*, char);
+extern "C" char _InterlockedCompareExchange8(char volatile*, char, char);
+extern "C" short _InterlockedExchangeAdd8(char volatile*, char);
+extern "C" char _InterlockedAnd8(char volatile*, char);
+extern "C" char _InterlockedOr8(char volatile*, char);
+extern "C" char _InterlockedXor8(char volatile*, char);
+extern "C" short _InterlockedIncrement16(short volatile*);
+extern "C" short _InterlockedDecrement16(short volatile*);
+extern "C" short _InterlockedExchange16(short volatile*, short);
+extern "C" short _InterlockedCompareExchange16(short volatile*, short, short);
+extern "C" short _InterlockedExchangeAdd16(short volatile*, short);
+extern "C" short _InterlockedAnd16(short volatile*, short);
+extern "C" short _InterlockedOr16(short volatile*, short);
+extern "C" short _InterlockedXor16(short volatile*, short);
+extern "C" long _InterlockedIncrement(long volatile*);
+extern "C" long _InterlockedDecrement(long volatile*);
+extern "C" long _InterlockedExchange(long volatile*, long);
+extern "C" long _InterlockedCompareExchange(long volatile*, long, long);
+extern "C" long _InterlockedExchangeAdd(long volatile*, long);
+extern "C" long _InterlockedAnd(long volatile*, long);
+extern "C" long _InterlockedOr(long volatile*, long);
+extern "C" long _InterlockedXor(long volatile*, long);
+extern "C" long long _InterlockedIncrement64(long long volatile*);
+extern "C" long long _InterlockedDecrement64(long long volatile*);
+extern "C" long long _InterlockedExchange64(long long volatile*, long long);
+extern "C" long long _InterlockedCompareExchange64(long long volatile*, long long, long long);
+extern "C" long long _InterlockedExchangeAdd64(long long volatile*, long long);
+extern "C" long long _InterlockedAnd64(long long volatile*, long long);
+extern "C" long long _InterlockedOr64(long long volatile*, long long);
+extern "C" long long _InterlockedXor64(long long volatile*, long long);
+extern "C" void* _InterlockedExchangePointer(void* volatile*, void*);
+extern "C" void* _InterlockedCompareExchangePointer(void* volatile*, void*, void*);
+extern "C" unsigned char _InterlockedCompareExchange128(
+    __int64 volatile*, __int64, __int64, __int64*);
+#pragma intrinsic(_InterlockedExchange8)
+#pragma intrinsic(_InterlockedCompareExchange8)
+#pragma intrinsic(_InterlockedAnd8)
+#pragma intrinsic(_InterlockedOr8)
+#pragma intrinsic(_InterlockedXor8)
+#pragma intrinsic(_InterlockedIncrement16)
+#pragma intrinsic(_InterlockedDecrement16)
+#pragma intrinsic(_InterlockedExchange16)
+#pragma intrinsic(_InterlockedCompareExchange16)
+#pragma intrinsic(_InterlockedAnd16)
+#pragma intrinsic(_InterlockedOr16)
+#pragma intrinsic(_InterlockedXor16)
+#pragma intrinsic(_InterlockedIncrement)
+#pragma intrinsic(_InterlockedDecrement)
+#pragma intrinsic(_InterlockedExchange)
+#pragma intrinsic(_InterlockedCompareExchange)
+#pragma intrinsic(_InterlockedExchangeAdd)
+#pragma intrinsic(_InterlockedAnd)
+#pragma intrinsic(_InterlockedOr)
+#pragma intrinsic(_InterlockedXor)
+#pragma intrinsic(_InterlockedIncrement64)
+#pragma intrinsic(_InterlockedDecrement64)
+#pragma intrinsic(_InterlockedExchange64)
+#pragma intrinsic(_InterlockedCompareExchange64)
+#pragma intrinsic(_InterlockedExchangeAdd64)
+#pragma intrinsic(_InterlockedAnd64)
+#pragma intrinsic(_InterlockedOr64)
+#pragma intrinsic(_InterlockedXor64)
+#pragma intrinsic(_InterlockedExchangePointer)
+#pragma intrinsic(_InterlockedCompareExchangePointer)
+#pragma intrinsic(_InterlockedCompareExchange128)
+
+#if UTL_ARCH_X86
+#  define _InterlockedExchange8_acq _InterlockedExchange8
+#  define _InterlockedCompareExchange8_acq _InterlockedCompareExchange8
+#  define _InterlockedExchangeAdd8_acq _InterlockedExchangeAdd8
+#  define _InterlockedAnd8_acq _InterlockedAnd8
+#  define _InterlockedOr8_acq _InterlockedOr8
+#  define _InterlockedXor8_acq _InterlockedXor8
+#  define _InterlockedIncrement16_acq _InterlockedIncrement16
+#  define _InterlockedDecrement16_acq _InterlockedDecrement16
+#  define _InterlockedExchange16_acq _InterlockedExchange16
+#  define _InterlockedCompareExchange16_acq _InterlockedCompareExchange16
+#  define _InterlockedExchangeAdd16_acq _InterlockedExchangeAdd16
+#  define _InterlockedAnd16_acq _InterlockedAnd16
+#  define _InterlockedOr16_acq _InterlockedOr16
+#  define _InterlockedXor16_acq _InterlockedXor16
+#  define _InterlockedIncrement_acq _InterlockedIncrement
+#  define _InterlockedDecrement_acq _InterlockedDecrement
+#  define _InterlockedAdd_acq _InterlockedAdd
+#  define _InterlockedExchange_acq _InterlockedExchange
+#  define _InterlockedCompareExchange_acq _InterlockedCompareExchange
+#  define _InterlockedExchangeAdd_acq _InterlockedExchangeAdd
+#  define _InterlockedAnd_acq _InterlockedAnd
+#  define _InterlockedOr_acq _InterlockedOr
+#  define _InterlockedXor_acq _InterlockedXor
+#  define _InterlockedIncrement64_acq _InterlockedIncrement64
+#  define _InterlockedDecrement64_acq _InterlockedDecrement64
+#  define _InterlockedAdd64_acq _InterlockedAdd64
+#  define _InterlockedExchange64_acq _InterlockedExchange64
+#  define _InterlockedCompareExchange64_acq _InterlockedCompareExchange64
+#  define _InterlockedExchangeAdd64_acq _InterlockedExchangeAdd64
+#  define _InterlockedAnd64_acq _InterlockedAnd64
+#  define _InterlockedOr64_acq _InterlockedOr64
+#  define _InterlockedXor64_acq _InterlockedXor64
+#  define _InterlockedExchangePointer_acq _InterlockedExchangePointer
+#  define _InterlockedCompareExchangePointer_acq _InterlockedCompareExchangePointer
+#  define _InterlockedCompareExchange128_acq _InterlockedCompareExchange128
+#  define _InterlockedExchange8_rel _InterlockedExchange8
+#  define _InterlockedCompareExchange8_rel _InterlockedCompareExchange8
+#  define _InterlockedExchangeAdd8_rel _InterlockedExchangeAdd8
+#  define _InterlockedAnd8_rel _InterlockedAnd8
+#  define _InterlockedOr8_rel _InterlockedOr8
+#  define _InterlockedXor8_rel _InterlockedXor8
+#  define _InterlockedIncrement16_rel _InterlockedIncrement16
+#  define _InterlockedDecrement16_rel _InterlockedDecrement16
+#  define _InterlockedExchange16_rel _InterlockedExchange16
+#  define _InterlockedCompareExchange16_rel _InterlockedCompareExchange16
+#  define _InterlockedExchangeAdd16_rel _InterlockedExchangeAdd16
+#  define _InterlockedAnd16_rel _InterlockedAnd16
+#  define _InterlockedOr16_rel _InterlockedOr16
+#  define _InterlockedXor16_rel _InterlockedXor16
+#  define _InterlockedIncrement_rel _InterlockedIncrement
+#  define _InterlockedDecrement_rel _InterlockedDecrement
+#  define _InterlockedAdd_rel _InterlockedAdd
+#  define _InterlockedExchange_rel _InterlockedExchange
+#  define _InterlockedCompareExchange_rel _InterlockedCompareExchange
+#  define _InterlockedExchangeAdd_rel _InterlockedExchangeAdd
+#  define _InterlockedAnd_rel _InterlockedAnd
+#  define _InterlockedOr_rel _InterlockedOr
+#  define _InterlockedXor_rel _InterlockedXor
+#  define _InterlockedIncrement64_rel _InterlockedIncrement64
+#  define _InterlockedDecrement64_rel _InterlockedDecrement64
+#  define _InterlockedAdd64_rel _InterlockedAdd64
+#  define _InterlockedExchange64_rel _InterlockedExchange64
+#  define _InterlockedCompareExchange64_rel _InterlockedCompareExchange64
+#  define _InterlockedExchangeAdd64_rel _InterlockedExchangeAdd64
+#  define _InterlockedAnd64_rel _InterlockedAnd64
+#  define _InterlockedOr64_rel _InterlockedOr64
+#  define _InterlockedXor64_rel _InterlockedXor64
+#  define _InterlockedExchangePointer_rel _InterlockedExchangePointer
+#  define _InterlockedCompareExchangePointer_rel _InterlockedCompareExchangePointer
+#  define _InterlockedCompareExchange128_rel _InterlockedCompareExchange128
+#  define _InterlockedExchange8_nf _InterlockedExchange8
+#  define _InterlockedCompareExchange8_nf _InterlockedCompareExchange8
+#  define _InterlockedExchangeAdd8_nf _InterlockedExchangeAdd8
+#  define _InterlockedAnd8_nf _InterlockedAnd8
+#  define _InterlockedOr8_nf _InterlockedOr8
+#  define _InterlockedXor8_nf _InterlockedXor8
+#  define _InterlockedIncrement16_nf _InterlockedIncrement16
+#  define _InterlockedDecrement16_nf _InterlockedDecrement16
+#  define _InterlockedExchange16_nf _InterlockedExchange16
+#  define _InterlockedCompareExchange16_nf _InterlockedCompareExchange16
+#  define _InterlockedExchangeAdd16_nf _InterlockedExchangeAdd16
+#  define _InterlockedAnd16_nf _InterlockedAnd16
+#  define _InterlockedOr16_nf _InterlockedOr16
+#  define _InterlockedXor16_nf _InterlockedXor16
+#  define _InterlockedIncrement_nf _InterlockedIncrement
+#  define _InterlockedDecrement_nf _InterlockedDecrement
+#  define _InterlockedAdd_nf _InterlockedAdd
+#  define _InterlockedExchange_nf _InterlockedExchange
+#  define _InterlockedCompareExchange_nf _InterlockedCompareExchange
+#  define _InterlockedExchangeAdd_nf _InterlockedExchangeAdd
+#  define _InterlockedAnd_nf _InterlockedAnd
+#  define _InterlockedOr_nf _InterlockedOr
+#  define _InterlockedXor_nf _InterlockedXor
+#  define _InterlockedIncrement64_nf _InterlockedIncrement64
+#  define _InterlockedDecrement64_nf _InterlockedDecrement64
+#  define _InterlockedAdd64_nf _InterlockedAdd64
+#  define _InterlockedExchange64_nf _InterlockedExchange64
+#  define _InterlockedCompareExchange64_nf _InterlockedCompareExchange64
+#  define _InterlockedExchangeAdd64_nf _InterlockedExchangeAdd64
+#  define _InterlockedAnd64_nf _InterlockedAnd64
+#  define _InterlockedOr64_nf _InterlockedOr64
+#  define _InterlockedXor64_nf _InterlockedXor64
+#  define _InterlockedExchangePointer_nf _InterlockedExchangePointer
+#  define _InterlockedCompareExchangePointer_nf _InterlockedCompareExchangePointer
+#  define _InterlockedCompareExchange128_nf _InterlockedCompareExchange128
+
+#elif UTL_ARCH_ARM
+extern "C" long _InterlockedAdd(long volatile*, long);
+extern "C" long long _InterlockedAdd64(long long volatile*, long long);
+extern "C" char _InterlockedExchange8_acq(char volatile*, char);
+extern "C" char _InterlockedCompareExchange8_acq(char volatile*, char, char);
+extern "C" short _InterlockedExchangeAdd8_acq(char volatile*, char);
+extern "C" char _InterlockedAnd8_acq(char volatile*, char);
+extern "C" char _InterlockedOr8_acq(char volatile*, char);
+extern "C" char _InterlockedXor8_acq(char volatile*, char);
+extern "C" short _InterlockedIncrement16_acq(short volatile*);
+extern "C" short _InterlockedDecrement16_acq(short volatile*);
+extern "C" short _InterlockedExchange16_acq(short volatile*, short);
+extern "C" short _InterlockedCompareExchange16_acq(short volatile*, short, short);
+extern "C" short _InterlockedExchangeAdd16_acq(short volatile*, short);
+extern "C" short _InterlockedAnd16_acq(short volatile*, short);
+extern "C" short _InterlockedOr16_acq(short volatile*, short);
+extern "C" short _InterlockedXor16_acq(short volatile*, short);
+extern "C" long _InterlockedIncrement_acq(long volatile*);
+extern "C" long _InterlockedDecrement_acq(long volatile*);
+extern "C" long _InterlockedAdd_acq(long volatile*, long);
+extern "C" long _InterlockedExchange_acq(long volatile*, long);
+extern "C" long _InterlockedCompareExchange_acq(long volatile*, long, long);
+extern "C" long _InterlockedExchangeAdd_acq(long volatile*, long);
+extern "C" long _InterlockedAnd_acq(long volatile*, long);
+extern "C" long _InterlockedOr_acq(long volatile*, long);
+extern "C" long _InterlockedXor_acq(long volatile*, long);
+extern "C" long long _InterlockedIncrement64_acq(long long volatile*);
+extern "C" long long _InterlockedDecrement64_acq(long long volatile*);
+extern "C" long long _InterlockedAdd64_acq(long long volatile*, long long);
+extern "C" long long _InterlockedExchange64_acq(long long volatile*, long long);
+extern "C" long long _InterlockedCompareExchange64_acq(long long volatile*, long long, long long);
+extern "C" long long _InterlockedExchangeAdd64_acq(long long volatile*, long long);
+extern "C" long long _InterlockedAnd64_acq(long long volatile*, long long);
+extern "C" long long _InterlockedOr64_acq(long long volatile*, long long);
+extern "C" long long _InterlockedXor64_acq(long long volatile*, long long);
+extern "C" void* _InterlockedExchangePointer_acq(void* volatile*, void*);
+extern "C" void* _InterlockedCompareExchangePointer_acq(void* volatile*, void*, void*);
+extern "C" unsigned char _InterlockedCompareExchange128_acq(
+    __int64 volatile*, __int64, __int64, __int64*);
+extern "C" char _InterlockedExchange8_rel(char volatile*, char);
+extern "C" char _InterlockedCompareExchange8_rel(char volatile*, char, char);
+extern "C" short _InterlockedExchangeAdd8_rel(char volatile*, char);
+extern "C" char _InterlockedAnd8_rel(char volatile*, char);
+extern "C" char _InterlockedOr8_rel(char volatile*, char);
+extern "C" char _InterlockedXor8_rel(char volatile*, char);
+extern "C" short _InterlockedIncrement16_rel(short volatile*);
+extern "C" short _InterlockedDecrement16_rel(short volatile*);
+extern "C" short _InterlockedExchange16_rel(short volatile*, short);
+extern "C" short _InterlockedCompareExchange16_rel(short volatile*, short, short);
+extern "C" short _InterlockedExchangeAdd16_rel(short volatile*, short);
+extern "C" short _InterlockedAnd16_rel(short volatile*, short);
+extern "C" short _InterlockedOr16_rel(short volatile*, short);
+extern "C" short _InterlockedXor16_rel(short volatile*, short);
+extern "C" long _InterlockedIncrement_rel(long volatile*);
+extern "C" long _InterlockedDecrement_rel(long volatile*);
+extern "C" long _InterlockedAdd_rel(long volatile*, long);
+extern "C" long _InterlockedExchange_rel(long volatile*, long);
+extern "C" long _InterlockedCompareExchange_rel(long volatile*, long, long);
+extern "C" long _InterlockedExchangeAdd_rel(long volatile*, long);
+extern "C" long _InterlockedAnd_rel(long volatile*, long);
+extern "C" long _InterlockedOr_rel(long volatile*, long);
+extern "C" long _InterlockedXor_rel(long volatile*, long);
+extern "C" long long _InterlockedIncrement64_rel(long long volatile*);
+extern "C" long long _InterlockedDecrement64_rel(long long volatile*);
+extern "C" long long _InterlockedAdd64_rel(long long volatile*, long long);
+extern "C" long long _InterlockedExchange64_rel(long long volatile*, long long);
+extern "C" long long _InterlockedCompareExchange64_rel(long long volatile*, long long, long long);
+extern "C" long long _InterlockedExchangeAdd64_rel(long long volatile*, long long);
+extern "C" long long _InterlockedAnd64_rel(long long volatile*, long long);
+extern "C" long long _InterlockedOr64_rel(long long volatile*, long long);
+extern "C" long long _InterlockedXor64_rel(long long volatile*, long long);
+extern "C" void* _InterlockedExchangePointer_rel(void* volatile*, void*);
+extern "C" void* _InterlockedCompareExchangePointer_rel(void* volatile*, void*, void*);
+extern "C" unsigned char _InterlockedCompareExchange128_rel(
+    __int64 volatile*, __int64, __int64, __int64*);
+extern "C" char _InterlockedExchange8_nf(char volatile*, char);
+extern "C" char _InterlockedCompareExchange8_nf(char volatile*, char, char);
+extern "C" short _InterlockedExchangeAdd8_nf(char volatile*, char);
+extern "C" char _InterlockedAnd8_nf(char volatile*, char);
+extern "C" char _InterlockedOr8_nf(char volatile*, char);
+extern "C" char _InterlockedXor8_nf(char volatile*, char);
+extern "C" short _InterlockedIncrement16_nf(short volatile*);
+extern "C" short _InterlockedDecrement16_nf(short volatile*);
+extern "C" short _InterlockedExchange16_nf(short volatile*, short);
+extern "C" short _InterlockedCompareExchange16_nf(short volatile*, short, short);
+extern "C" short _InterlockedExchangeAdd16_nf(short volatile*, short);
+extern "C" short _InterlockedAnd16_nf(short volatile*, short);
+extern "C" short _InterlockedOr16_nf(short volatile*, short);
+extern "C" short _InterlockedXor16_nf(short volatile*, short);
+extern "C" long _InterlockedIncrement_nf(long volatile*);
+extern "C" long _InterlockedDecrement_nf(long volatile*);
+extern "C" long _InterlockedAdd_nf(long volatile*, long);
+extern "C" long _InterlockedExchange_nf(long volatile*, long);
+extern "C" long _InterlockedCompareExchange_nf(long volatile*, long, long);
+extern "C" long _InterlockedExchangeAdd_nf(long volatile*, long);
+extern "C" long _InterlockedAnd_nf(long volatile*, long);
+extern "C" long _InterlockedOr_nf(long volatile*, long);
+extern "C" long _InterlockedXor_nf(long volatile*, long);
+extern "C" long long _InterlockedIncrement64_nf(long long volatile*);
+extern "C" long long _InterlockedDecrement64_nf(long long volatile*);
+extern "C" long long _InterlockedAdd64_nf(long long volatile*, long long);
+extern "C" long long _InterlockedExchange64_nf(long long volatile*, long long);
+extern "C" long long _InterlockedCompareExchange64_nf(long long volatile*, long long, long long);
+extern "C" long long _InterlockedExchangeAdd64_nf(long long volatile*, long long);
+extern "C" long long _InterlockedAnd64_nf(long long volatile*, long long);
+extern "C" long long _InterlockedOr64_nf(long long volatile*, long long);
+extern "C" long long _InterlockedXor64_nf(long long volatile*, long long);
+extern "C" void* _InterlockedExchangePointer_nf(void* volatile*, void*);
+extern "C" void* _InterlockedCompareExchangePointer_nf(void* volatile*, void*, void*);
+extern "C" unsigned char _InterlockedCompareExchange128_nf(
+    __int64 volatile*, __int64, __int64, __int64*);
+#  pragma intrinsic(_InterlockedAdd)
+#  pragma intrinsic(_InterlockedAdd64)
+#  pragma intrinsic(_InterlockedExchange8_acq)
+#  pragma intrinsic(_InterlockedCompareExchange8_acq)
+#  pragma intrinsic(_InterlockedExchangeAdd8_acq)
+#  pragma intrinsic(_InterlockedAnd8_acq)
+#  pragma intrinsic(_InterlockedOr8_acq)
+#  pragma intrinsic(_InterlockedXor8_acq)
+#  pragma intrinsic(_InterlockedIncrement16_acq)
+#  pragma intrinsic(_InterlockedDecrement16_acq)
+#  pragma intrinsic(_InterlockedExchange16_acq)
+#  pragma intrinsic(_InterlockedCompareExchange16_acq)
+#  pragma intrinsic(_InterlockedExchangeAdd16_acq)
+#  pragma intrinsic(_InterlockedAnd16_acq)
+#  pragma intrinsic(_InterlockedOr16_acq)
+#  pragma intrinsic(_InterlockedXor16_acq)
+#  pragma intrinsic(_InterlockedIncrement_acq)
+#  pragma intrinsic(_InterlockedDecrement_acq)
+#  pragma intrinsic(_InterlockedAdd_acq)
+#  pragma intrinsic(_InterlockedExchange_acq)
+#  pragma intrinsic(_InterlockedCompareExchange_acq)
+#  pragma intrinsic(_InterlockedExchangeAdd_acq)
+#  pragma intrinsic(_InterlockedAnd_acq)
+#  pragma intrinsic(_InterlockedOr_acq)
+#  pragma intrinsic(_InterlockedXor_acq)
+#  pragma intrinsic(_InterlockedIncrement64_acq)
+#  pragma intrinsic(_InterlockedDecrement64_acq)
+#  pragma intrinsic(_InterlockedAdd64_acq)
+#  pragma intrinsic(_InterlockedExchange64_acq)
+#  pragma intrinsic(_InterlockedCompareExchange64_acq)
+#  pragma intrinsic(_InterlockedExchangeAdd64_acq)
+#  pragma intrinsic(_InterlockedAnd64_acq)
+#  pragma intrinsic(_InterlockedOr64_acq)
+#  pragma intrinsic(_InterlockedXor64_acq)
+#  pragma intrinsic(_InterlockedExchangePointer_acq)
+#  pragma intrinsic(_InterlockedCompareExchangePointer_acq)
+#  pragma intrinsic(_InterlockedCompareExchange128_acq)
+#  pragma intrinsic(_InterlockedExchange8_rel)
+#  pragma intrinsic(_InterlockedCompareExchange8_rel)
+#  pragma intrinsic(_InterlockedExchangeAdd8_rel)
+#  pragma intrinsic(_InterlockedAnd8_rel)
+#  pragma intrinsic(_InterlockedOr8_rel)
+#  pragma intrinsic(_InterlockedXor8_rel)
+#  pragma intrinsic(_InterlockedIncrement16_rel)
+#  pragma intrinsic(_InterlockedDecrement16_rel)
+#  pragma intrinsic(_InterlockedExchange16_rel)
+#  pragma intrinsic(_InterlockedCompareExchange16_rel)
+#  pragma intrinsic(_InterlockedExchangeAdd16_rel)
+#  pragma intrinsic(_InterlockedAnd16_rel)
+#  pragma intrinsic(_InterlockedOr16_rel)
+#  pragma intrinsic(_InterlockedXor16_rel)
+#  pragma intrinsic(_InterlockedIncrement_rel)
+#  pragma intrinsic(_InterlockedDecrement_rel)
+#  pragma intrinsic(_InterlockedAdd_rel)
+#  pragma intrinsic(_InterlockedExchange_rel)
+#  pragma intrinsic(_InterlockedCompareExchange_rel)
+#  pragma intrinsic(_InterlockedExchangeAdd_rel)
+#  pragma intrinsic(_InterlockedAnd_rel)
+#  pragma intrinsic(_InterlockedOr_rel)
+#  pragma intrinsic(_InterlockedXor_rel)
+#  pragma intrinsic(_InterlockedIncrement64_rel)
+#  pragma intrinsic(_InterlockedDecrement64_rel)
+#  pragma intrinsic(_InterlockedAdd64_rel)
+#  pragma intrinsic(_InterlockedExchange64_rel)
+#  pragma intrinsic(_InterlockedCompareExchange64_rel)
+#  pragma intrinsic(_InterlockedExchangeAdd64_rel)
+#  pragma intrinsic(_InterlockedAnd64_rel)
+#  pragma intrinsic(_InterlockedOr64_rel)
+#  pragma intrinsic(_InterlockedXor64_rel)
+#  pragma intrinsic(_InterlockedExchangePointer_rel)
+#  pragma intrinsic(_InterlockedCompareExchangePointer_rel)
+#  pragma intrinsic(_InterlockedCompareExchange128_rel)
+#  pragma intrinsic(_InterlockedExchange8_nf)
+#  pragma intrinsic(_InterlockedCompareExchange8_nf)
+#  pragma intrinsic(_InterlockedExchangeAdd8_nf)
+#  pragma intrinsic(_InterlockedAnd8_nf)
+#  pragma intrinsic(_InterlockedOr8_nf)
+#  pragma intrinsic(_InterlockedXor8_nf)
+#  pragma intrinsic(_InterlockedIncrement16_nf)
+#  pragma intrinsic(_InterlockedDecrement16_nf)
+#  pragma intrinsic(_InterlockedExchange16_nf)
+#  pragma intrinsic(_InterlockedCompareExchange16_nf)
+#  pragma intrinsic(_InterlockedExchangeAdd16_nf)
+#  pragma intrinsic(_InterlockedAnd16_nf)
+#  pragma intrinsic(_InterlockedOr16_nf)
+#  pragma intrinsic(_InterlockedXor16_nf)
+#  pragma intrinsic(_InterlockedIncrement_nf)
+#  pragma intrinsic(_InterlockedDecrement_nf)
+#  pragma intrinsic(_InterlockedAdd_nf)
+#  pragma intrinsic(_InterlockedExchange_nf)
+#  pragma intrinsic(_InterlockedCompareExchange_nf)
+#  pragma intrinsic(_InterlockedExchangeAdd_nf)
+#  pragma intrinsic(_InterlockedAnd_nf)
+#  pragma intrinsic(_InterlockedOr_nf)
+#  pragma intrinsic(_InterlockedXor_nf)
+#  pragma intrinsic(_InterlockedIncrement64_nf)
+#  pragma intrinsic(_InterlockedDecrement64_nf)
+#  pragma intrinsic(_InterlockedAdd64_nf)
+#  pragma intrinsic(_InterlockedExchange64_nf)
+#  pragma intrinsic(_InterlockedCompareExchange64_nf)
+#  pragma intrinsic(_InterlockedExchangeAdd64_nf)
+#  pragma intrinsic(_InterlockedAnd64_nf)
+#  pragma intrinsic(_InterlockedOr64_nf)
+#  pragma intrinsic(_InterlockedXor64_nf)
+#  pragma intrinsic(_InterlockedExchangePointer_nf)
+#  pragma intrinsic(_InterlockedCompareExchangePointer_nf)
+#  pragma intrinsic(_InterlockedCompareExchange128_nf)
+#else
+#  error "Unsupported architecture"
+#endif

--- a/src/utl/public/utl/atomic/winapi/utl_memory_access.h
+++ b/src/utl/public/utl/atomic/winapi/utl_memory_access.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#if !defined(UTL_PLATFORM_ATOMIC_PRIVATE_HEADER_GUARD)
+#if !defined(UTL_ATOMIC_PRIVATE_HEADER_GUARD)
 #  error "Private header accessed"
 #endif
 

--- a/src/utl/public/utl/atomic/winapi/utl_memory_access.h
+++ b/src/utl/public/utl/atomic/winapi/utl_memory_access.h
@@ -1,0 +1,61 @@
+// Copyright 2023-2024 Bryan Wong
+
+#pragma once
+
+#if !defined(UTL_PLATFORM_ATOMIC_PRIVATE_HEADER_GUARD)
+#  error "Private header accessed"
+#endif
+
+#include "utl/utl_config.h"
+
+#if !UTL_COMPILER_MSVC
+#  error Invalid compiler
+#endif
+
+extern "C" __int8 __iso_volatile_load8(__int8 const volatile*);
+extern "C" __int16 __iso_volatile_load16(__int16 const volatile*);
+extern "C" __int32 __iso_volatile_load32(__int32 const volatile*);
+extern "C" __int64 __iso_volatile_load64(__int64 const volatile*);
+extern "C" unsigned __int8 __ldar8(unsigned __int8 volatile*);
+extern "C" unsigned __int16 __ldar16(unsigned __int16 volatile*);
+extern "C" unsigned __int32 __ldar32(unsigned __int32 volatile*);
+extern "C" unsigned __int64 __ldar64(unsigned __int64 volatile*);
+extern "C" void __iso_volatile_store8(__int8 volatile*, __int8);
+extern "C" void __iso_volatile_store16(__int16 volatile*, __int16);
+extern "C" void __iso_volatile_store32(__int32 volatile*, __int32);
+extern "C" void __iso_volatile_store64(__int64 volatile*, __int64);
+extern "C" void __stlr8(unsigned __int8 volatile*, unsigned __int8);
+extern "C" void __stlr16(unsigned __int16 volatile*, unsigned __int16);
+extern "C" void __stlr32(unsigned __int32 volatile*, unsigned __int32);
+extern "C" void __stlr64(unsigned __int8 volatile*, unsigned __int64);
+#pragma intrinsic(__iso_volatile_load8)
+#pragma intrinsic(__iso_volatile_load16)
+#pragma intrinsic(__iso_volatile_load32)
+#pragma intrinsic(__iso_volatile_load64)
+#pragma intrinsic(__ldar8)
+#pragma intrinsic(__ldar16)
+#pragma intrinsic(__ldar32)
+#pragma intrinsic(__ldar64)
+#pragma intrinsic(__iso_volatile_store8)
+#pragma intrinsic(__iso_volatile_store16)
+#pragma intrinsic(__iso_volatile_store32)
+#pragma intrinsic(__iso_volatile_store64)
+#pragma intrinsic(__stlr8)
+#pragma intrinsic(__stlr16)
+#pragma intrinsic(__stlr32)
+#pragma intrinsic(__stlr64)
+
+#if __ARM_ARCH >= 830 && !defined(UTL_ENABLE_RCPC_LOAD)
+#  define UTL_ENABLE_RCPC_LOAD
+#endif
+
+#ifdef UTL_ENABLE_RCPC_LOAD
+extern "C" unsigned __int8 __ldapr8(unsigned __int8 volatile*);
+extern "C" unsigned __int16 __ldapr16(unsigned __int16 volatile*);
+extern "C" unsigned __int32 __ldapr32(unsigned __int32 volatile*);
+extern "C" unsigned __int64 __ldapr64(unsigned __int64 volatile*);
+#  pragma intrinsic(__ldapr8)
+#  pragma intrinsic(__ldapr16)
+#  pragma intrinsic(__ldapr32)
+#  pragma intrinsic(__ldapr64)
+#endif

--- a/src/utl/public/utl/atomic/winapi/utl_memory_barriers.h
+++ b/src/utl/public/utl/atomic/winapi/utl_memory_barriers.h
@@ -1,0 +1,35 @@
+// Copyright 2023-2024 Bryan Wong
+
+#pragma once
+
+#if !defined(UTL_PLATFORM_ATOMIC_PRIVATE_HEADER_GUARD)
+#  error "Private header accessed"
+#endif
+
+#include "utl/utl_config.h"
+
+#if !UTL_COMPILER_MSVC
+#  error Invalid compiler
+#endif
+
+extern "C" void _mm_mfence(void);
+#pragma intrinsic(_mm_mfence)
+
+#if UTL_ARCH_ARM
+#  include "utl/hardware/arm/utl_barrier.h"
+
+extern "C" void __dmb(unsigned int);
+#  pragma intrinsic(__dmb)
+#  define __UTL_ACQUIRE_BARRIER() __dmb(arm::barrier::ISHLD)
+#  define __UTL_MEMORY_BARRIER() __dmb(arm::barrier::ISH)
+#  define __UTL_STORE_BARRIER() __dmb(arm::barrier::ISHST)
+#  define __UTL_HW_MEMORY_BARRIER() __UTL_MEMORY_BARRIER()
+
+#elif UTL_ARCH_x86
+#  define __UTL_ACQUIRE_BARRIER() UTL_COMPILER_BARRIER()
+#  define __UTL_MEMORY_BARRIER() UTL_COMPILER_BARRIER()
+#  define __UTL_STORE_BARRIER() UTL_COMPILER_BARRIER()
+#  define __UTL_HW_MEMORY_BARRIER() _mm_mfence()
+#else
+#  error Unsupported architecture
+#endif

--- a/src/utl/public/utl/atomic/winapi/utl_memory_barriers.h
+++ b/src/utl/public/utl/atomic/winapi/utl_memory_barriers.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#if !defined(UTL_PLATFORM_ATOMIC_PRIVATE_HEADER_GUARD)
+#if !defined(UTL_ATOMIC_PRIVATE_HEADER_GUARD)
 #  error "Private header accessed"
 #endif
 

--- a/src/utl/public/utl/concepts/utl_boolean_type.h
+++ b/src/utl/public/utl/concepts/utl_boolean_type.h
@@ -1,0 +1,17 @@
+// Copyright 2023-2024 Bryan Wong
+
+#pragma once
+
+#include "utl/utl_config.h"
+
+#include "utl/concepts/utl_same_as.h"
+#include "utl/type_traits/utl_remove_cv.h"
+
+#if UTL_CXX20
+UTL_NAMESPACE_BEGIN
+
+template <typename T>
+concept boolean_type = same_as<bool, remove_cv_t<T>>;
+
+UTL_NAMESPACE_END
+#endif

--- a/src/utl/public/utl/configuration/utl_memcmp.h
+++ b/src/utl/public/utl/configuration/utl_memcmp.h
@@ -1,0 +1,26 @@
+/* Copyright 2023-2024 Bryan Wong */
+
+#pragma once
+
+#include "utl/configuration/utl_compiler.h"
+#include "utl/configuration/utl_keywords.h"
+#include "utl/configuration/utl_standard.h"
+
+#if UTL_HAS_BUILTIN(__builtin_memcmp)
+
+#  define __UTL_MEMCMP __builtin_memcmp
+
+#else
+
+#  if UTL_CXX
+extern "C" int memcmp(void const*, void const*, decltype(sizeof(0)));
+#  else
+int memcmp(void const*, void const*, size_t);
+#  endif
+
+#  if UTL_COMPILER_MSVC
+#    pragma intrinsic(memcmp)
+#  endif
+#  define __UTL_MEMCMP ::memcmp
+
+#endif

--- a/src/utl/public/utl/configuration/utl_memcpy.h
+++ b/src/utl/public/utl/configuration/utl_memcpy.h
@@ -1,0 +1,29 @@
+/* Copyright 2023-2024 Bryan Wong */
+
+#pragma once
+
+#include "utl/configuration/utl_compiler.h"
+#include "utl/configuration/utl_keywords.h"
+#include "utl/configuration/utl_standard.h"
+
+#if UTL_HAS_BUILTIN(__builtin_memcpy_inline)
+#  define __UTL_MEMCPY __builtin_memcpy_inline
+
+#elif UTL_HAS_BUILTIN(__builtin_memcpy)
+
+#  define __UTL_MEMCPY __builtin_memcpy
+
+#else
+
+#  if UTL_CXX
+extern "C" void* memcpy(void* UTL_RESTRICT, void const* UTL_RESTRICT, decltype(sizeof(0)));
+#  else
+void* memcpy(void* UTL_RESTRICT, void const* UTL_RESTRICT, size_t);
+#  endif
+
+#  if UTL_COMPILER_MSVC
+#    pragma intrinsic(memcpy)
+#  endif
+#  define __UTL_MEMCPY ::memcpy
+
+#endif

--- a/src/utl/public/utl/configuration/utl_memcpy.h
+++ b/src/utl/public/utl/configuration/utl_memcpy.h
@@ -6,10 +6,7 @@
 #include "utl/configuration/utl_keywords.h"
 #include "utl/configuration/utl_standard.h"
 
-#if UTL_HAS_BUILTIN(__builtin_memcpy_inline)
-#  define __UTL_MEMCPY __builtin_memcpy_inline
-
-#elif UTL_HAS_BUILTIN(__builtin_memcpy)
+#if UTL_HAS_BUILTIN(__builtin_memcpy)
 
 #  define __UTL_MEMCPY __builtin_memcpy
 

--- a/src/utl/public/utl/memory/utl_start_lifetime.h
+++ b/src/utl/public/utl/memory/utl_start_lifetime.h
@@ -11,16 +11,10 @@
 #include <new>
 
 #if UTL_HAS_BUILTIN(__builtin_memmove)
-#  define __UTL_MEMMOVE(...) __builtin_memmove(__VA_ARGS__)
+#  define __UTL_MEMMOVE __builtin_memmove
 #else
 #  include <string.h>
-#  define __UTL_MEMMOVE(...) ::memmove(__VA_ARGS__)
-#endif
-#if UTL_HAS_BUILTIN(__builtin_memcpy)
-#  define __UTL_MEMCPY(...) __builtin_memcpy(__VA_ARGS__)
-#else
-#  include <string.h>
-#  define __UTL_MEMCPY(...) ::memcpy(__VA_ARGS__)
+#  define __UTL_MEMMOVE ::memmove
 #endif
 
 UTL_NAMESPACE_BEGIN
@@ -42,9 +36,6 @@ namespace lifetime {
 #  define __UTL_ENTANGLE_PLACEMENT_IMPL 1
 #else
 #  define __UTL_ENTANGLE_MEMCPY_IMPL 1
-#  if UTL_COMPILER_MSVC
-#    pragma intrinsic(memcpy)
-#  endif
 #endif
 /**
  * Generates a superposition of all posible implicit lifetime types of size n with alignment

--- a/src/utl/public/utl/utl_config.h
+++ b/src/utl/public/utl/utl_config.h
@@ -12,6 +12,8 @@
 #include "utl/configuration/utl_compiler_barrier.h"
 #include "utl/configuration/utl_exceptions.h"
 #include "utl/configuration/utl_keywords.h"
+#include "utl/configuration/utl_memcmp.h"
+#include "utl/configuration/utl_memcpy.h"
 #include "utl/configuration/utl_namespace.h"
 #include "utl/configuration/utl_pragma.h"
 #include "utl/configuration/utl_simd.h"


### PR DESCRIPTION
## Atomic API
* More explicit API, memory orders must be specified
* Procedural API instead of object-oriented for simplicity and flexibility