### PR TITLE
Feat/string utils

### DIFF
--- a/NOTES
+++ b/NOTES
@@ -1,7 +1,8 @@
-* Supporting modules will probably be a massive PITA
+# Supporting modules will probably be a massive PITA
 # TODO: Modules doesn't play well with forward declarations, if using modules, just import std modules that we need
-* TODO: Maybe move all the type_traits builtins to a single file?
+# TODO: Maybe move all the type_traits builtins to a single file?
 # TODO: Fix for C++11 T.T
 # TODO: define CONSTEXPR_ASSERT for C++11
 # TODO: Investigate consteval bugs
 # TODO: Enable UTL keywords (utl_standard.h) based on features instead of standard
+# TODO: Make string_view use pointer_traits to allow smaller pointers

--- a/src/utl/private/tests/string/string.cpp
+++ b/src/utl/private/tests/string/string.cpp
@@ -6,8 +6,7 @@
 #include "utl/string/utl_string_utils.h"
 
 static_assert(utl::string_view("  \tabc ").find_last_not_of(" ") == 5, "");
-static_assert(
-    utl::string_utils::strip(utl::string_view("  \tabc ")) == utl::string_view("abc"), "");
+static_assert(utl::strip(utl::string_view("  \tabc ")) == utl::string_view("abc"), "");
 
 int comparable(utl::string s) {
     if (s != "hello") {

--- a/src/utl/private/tests/string/string.cpp
+++ b/src/utl/private/tests/string/string.cpp
@@ -3,6 +3,11 @@
 #include "utl/string/utl_basic_short_string.h"
 #include "utl/string/utl_basic_string_view.h"
 #include "utl/string/utl_basic_zstring_view.h"
+#include "utl/string/utl_string_utils.h"
+
+static_assert(utl::string_view("  \tabc ").find_last_not_of(" ") == 5, "");
+static_assert(
+    utl::string_utils::strip(utl::string_view("  \tabc ")) == utl::string_view("abc"), "");
 
 int comparable(utl::string s) {
     if (s != "hello") {

--- a/src/utl/public/utl/string/utl_basic_short_string.h
+++ b/src/utl/public/utl/string/utl_basic_short_string.h
@@ -49,6 +49,16 @@
 #define __UTL_ATTRIBUTE_STRING_CONST (CONST)(NODISCARD) __UTL_ATTRIBUTE__HIDE_FROM_ABI
 #define __UTL_ATTRIBUTE_TYPE_AGGREGATE_STRING_CONST
 
+/**
+ * Option to make string member definitions inline for C++ modules
+ * To be used in conjunction with basic_string_abi
+ */
+#ifndef UTL_STRING_NO_INLINE
+#  define __UTL_STRING_INLINE inline
+#else
+#  define __UTL_STRING_INLINE
+#endif
+
 UTL_NAMESPACE_BEGIN
 
 template <typename CharType, size_t ShortSize, typename Traits, typename Alloc>
@@ -182,16 +192,17 @@ public:
     using const_reverse_iterator = __UTL reverse_iterator<const_iterator>;
 
     basic_short_string(decltype(nullptr)) = delete;
-    __UTL_HIDE_FROM_ABI inline constexpr basic_short_string() noexcept(noexcept(allocator_type()))
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE constexpr basic_short_string() noexcept(
+        noexcept(allocator_type()))
         : basic_short_string(allocator_type()) {}
 
-    __UTL_HIDE_FROM_ABI explicit inline constexpr basic_short_string(
+    __UTL_HIDE_FROM_ABI explicit __UTL_STRING_INLINE constexpr basic_short_string(
         allocator_type const& a) noexcept
         : storage_(details::compressed_pair::default_initialize, a)
         , size_()
         , is_heap_() {}
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string(
         const_char_pointer str, size_type len, allocator_type const& a = allocator_type())
         UTL_THROWS
         : basic_short_string(a) {
@@ -200,22 +211,22 @@ public:
 
     template <UTL_CONCEPT_CXX20(__UTL legacy_input_iterator) It UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_legacy_input_iterator(It))>
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string(
         It first, It last, allocator_type const& a = allocator_type()) UTL_THROWS
         : basic_short_string(a) {
         assign(first, last);
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string(
         const_char_pointer str, allocator_type const& a = allocator_type()) UTL_THROWS
         : basic_short_string(str, traits_type::length(str), a) {}
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string(
         ::std::initializer_list<value_type> ilist,
         allocator_type const& a = allocator_type()) UTL_THROWS
         : basic_short_string(ilist.begin(), ilist.size(), a) {}
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string(
         size_type count, value_type ch, allocator_type const& a = allocator_type()) UTL_THROWS
         : basic_short_string(a) {
         resize(count, ch);
@@ -223,7 +234,7 @@ public:
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_HIDE_FROM_ABI explicit inline UTL_CONSTEXPR_CXX14 basic_short_string(View const& view,
+    __UTL_HIDE_FROM_ABI explicit __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string(View const& view,
         allocator_type const& a = allocator_type()) noexcept(!utl::with_exceptions &&
         is_nothrow_convertible<View, view_type>::value)
         : basic_short_string(a) {
@@ -232,14 +243,15 @@ public:
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string(View const& view, size_type pos,
-        size_type n, allocator_type const& a = allocator_type()) noexcept(!utl::with_exceptions &&
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string(View const& view,
+        size_type pos, size_type n,
+        allocator_type const& a = allocator_type()) noexcept(!utl::with_exceptions &&
         is_nothrow_convertible<View, view_type>::value)
         : basic_short_string(a) {
         assign(view, pos, n);
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string(
         basic_short_string const& other) UTL_THROWS
         : storage_(other.storage_.first(),
               alloc_traits::select_on_container_copy_construction(other.allocator_ref()))
@@ -250,8 +262,9 @@ public:
         }
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string(basic_short_string const& other,
-        size_type pos, size_type count, allocator_type const& alloc = allocator_type()) UTL_THROWS
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string(
+        basic_short_string const& other, size_type pos, size_type count,
+        allocator_type const& alloc = allocator_type()) UTL_THROWS
         : storage_(other.storage_.first(), alloc)
         , size_(other.size_)
         , is_heap_(other.is_heap_) {
@@ -267,11 +280,12 @@ public:
         inline_substring(pos, count);
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string(basic_short_string const& other,
-        size_type pos, allocator_type const& alloc = allocator_type()) UTL_THROWS
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string(
+        basic_short_string const& other, size_type pos,
+        allocator_type const& alloc = allocator_type()) UTL_THROWS
         : basic_short_string(other, pos, other.size(), alloc) {}
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& operator=(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& operator=(
         basic_short_string const& other) UTL_THROWS {
         if (this != __UTL addressof(other)) {
             destroy();
@@ -288,14 +302,15 @@ public:
         return *this;
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string(basic_short_string&& other) noexcept
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string(
+        basic_short_string&& other) noexcept
         : storage_(other.storage_)
         , size_(other.size_)
         , is_heap_(other.is_heap_) {
         __UTL move(other).reset_to_short();
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string(basic_short_string&& other,
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string(basic_short_string&& other,
         size_type pos, size_type count, allocator_type const& alloc = allocator_type()) UTL_THROWS
         : storage_(other.storage_.first(), alloc)
         , size_(other.size_)
@@ -309,21 +324,21 @@ public:
         on_move_construct_with_alloc(other, pos, count, alloc_traits::is_always_equal);
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string(basic_short_string&& other,
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string(basic_short_string&& other,
         size_type pos, allocator_type const& alloc = allocator_type()) UTL_THROWS
         : basic_short_string(__UTL move(other), pos, other.size(), alloc) {}
 
     // TODO: container-compatible-ranges ctor
 
-    __UTL_HIDE_FROM_ABI inline constexpr operator view_type() const noexcept UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE constexpr operator view_type() const noexcept UTL_LIFETIMEBOUND {
         return view_type{data(), size()};
     }
-    __UTL_HIDE_FROM_ABI explicit inline constexpr
+    __UTL_HIDE_FROM_ABI explicit __UTL_STRING_INLINE constexpr
     operator basic_zstring_view<value_type, traits_type>() const noexcept UTL_LIFETIMEBOUND {
         return basic_zstring_view<value_type, traits_type>{data(), size()};
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string&
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string&
     operator=(basic_short_string&& other) noexcept(
         (alloc_traits::propagate_on_container_move_assignment::value &&
             alloc_traits::is_always_equal::value) ||
@@ -336,39 +351,42 @@ public:
         return *this;
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX20 ~basic_short_string() noexcept { destroy(); }
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX20 ~basic_short_string() noexcept { destroy(); }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 char_pointer data() noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 char_pointer data() noexcept UTL_LIFETIMEBOUND {
         return !is_heap_ ? get_short().data_ : __UTL to_address(get_heap().data_);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_char_pointer data() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr const_char_pointer data() const noexcept UTL_LIFETIMEBOUND {
         return !is_heap_ ? get_short().data_ : __UTL to_address(get_heap().data_);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_pointer c_str() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr const_pointer c_str() const noexcept UTL_LIFETIMEBOUND {
         return data();
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool empty() const noexcept { return !size_; }
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type size() const noexcept { return size_; }
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type length() const noexcept { return size_; }
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool empty() const noexcept { return !size_; }
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type size() const noexcept { return size_; }
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type length() const noexcept {
+        return size_;
+    }
 
-    UTL_ATTRIBUTE(STRING_CONST) inline constexpr size_type max_size() const noexcept {
+    UTL_ATTRIBUTE(STRING_CONST) __UTL_STRING_INLINE constexpr size_type max_size() const noexcept {
         return numeric::maximum<size_type>::value >> 1;
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type capacity() const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type capacity() const noexcept {
         size_type const short_capacity = sizeof(short_type::data_) / sizeof(value_type);
         size_type const buffer_capacity = !is_heap_ ? short_capacity : get_heap().capacity_;
         return buffer_capacity - 1;
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr allocator_type get_allocator() const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr allocator_type get_allocator() const noexcept {
         return allocator_ref();
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void reserve(size_type new_capacity) UTL_THROWS {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 void reserve(
+        size_type new_capacity) UTL_THROWS {
         if (new_capacity <= this->capacity()) {
             return;
         }
@@ -381,12 +399,13 @@ public:
         reserve_impl(new_capacity);
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void resize(size_type new_size) UTL_THROWS {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 void resize(size_type new_size)
+        UTL_THROWS {
         resize(new_size, value_type());
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void resize(size_type new_size, value_type ch)
-        UTL_THROWS {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 void resize(
+        size_type new_size, value_type ch) UTL_THROWS {
         reserve(new_size);
         traits_type::assign(data() + size(), __UTL numeric::max(new_size, size()) - size(), ch);
         data()[new_size] = value_type();
@@ -398,7 +417,7 @@ public:
     UTL_CONSTRAINT_CXX20(requires(Op op, char_pointer p, size_type s) {
         { op(p, s) } -> integral;
     })
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_WITH_TRY void resize_and_overwrite(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_WITH_TRY void resize_and_overwrite(
         size_type new_size, Op operation) UTL_THROWS {
         reserve(new_size);
         UTL_TRY {
@@ -411,75 +430,76 @@ public:
         }
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void shrink_to_fit() UTL_THROWS {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 void shrink_to_fit() UTL_THROWS {
         if (is_heap_ && size() < capacity()) {
             get_heap() = alloc_traits::reallocate(allocator_ref(), get_heap(), size() + 1);
         }
     }
 
-    UTL_ATTRIBUTES(REINITIALIZES, _HIDE_FROM_ABI) inline UTL_CONSTEXPR_CXX14 void clear() noexcept {
+    UTL_ATTRIBUTES(REINITIALIZES, _HIDE_FROM_ABI) __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 void clear() noexcept {
         *data() = 0;
         size_ = 0;
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 iterator begin() noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 iterator begin() noexcept UTL_LIFETIMEBOUND {
         return iterator(data());
     }
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_iterator cbegin() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr const_iterator cbegin() const noexcept UTL_LIFETIMEBOUND {
         return const_iterator(data());
     }
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_iterator begin() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr const_iterator begin() const noexcept UTL_LIFETIMEBOUND {
         return const_iterator(data());
     }
-    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 iterator end() noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 iterator end() noexcept UTL_LIFETIMEBOUND {
         return iterator(data() + size());
     }
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_iterator cend() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr const_iterator cend() const noexcept UTL_LIFETIMEBOUND {
         return const_iterator(data() + size());
     }
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_iterator end() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr const_iterator end() const noexcept UTL_LIFETIMEBOUND {
         return const_iterator(data() + size());
     }
-    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 iterator rbegin() noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 iterator rbegin() noexcept UTL_LIFETIMEBOUND {
         return reverse_iterator(end());
     }
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_iterator crbegin() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr const_iterator crbegin() const noexcept UTL_LIFETIMEBOUND {
         return const_reverse_iterator(end());
     }
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_iterator rbegin() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr const_iterator rbegin() const noexcept UTL_LIFETIMEBOUND {
         return const_reverse_iterator(end());
     }
-    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 iterator rend() noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 iterator rend() noexcept UTL_LIFETIMEBOUND {
         return reverse_iterator(begin());
     }
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_iterator crend() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr const_iterator crend() const noexcept UTL_LIFETIMEBOUND {
         return const_reverse_iterator(begin());
     }
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_iterator rend() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr const_iterator rend() const noexcept UTL_LIFETIMEBOUND {
         return const_reverse_iterator(begin());
     }
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_reference front() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr const_reference front() const noexcept UTL_LIFETIMEBOUND {
         return *data();
     }
-    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 reference front() noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 reference front() noexcept UTL_LIFETIMEBOUND {
         return *data();
     }
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_reference back() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr const_reference back() const noexcept UTL_LIFETIMEBOUND {
         return data()[size() - 1];
     }
-    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 reference back() noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 reference back() noexcept UTL_LIFETIMEBOUND {
         return data()[size() - 1];
     }
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_reference operator[](size_type idx) const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr const_reference operator[](
+        size_type idx) const noexcept UTL_LIFETIMEBOUND {
         return data()[idx];
     }
-    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 reference operator[](size_type idx) noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 reference operator[](size_type idx) noexcept UTL_LIFETIMEBOUND {
         return data()[idx];
     }
-    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 reference at(size_type idx) UTL_THROWS UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 reference at(size_type idx) UTL_THROWS UTL_LIFETIMEBOUND {
         return const_cast<reference>(as_const(*this).data()[idx]);
     }
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_reference at(size_type idx) const UTL_THROWS UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr const_reference at(size_type idx) const UTL_THROWS UTL_LIFETIMEBOUND {
         UTL_THROW_IF(idx >= size(),
             out_of_range(UTL_MESSAGE_FORMAT("[UTL] basic_short_string::at operation failed, "
                                             "Reason=[index out of range], idx=[%zu], size=[%zu]"),
@@ -487,19 +507,20 @@ public:
         return data()[idx];
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void push_back(value_type ch) UTL_THROWS {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 void push_back(value_type ch)
+        UTL_THROWS {
         reserve(size() + 1);
         data()[size_++] = ch;
         data()[size_] = value_type();
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void pop_back() noexcept {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 void pop_back() noexcept {
         data()[--size_] = value_type();
     }
 
     basic_short_string& assign(decltype(nullptr)) = delete;
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_WITH_TRY basic_short_string& assign(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_WITH_TRY basic_short_string& assign(
         size_type count, value_type ch) UTL_THROWS UTL_LIFETIMEBOUND {
         UTL_ATTRIBUTE(MAYBE_UNUSED) size_type const old_size = exchange(size_, 0);
         UTL_TRY {
@@ -512,13 +533,14 @@ public:
         }
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& assign(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& assign(
         basic_short_string const& other) UTL_THROWS UTL_LIFETIMEBOUND {
         return *this = other;
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& assign(basic_short_string const& other,
-        size_type pos, size_type count = npos) UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& assign(
+        basic_short_string const& other, size_type pos, size_type count = npos)
+        UTL_THROWS UTL_LIFETIMEBOUND {
         if (this == addressof(other)) {
             return *this;
         }
@@ -535,12 +557,12 @@ public:
         return *this;
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& assign(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& assign(
         basic_short_string&& other) UTL_THROWS UTL_LIFETIMEBOUND {
         return *this = move(other);
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& assign(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& assign(
         const_char_pointer str, size_type count) UTL_THROWS UTL_LIFETIMEBOUND {
         UTL_ASSERT(str != nullptr);
         reserve(count);
@@ -549,7 +571,7 @@ public:
         return *this;
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& assign(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& assign(
         const_char_pointer str) UTL_THROWS {
         UTL_ASSERT(str != nullptr);
         assign(str, traits_type::length(str));
@@ -557,8 +579,8 @@ public:
 
     template <UTL_CONCEPT_CXX20(__UTL legacy_input_iterator) It UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_legacy_input_iterator(It) && !UTL_TRAIT_is_legacy_forward_iterator(It))>
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& assign(It begin, It end)
-        UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& assign(
+        It begin, It end) UTL_THROWS UTL_LIFETIMEBOUND {
         size_ = 0;
         while (begin != end) {
             push_back(*begin);
@@ -568,8 +590,8 @@ public:
 
     template <UTL_CONCEPT_CXX20(__UTL legacy_forward_iterator) It UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_legacy_forward_iterator(It))>
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX17 basic_short_string& assign(It begin, It end)
-        UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX17 basic_short_string& assign(
+        It begin, It end) UTL_THROWS UTL_LIFETIMEBOUND {
         auto const diff = __UTL distance(begin, end);
         if (diff < 0) UTL_ATTRIBUTE(UNLIKELY) {
             return *this;
@@ -585,22 +607,22 @@ public:
         size_ = diff;
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& assign(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& assign(
         ::std::initializer_list<value_type> list) UTL_THROWS UTL_LIFETIMEBOUND {
         assign(list.begin(), list.end());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& assign(View const& view)
-        UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& assign(
+        View const& view) UTL_THROWS UTL_LIFETIMEBOUND {
         view_type const v(view);
         return assign(v.data(), v.size());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& assign(View const& view,
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& assign(View const& view,
         size_type subidx, size_type subcount = npos) UTL_THROWS UTL_LIFETIMEBOUND {
         view_type const v(view);
         UTL_THROW_IF(subidx > v.size(),
@@ -612,7 +634,7 @@ public:
         return assign(v.substr(subidx, subcount));
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& insert(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& insert(
         size_type pos, size_type count, value_type ch) UTL_THROWS UTL_LIFETIMEBOUND {
         UTL_THROW_IF(pos > size(),
             out_of_range(UTL_MESSAGE_FORMAT("[UTL] `basic_short_string::insert` operation failed, "
@@ -627,7 +649,7 @@ public:
         return begin() + pos;
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& insert(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& insert(
         size_type pos, const_char_pointer str, size_type length) UTL_THROWS UTL_LIFETIMEBOUND {
         UTL_THROW_IF(pos > size(),
             out_of_range(UTL_MESSAGE_FORMAT("[UTL] `basic_short_string::insert` operation failed, "
@@ -642,17 +664,17 @@ public:
         return *this;
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& insert(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& insert(
         size_type pos, const_char_pointer str) UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(pos, str, traits_type::length(str));
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& insert(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& insert(
         size_type pos, basic_short_string const& str) UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(pos, str.data(), str.size());
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& insert(size_type pos,
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& insert(size_type pos,
         basic_short_string const& str, size_type idx, size_type count = npos)
         UTL_THROWS UTL_LIFETIMEBOUND {
         UTL_THROW_IF(idx > str.size(),
@@ -665,19 +687,19 @@ public:
         return insert(pos, str.data() + idx, copy_size);
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 iterator insert(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 iterator insert(
         const_iterator pos, size_type count, value_type ch) UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(pos - cbegin(), count, ch);
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 iterator insert(const_iterator pos, value_type ch)
-        UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 iterator insert(
+        const_iterator pos, value_type ch) UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(pos, 1, ch);
     }
 
     template <UTL_CONCEPT_CXX20(__UTL legacy_input_iterator) It UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_legacy_input_iterator(It) && !UTL_TRAIT_is_legacy_forward_iterator(It))>
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 iterator insert(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 iterator insert(
         const_iterator pos, It first, It last) UTL_THROWS UTL_LIFETIMEBOUND {
         auto const idx = pos - begin();
         while (first != last) {
@@ -690,7 +712,7 @@ public:
 
     template <UTL_CONCEPT_CXX20(__UTL legacy_forward_iterator) It UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_legacy_forward_iterator(It))>
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 iterator insert(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 iterator insert(
         const_iterator pos, It first, It last) UTL_THROWS UTL_LIFETIMEBOUND {
         auto const length = __UTL distance(first, last);
         if (length < 0) UTL_ATTRIBUTE(UNLIKELY) {
@@ -712,14 +734,14 @@ public:
         return iterator(data() + idx);
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 iterator insert(const_iterator pos,
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 iterator insert(const_iterator pos,
         ::std::initializer_list<value_type> list) UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(pos, list.begin(), list.size());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& insert(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& insert(
         size_type pos, View const& view) UTL_THROWS UTL_LIFETIMEBOUND {
         view_type const v(view);
         return insert(pos, v.data(), v.size());
@@ -727,8 +749,9 @@ public:
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& insert(size_type pos, View const& view,
-        size_type subidx, size_type subcount = npos) UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& insert(
+        size_type pos, View const& view, size_type subidx, size_type subcount = npos)
+        UTL_THROWS UTL_LIFETIMEBOUND {
         view_type const v(view);
         UTL_THROW_IF(subidx > v.size(),
             out_of_range(
@@ -739,27 +762,28 @@ public:
         return insert(pos, v.substr(subidx, subcount));
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& erase(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& erase(
         size_type idx = 0, size_type count = npos) UTL_THROWS UTL_LIFETIMEBOUND {
         auto const length = __UTL numeric::min(size() - idx, count);
         auto const first = begin() + idx;
         return erase(first, first + length), *this;
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 iterator erase(iterator pos) noexcept UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 iterator erase(iterator pos) noexcept UTL_LIFETIMEBOUND {
         return erase(pos, pos + 1);
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 iterator erase(const_iterator pos) noexcept UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 iterator erase(const_iterator pos) noexcept UTL_LIFETIMEBOUND {
         return erase(pos, pos + 1);
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 iterator erase(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 iterator erase(
         const_iterator first, const_iterator last) noexcept UTL_LIFETIMEBOUND {
         return erase(iterator(first), iterator(last));
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 iterator erase(iterator first, iterator last) noexcept UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 iterator erase(
+        iterator first, iterator last) noexcept UTL_LIFETIMEBOUND {
         auto const length = last - first;
         auto const src = last.operator->();
         auto const dst = first.operator->();
@@ -769,53 +793,54 @@ public:
         return iterator(dst + length);
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& append(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& append(
         size_type count, value_type ch) UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(size(), count, ch);
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& append(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& append(
         basic_short_string const& str) UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(size(), str);
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& append(basic_short_string const& str,
-        size_type idx, size_type count = npos) UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& append(
+        basic_short_string const& str, size_type idx, size_type count = npos)
+        UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(size(), str, idx, count);
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& append(const_char_pointer str)
-        UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& append(
+        const_char_pointer str) UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(size(), str);
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& append(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& append(
         const_char_pointer str, size_type count) UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(size(), str, count);
     }
 
     template <UTL_CONCEPT_CXX20(__UTL legacy_input_iterator) It UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_legacy_input_iterator(It))>
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& append(It first, It last)
-        UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& append(
+        It first, It last) UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(end(), first, last), *this;
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& append(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& append(
         ::std::initializer_list<value_type> list) UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(size(), list.begin(), list.size());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& append(View const& view)
-        UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& append(
+        View const& view) UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(size(), view);
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& append(View const& view,
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& append(View const& view,
         size_type subidx, size_type subcount = npos) UTL_THROWS UTL_LIFETIMEBOUND {
         view_type const v(view);
         UTL_THROW_IF(subidx > v.size(),
@@ -827,46 +852,47 @@ public:
         return insert(size(), v.substr(subidx, subcount));
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& operator+=(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& operator+=(
         basic_short_string const& str) UTL_THROWS UTL_LIFETIMEBOUND {
         return append(str);
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& operator+=(value_type ch)
-        UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& operator+=(
+        value_type ch) UTL_THROWS UTL_LIFETIMEBOUND {
         return append(1, ch);
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& operator+=(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& operator+=(
         const_char_pointer str) UTL_THROWS UTL_LIFETIMEBOUND {
         return append(str);
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& operator+=(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& operator+=(
         ::std::initializer_list<value_type> list) UTL_THROWS UTL_LIFETIMEBOUND {
         return append(list);
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& operator+=(View const& view)
-        UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& operator+=(
+        View const& view) UTL_THROWS UTL_LIFETIMEBOUND {
         return append(view);
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(size_type pos, size_type count,
-        basic_short_string const& str) UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& replace(size_type pos,
+        size_type count, basic_short_string const& str) UTL_THROWS UTL_LIFETIMEBOUND {
         return replace(pos, count, str.data(), str.size());
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
-        const_iterator last, basic_short_string const& str) UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& replace(
+        const_iterator first, const_iterator last, basic_short_string const& str)
+        UTL_THROWS UTL_LIFETIMEBOUND {
         return replace(first, last, str.data(), str.size());
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(size_type pos, size_type count,
-        basic_short_string const& str, size_type subidx, size_type subcount = npos)
-        UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& replace(size_type pos,
+        size_type count, basic_short_string const& str, size_type subidx,
+        size_type subcount = npos) UTL_THROWS UTL_LIFETIMEBOUND {
         UTL_THROW_IF(subidx > str.size(),
             out_of_range(
                 UTL_MESSAGE_FORMAT(
@@ -877,8 +903,9 @@ public:
         return replace(pos, count, view.data(), view.size());
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(size_type pos, size_type count,
-        const_char_pointer str, size_type length) UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& replace(
+        size_type pos, size_type count, const_char_pointer str, size_type length)
+        UTL_THROWS UTL_LIFETIMEBOUND {
         UTL_THROW_IF(pos > size(),
             out_of_range(UTL_MESSAGE_FORMAT("[UTL] `basic_short_string::replace` operation failed, "
                                             "Reason=[index out of range], pos=[%zu], size=[%zu]"),
@@ -887,9 +914,9 @@ public:
         return replace(first, first + count, str, length);
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
-        const_iterator last, const_char_pointer str, size_type length)
-        UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& replace(
+        const_iterator first, const_iterator last, const_char_pointer str,
+        size_type length) UTL_THROWS UTL_LIFETIMEBOUND {
         auto const replaced_count = last - first;
         auto copy_str = [p = const_cast<pointer>(first.operator->()), str](
                             size_type count) { return traits_type::move(p, str, count); };
@@ -905,20 +932,21 @@ public:
         return *this;
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& replace(
         size_type pos, size_type count, const_char_pointer str) UTL_THROWS {
         UTL_ASSERT(str != nullptr);
         return replace(pos, count, str, traits_type::length(str));
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
-        const_iterator last, const_char_pointer str) UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& replace(
+        const_iterator first, const_iterator last, const_char_pointer str)
+        UTL_THROWS UTL_LIFETIMEBOUND {
         UTL_ASSERT(str != nullptr);
         return replace(first, last, str, traits_type::length(str));
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(size_type pos, size_type count,
-        size_type char_count, value_type ch) UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& replace(size_type pos,
+        size_type count, size_type char_count, value_type ch) UTL_THROWS UTL_LIFETIMEBOUND {
         UTL_THROW_IF(pos > size(),
             out_of_range(UTL_MESSAGE_FORMAT("[UTL] `basic_short_string::replace` operation failed, "
                                             "Reason=[index out of range], pos=[%zu], size=[%zu]"),
@@ -927,8 +955,9 @@ public:
         return replace(first, first + count, char_count, ch);
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
-        const_iterator last, size_type char_count, value_type ch) UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& replace(
+        const_iterator first, const_iterator last, size_type char_count, value_type ch)
+        UTL_THROWS UTL_LIFETIMEBOUND {
         auto const replaced_count = last - first;
         auto const assign_ch = [p = const_cast<pointer>(first.operator->()), ch](
                                    size_type cnt) { return traits_type::assign(p, cnt, ch); };
@@ -946,8 +975,9 @@ public:
 
     template <UTL_CONCEPT_CXX20(__UTL legacy_input_iterator) It UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_legacy_input_iterator(It))>
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
-        const_iterator last, It in_first, It in_last) UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& replace(
+        const_iterator first, const_iterator last, It in_first, It in_last)
+        UTL_THROWS UTL_LIFETIMEBOUND {
         while (first != last && in_first != in_last) {
             const_cast<reference>(*first) = *in_first;
             ++first;
@@ -959,25 +989,25 @@ public:
         return *this;
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
-        const_iterator last, ::std::initializer_list<value_type> list)
-        UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& replace(
+        const_iterator first, const_iterator last,
+        ::std::initializer_list<value_type> list) UTL_THROWS UTL_LIFETIMEBOUND {
         return replace(first, last, list.begin(), list.size());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
-        const_iterator last, View const& view) UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& replace(
+        const_iterator first, const_iterator last, View const& view) UTL_THROWS UTL_LIFETIMEBOUND {
         view_type const v(view);
         return replace(first, last, v.data(), v.size());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
-        const_iterator last, View const& view, size_type subidx, size_type subcount = npos)
-        UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& replace(
+        const_iterator first, const_iterator last, View const& view, size_type subidx,
+        size_type subcount = npos) UTL_THROWS UTL_LIFETIMEBOUND {
         view_type const v(view);
         UTL_THROW_IF(subidx > v.size(),
             out_of_range(
@@ -990,7 +1020,7 @@ public:
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& replace(
         size_type idx, size_type count, View const& view) UTL_THROWS UTL_LIFETIMEBOUND {
         auto const first = cbegin() + idx;
         return replace(first, first + count, view);
@@ -998,8 +1028,8 @@ public:
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(size_type idx, size_type count,
-        View const& view, size_type subidx, size_type subcount = npos)
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 basic_short_string& replace(size_type idx,
+        size_type count, View const& view, size_type subidx, size_type subcount = npos)
         UTL_THROWS UTL_LIFETIMEBOUND {
         view_type const v(view);
         UTL_THROW_IF(subidx > v.size(),
@@ -1011,7 +1041,7 @@ public:
         return replace(idx, count, v.substr(subidx, subcount));
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 size_type copy(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 size_type copy(
         pointer dst, size_type count, size_type pos = 0) const UTL_THROWS {
         UTL_THROW_IF(pos > size(),
             out_of_range(UTL_MESSAGE_FORMAT("[UTL] `basic_short_string::replace` operation failed, "
@@ -1023,249 +1053,254 @@ public:
         return copied;
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void swap(basic_short_string& other) noexcept(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 void swap(basic_short_string& other) noexcept(
         alloc_traits::propagate_on_container_swap::value || alloc_traits::is_always_equal::value) {
         using swap_alloc_t = bool_constant<alloc_traits::propagate_on_container_swap::value ||
             !alloc_traits::is_always_equal::value>;
         swap(other, swap_alloc_t{});
     }
 
-    __UTL_HIDE_FROM_ABI friend inline UTL_CONSTEXPR_CXX14 void swap(
+    __UTL_HIDE_FROM_ABI friend __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 void swap(
         basic_short_string& l, basic_short_string& r) noexcept(noexcept(l.swap(r))) {
         l.swap(r);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find(
         basic_short_string const& str, size_type pos = 0) const noexcept {
         return find(str.data(), pos, str.size());
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find(
         const_char_pointer str, size_type pos, size_type str_len) const noexcept {
         // CONSTEXPR_ASSERT(str != nullptr);
         return details::string::find<traits_type>(data(), size(), str, str_len, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find(
         const_char_pointer str, size_type pos = 0) const noexcept {
         // CONSTEXPR_ASSERT(str != nullptr);
         return find(str, pos, traits_type::length(str));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find(
         value_type ch, size_type pos = 0) const noexcept {
         return details::string::find<traits_type>(data(), size(), ch, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find(
         view_type view, size_type pos = 0) const noexcept {
         return find(view.data(), pos, view.size());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) inline constexpr size_type find(View const& view,
+    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) __UTL_STRING_INLINE constexpr size_type find(View const& view,
         size_type pos = 0) const noexcept(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
         return find(view_type(view), pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type rfind(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type rfind(
         basic_short_string const& str, size_type pos = npos) const noexcept {
         return rfind(str.data(), pos, str.size());
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type rfind(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type rfind(
         const_char_pointer str, size_type pos, size_type str_len) const noexcept {
         // CONSTEXPR_ASSERT(str != nullptr);
         return details::string::rfind<traits_type>(data(), size(), str, str_len, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type rfind(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type rfind(
         const_char_pointer str, size_type pos = npos) const noexcept {
         // CONSTEXPR_ASSERT(str != nullptr);
         return rfind(str, pos, traits_type::length(str));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type rfind(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type rfind(
         value_type ch, size_type pos = npos) const noexcept {
         return details::string::rfind<traits_type>(data(), size(), ch, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type rfind(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type rfind(
         view_type view, size_type pos = npos) const noexcept {
         return rfind(view.data(), pos, view.size());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) inline constexpr size_type rfind(View const& view,
+    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) __UTL_STRING_INLINE constexpr size_type rfind(View const& view,
         size_type pos = npos) const noexcept(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
         return rfind(view_type(view), pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_of(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find_first_of(
         basic_short_string const& chars, size_type pos = 0) const noexcept {
         return find_first_of(chars.data(), pos, chars.size());
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_of(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find_first_of(
         const_char_pointer chars, size_type pos, size_type chars_count) const noexcept {
         // CONSTEXPR_ASSERT(chars != nullptr);
         return details::string::find_first_of<traits_type>(data(), size(), chars, chars_count, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_of(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find_first_of(
         const_char_pointer chars, size_type pos = 0) const noexcept {
         // CONSTEXPR_ASSERT(chars != nullptr);
         return find_first_of(chars, pos, traits_type::length(chars));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_of(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find_first_of(
         value_type ch, size_type pos = 0) const noexcept {
         return details::string::find_first_of<traits_type>(data(), size(), ch, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_of(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find_first_of(
         view_type view, size_type pos = 0) const noexcept {
         return find_first_of(view.data(), pos, view.size());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) inline constexpr size_type find_first_of(View const& view,
-        size_type pos = 0) const noexcept(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
+    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) __UTL_STRING_INLINE constexpr size_type find_first_of(
+        View const& view, size_type pos = 0) const
+        noexcept(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
         return find_first_of(view_type(view), pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find_first_not_of(
         basic_short_string const& chars, size_type pos = 0) const noexcept {
         return find_first_not_of(chars.data(), pos, chars.size());
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find_first_not_of(
         const_char_pointer chars, size_type pos, size_type chars_count) const noexcept {
         // CONSTEXPR_ASSERT(chars != nullptr);
         return details::string::find_first_not_of<traits_type>(
             data(), size(), chars, chars_count, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find_first_not_of(
         const_char_pointer chars, size_type pos = 0) const noexcept {
         // CONSTEXPR_ASSERT(chars != nullptr);
         return find_first_not_of(chars, pos, traits_type::length(chars));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find_first_not_of(
         value_type ch, size_type pos = 0) const noexcept {
         return find_first_not_of(&ch, pos, 1);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find_first_not_of(
         view_type view, size_type pos = 0) const noexcept {
         return find_first_not_of(view.data(), pos, view.size());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) inline constexpr size_type find_first_not_of(View const& view,
-        size_type pos = 0) const noexcept(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
+    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) __UTL_STRING_INLINE constexpr size_type find_first_not_of(
+        View const& view, size_type pos = 0) const
+        noexcept(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
         return find_first_not_of(view_type(view), pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_of(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find_last_of(
         basic_short_string const& chars, size_type pos = npos) const noexcept {
         return find_last_of(chars.data(), pos, chars.size());
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_of(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find_last_of(
         const_char_pointer chars, size_type pos, size_type chars_count) const noexcept {
         // CONSTEXPR_ASSERT(chars != nullptr);
         return details::string::find_last_of<traits_type>(data(), size(), chars, chars_count, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_of(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find_last_of(
         const_char_pointer chars, size_type pos = npos) const noexcept {
         // CONSTEXPR_ASSERT(chars != nullptr);
         return find_last_of(chars, pos, traits_type::length(chars));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_of(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find_last_of(
         value_type ch, size_type pos = npos) const noexcept {
         return find_last_of(&ch, pos, 1);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_of(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find_last_of(
         view_type view, size_type pos = npos) const noexcept {
         return find_last_of(view.data(), pos, view.size());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) inline constexpr size_type find_last_of(View const& view,
-        size_type pos = npos) const noexcept(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
+    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) __UTL_STRING_INLINE constexpr size_type find_last_of(
+        View const& view, size_type pos = npos) const
+        noexcept(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
         return find_last_of(view_type(view), pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find_last_not_of(
         basic_short_string const& chars, size_type pos = npos) const noexcept {
         return find_last_not_of(chars.data(), pos, chars.size());
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find_last_not_of(
         const_char_pointer chars, size_type pos, size_type count) const UTL_THROWS {
         // CONSTEXPR_ASSERT(chars != nullptr);
         return details::string::find_last_not_of<traits_type>(data(), size(), chars, count, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find_last_not_of(
         const_char_pointer chars, size_type pos = npos) const UTL_THROWS {
         // CONSTEXPR_ASSERT(chars != nullptr);
         return find_last_not_of(chars, pos, traits_type::length(chars));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find_last_not_of(
         value_type ch, size_type pos = npos) const UTL_THROWS {
         return find_last_not_of(&ch, pos, 1);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr size_type find_last_not_of(
         view_type view, size_type pos = npos) const UTL_THROWS {
         return find_last_not_of(view.data(), pos, view.size());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) inline constexpr size_type find_last_not_of(View const& view,
-        size_type pos = npos) const UTL_NOEXCEPT(UTL_TRAIT_is_nothrow_convertible(View,
+    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) __UTL_STRING_INLINE constexpr size_type find_last_not_of(
+        View const& view, size_type pos = npos) const UTL_NOEXCEPT(UTL_TRAIT_is_nothrow_convertible(View,
         view_type)) {
         return find_last_not_of(view_type(view), pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr int compare(basic_short_string const& other) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr int compare(
+        basic_short_string const& other) const noexcept {
         return details::string::compare<traits_type>(data(), size(), other.data(), other.size());
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr int compare(const_char_pointer str) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr int compare(
+        const_char_pointer str) const noexcept {
         // CONSTEXPR_ASSERT(str != nullptr);
         return details::string::compare<traits_type>(data(), size(), str, traits_type::length(str));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr int compare(view_type view) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr int compare(view_type view) const noexcept {
         return details::string::compare<traits_type>(data(), size(), view.data(), view.size());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(is_convertible<View, view_type>::value)>
-    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) inline UTL_CONSTEXPR_CXX14 int compare(View const& view) const
+    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 int compare(View const& view) const
         noexcept(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
         return compare(view_type(view));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 int compare(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 int compare(
         size_type pos, size_type count, basic_short_string const& other) const UTL_THROWS {
         return compare(pos, count, other.data(), other.size());
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 int compare(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 int compare(
         size_type pos, size_type count, const_char_pointer str, size_type str_len) const UTL_THROWS {
         UTL_ASSERT(str != nullptr);
         UTL_THROW_IF(pos > size(),
@@ -1276,24 +1311,24 @@ public:
             data() + pos, __UTL numeric::min(count, size() - pos), str, str_len);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 int compare(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 int compare(
         size_type pos, size_type count, const_char_pointer str) const UTL_THROWS {
         return compare(pos, count, str, traits_type::length(str));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 int compare(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 int compare(
         size_type pos, size_type count, view_type view) const UTL_THROWS {
         return compare(pos, count, view.data(), view.size());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) inline UTL_CONSTEXPR_CXX14 int compare(size_type pos, size_type count,
-        View const& view) const UTL_NOEXCEPT(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
+    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 int compare(
+        size_type pos, size_type count, View const& view) const UTL_NOEXCEPT(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
         return compare(pos, count, view_type(view));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 int compare(size_type pos, size_type count,
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 int compare(size_type pos, size_type count,
         basic_short_string const& other, size_type pos2, size_type count2 = npos) const UTL_THROWS {
         UTL_THROW_IF(pos2 > other.size(),
             out_of_range(
@@ -1303,8 +1338,8 @@ public:
         return compare(pos, count, view_type(other).substr(pos2, count2));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 int compare(size_type pos, size_type count, view_type view,
-        size_type pos2, size_type count2 = npos) const UTL_THROWS {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 int compare(size_type pos, size_type count,
+        view_type view, size_type pos2, size_type count2 = npos) const UTL_THROWS {
         UTL_THROW_IF(pos2 > view.size(),
             out_of_range(
                 UTL_MESSAGE_FORMAT("[UTL] `basic_short_string::compare` operation failed, "
@@ -1315,65 +1350,69 @@ public:
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    UTL_ATTRIBUTES(NODISCARD, PURE, _ABI_PRIVATE) inline UTL_CONSTEXPR_CXX14 int compare(size_type pos, size_type count,
-        View const& view, size_type pos2, size_type count2 = npos) const UTL_NOEXCEPT(UTL_TRAIT_is_nothrow_convertible(View,
+    UTL_ATTRIBUTES(NODISCARD, PURE, _ABI_PRIVATE) __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 int compare(size_type pos,
+        size_type count, View const& view, size_type pos2, size_type count2 = npos) const UTL_NOEXCEPT(UTL_TRAIT_is_nothrow_convertible(View,
         view_type)) {
         return compare(pos, count, view_type(view), pos2, count2);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool starts_with(view_type view) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool starts_with(view_type view) const noexcept {
         return size() >= view.size() && traits_type::compare(data(), view.data(), view.size()) == 0;
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool starts_with(value_type ch) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool starts_with(value_type ch) const noexcept {
         return !empty() && front() == ch;
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool starts_with(const_char_pointer str) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool starts_with(
+        const_char_pointer str) const noexcept {
         // CONSTEXPR_ASSERT(str != nullptr);
         return starts_with(view_type(str));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool ends_with(view_type view) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool ends_with(view_type view) const noexcept {
         return size() >= view.size() &&
             traits_type::compare(view_type(*this).substr(size() - view.size()).data(), view.data(),
                 view.size()) == 0;
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool ends_with(value_type ch) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool ends_with(value_type ch) const noexcept {
         return !empty() && back() == ch;
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool ends_with(const_char_pointer str) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool ends_with(
+        const_char_pointer str) const noexcept {
         // CONSTEXPR_ASSERT(str != nullptr);
         return ends_with(view_type(str));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool contains(view_type view) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool contains(view_type view) const noexcept {
         return find(view) != npos;
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool contains(value_type ch) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool contains(value_type ch) const noexcept {
         return traits_type::find(data(), size(), ch) != nullptr;
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool contains(const_char_pointer str) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool contains(
+        const_char_pointer str) const noexcept {
         // CONSTEXPR_ASSERT(str != nullptr);
         return contains(view_type(str));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr basic_short_string substr(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr basic_short_string substr(
         size_type pos = 0, size_type count = npos) const& {
         return basic_short_string(*this, pos, count);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) inline constexpr basic_short_string substr(
+    UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr basic_short_string substr(
         size_type pos = 0, size_type count = npos) const&& {
         return basic_short_string(__UTL move(*this), pos, count);
     }
 
 private:
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void swap(basic_short_string& other, false_type) noexcept {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 void swap(
+        basic_short_string& other, false_type) noexcept {
         ranges::swap(storage_.first(), other.storage_.first());
         auto size_tmp = size_;
         auto heap_tmp = is_heap_;
@@ -1383,12 +1422,13 @@ private:
         other.is_heap_ = heap_tmp;
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void swap(basic_short_string& other, true_type) noexcept {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 void swap(
+        basic_short_string& other, true_type) noexcept {
         swap(other, false_type{});
         ranges::swap(allocator_ref(), other.allocator_ref());
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CONSTRUCTS_AT void transfer_to_heap(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CONSTRUCTS_AT void transfer_to_heap(
         size_type new_capacity) UTL_THROWS {
         UTL_ASSERT(!is_heap_);
         auto const result = alloc_traits::allocate_at_least(allocator_ref(), new_capacity + 1);
@@ -1398,15 +1438,15 @@ private:
         is_heap_ = true;
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX20 void grow_heap(size_type new_capacity)
-        UTL_THROWS {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX20 void grow_heap(
+        size_type new_capacity) UTL_THROWS {
         UTL_ASSERT(is_heap_);
         get_heap() =
             alloc_traits::reallocate_at_least(allocator_ref(), get_heap(), new_capacity + 1);
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX20 void reserve_impl(size_type new_capacity)
-        UTL_THROWS {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX20 void reserve_impl(
+        size_type new_capacity) UTL_THROWS {
         UTL_ASSERT(new_capacity > this->capacity());
         UTL_TRY {
             if (!is_heap_) {
@@ -1422,13 +1462,13 @@ private:
         }
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void destroy() noexcept {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 void destroy() noexcept {
         if (is_heap_) {
             alloc_traits::deallocate(allocator_ref(), get_heap().data_, get_heap().capacity_);
         }
     }
 
-    __UTL_HIDE_FROM_ABI static inline UTL_CONSTEXPR_CXX20 heap_type clone_heap(
+    __UTL_HIDE_FROM_ABI static __UTL_STRING_INLINE UTL_CONSTEXPR_CXX20 heap_type clone_heap(
         allocator_type& alloc, basic_short_string const& src) UTL_THROWS {
         UTL_ASSERT(src.is_heap_);
         UTL_TRY {
@@ -1443,10 +1483,9 @@ private:
         }
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void reset_to_short() && noexcept {
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 void reset_to_short() && noexcept {
         // The && qualifier is not needed but added to prevent accidental use
-        // inline constexpr only if `is_heap_` is `false` because inline constexpr placement new is
-        // not portable
+        // constexpr only if `is_heap_` is `false` because constexpr placement new is not portable
         if (is_heap_) {
             size_ = 0;
             is_heap_ = false;
@@ -1454,12 +1493,12 @@ private:
         }
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void move_assign(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 void move_assign(
         basic_short_string& other, false_type) UTL_THROWS {
         *this = other;
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void move_assign(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 void move_assign(
         basic_short_string& other, true_type) noexcept {
         destroy();
         storage_.first() = other.storage_.first();
@@ -1470,14 +1509,14 @@ private:
         __UTL move(other).reset_to_short();
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void inline_substring(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 void inline_substring(
         size_type pos, size_type count) noexcept {
         auto const new_size = __UTL numeric::min(this->size() - pos, count);
         traits_type::move(this->data(), this->data() + pos, new_size);
         this->resize(new_size);
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void on_move_construct_with_alloc(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 void on_move_construct_with_alloc(
         basic_short_string& other, size_type pos, size_type count, true_type) UTL_THROWS {
         if (!alloc_traits::equals(allocator_ref(), other.allocator_ref()) && other.is_heap_) {
             storage_.get_heap() = clone_heap(allocator_ref(), other);
@@ -1488,28 +1527,29 @@ private:
         }
     }
 
-    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void on_move_construct_with_alloc(
+    __UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 void on_move_construct_with_alloc(
         basic_short_string& other, size_type pos, size_type count, false_type) noexcept {
         inline_substring(pos, count);
         __UTL move(other).reset_to_short();
     }
 
-    UTL_ATTRIBUTE(STRING_CONST) inline UTL_CONSTEXPR_CXX14 short_type& get_short() noexcept {
+    UTL_ATTRIBUTE(STRING_CONST) __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 short_type& get_short() noexcept {
         return storage_.first().short_;
     }
-    UTL_ATTRIBUTE(STRING_CONST) inline UTL_CONSTEXPR_CXX14 heap_type& get_heap() noexcept {
+    UTL_ATTRIBUTE(STRING_CONST) __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 heap_type& get_heap() noexcept {
         return storage_.first().heap_;
     }
-    UTL_ATTRIBUTE(STRING_CONST) inline UTL_CONSTEXPR_CXX14 allocator_type& allocator_ref() noexcept {
+    UTL_ATTRIBUTE(STRING_CONST) __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14 allocator_type& allocator_ref() noexcept {
         return storage_.second();
     }
-    UTL_ATTRIBUTE(STRING_CONST) inline constexpr short_type const& get_short() const noexcept {
+    UTL_ATTRIBUTE(STRING_CONST) __UTL_STRING_INLINE constexpr short_type const& get_short() const noexcept {
         return storage_.first().short_;
     }
-    UTL_ATTRIBUTE(STRING_CONST) inline constexpr heap_type const& get_heap() const noexcept {
+    UTL_ATTRIBUTE(STRING_CONST) __UTL_STRING_INLINE constexpr heap_type const& get_heap() const noexcept {
         return storage_.first().heap_;
     }
-    UTL_ATTRIBUTE(STRING_CONST) inline constexpr allocator_type const& allocator_ref() const noexcept {
+    UTL_ATTRIBUTE(STRING_CONST) __UTL_STRING_INLINE constexpr allocator_type const&
+    allocator_ref() const noexcept {
         return storage_.second();
     }
 
@@ -1525,8 +1565,9 @@ private:
 };
 
 template <typename CharT, size_t N, typename Traits, typename Alloc, typename U>
-__UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 typename basic_short_string<CharT, N, Traits, Alloc>::size_type
-erase(basic_short_string<CharT, N, Traits, Alloc>& c, U const& value) {
+__UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14
+    typename basic_short_string<CharT, N, Traits, Alloc>::size_type
+    erase(basic_short_string<CharT, N, Traits, Alloc>& c, U const& value) {
     auto const it = __UTL remove(c.begin(), c.end(), value);
     auto const result = c.end() - it;
     c.erase(it, c.end());
@@ -1534,8 +1575,9 @@ erase(basic_short_string<CharT, N, Traits, Alloc>& c, U const& value) {
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc, typename Pred>
-__UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 typename basic_short_string<CharT, N, Traits, Alloc>::size_type
-erase_if(basic_short_string<CharT, N, Traits, Alloc>& c, Pred const& pred) {
+__UTL_HIDE_FROM_ABI __UTL_STRING_INLINE UTL_CONSTEXPR_CXX14
+    typename basic_short_string<CharT, N, Traits, Alloc>::size_type
+    erase_if(basic_short_string<CharT, N, Traits, Alloc>& c, Pred const& pred) {
     auto const it = __UTL remove_if(c.begin(), c.end(), pred);
     auto const result = c.end() - it;
     c.erase(it, c.end());
@@ -1543,21 +1585,21 @@ erase_if(basic_short_string<CharT, N, Traits, Alloc>& c, Pred const& pred) {
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(STRING_PURE) inline constexpr bool operator==(
+UTL_ATTRIBUTES(STRING_PURE) __UTL_STRING_INLINE constexpr bool operator==(
     basic_short_string<CharT, N, Traits, Alloc> const& lhs,
     basic_short_string<CharT, N, Traits, Alloc> const& rhs) noexcept {
     return lhs.size() == rhs.size() && lhs.compare(rhs) == 0;
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(STRING_PURE) inline constexpr bool operator==(
+UTL_ATTRIBUTES(STRING_PURE) __UTL_STRING_INLINE constexpr bool operator==(
     basic_short_string<CharT, N, Traits, Alloc> const& lhs, CharT const* rhs) noexcept {
     return lhs.compare(rhs) == 0;
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
-    basic_short_string<CharT, N, Traits, Alloc> const& l,
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) __UTL_STRING_INLINE constexpr basic_short_string<CharT, N, Traits, Alloc>
+operator+(basic_short_string<CharT, N, Traits, Alloc> const& l,
     basic_short_string<CharT, N, Traits, Alloc> const& r) UTL_THROWS {
     basic_short_string<CharT, N, Traits, Alloc> output;
     output.reserve(l.size() + r.size());
@@ -1567,14 +1609,14 @@ UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<Cha
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
-    basic_short_string<CharT, N, Traits, Alloc> const& l, CharT const* r) UTL_THROWS {
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) __UTL_STRING_INLINE constexpr basic_short_string<CharT, N, Traits, Alloc>
+operator+(basic_short_string<CharT, N, Traits, Alloc> const& l, CharT const* r) UTL_THROWS {
     return l + basic_string_view<CharT, Traits>(r);
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
-    basic_short_string<CharT, N, Traits, Alloc> const& l, CharT r) UTL_THROWS {
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) __UTL_STRING_INLINE constexpr basic_short_string<CharT, N, Traits, Alloc>
+operator+(basic_short_string<CharT, N, Traits, Alloc> const& l, CharT r) UTL_THROWS {
     basic_short_string<CharT, N, Traits, Alloc> output;
     output.reserve(l.size() + 1);
     output += l;
@@ -1583,8 +1625,8 @@ UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<Cha
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
-    basic_short_string<CharT, N, Traits, Alloc> const& l,
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) __UTL_STRING_INLINE constexpr basic_short_string<CharT, N, Traits, Alloc>
+operator+(basic_short_string<CharT, N, Traits, Alloc> const& l,
     type_identity_t<basic_string_view<CharT, Traits>> r) UTL_THROWS {
     basic_short_string<CharT, N, Traits, Alloc> output;
     output.reserve(l.size() + r.size());
@@ -1594,14 +1636,14 @@ UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<Cha
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
-    CharT const* l, basic_short_string<CharT, N, Traits, Alloc> const& r) UTL_THROWS {
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) __UTL_STRING_INLINE constexpr basic_short_string<CharT, N, Traits, Alloc>
+operator+(CharT const* l, basic_short_string<CharT, N, Traits, Alloc> const& r) UTL_THROWS {
     return basic_string_view<CharT, Traits>(l) + r;
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
-    CharT l, basic_short_string<CharT, N, Traits, Alloc> const& r) UTL_THROWS {
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) __UTL_STRING_INLINE constexpr basic_short_string<CharT, N, Traits, Alloc>
+operator+(CharT l, basic_short_string<CharT, N, Traits, Alloc> const& r) UTL_THROWS {
     basic_short_string<CharT, N, Traits, Alloc> output;
     output.reserve(l.size() + 1);
     output += l;
@@ -1610,8 +1652,8 @@ UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<Cha
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
-    type_identity_t<basic_string_view<CharT, Traits>> l,
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) __UTL_STRING_INLINE constexpr basic_short_string<CharT, N, Traits, Alloc>
+operator+(type_identity_t<basic_string_view<CharT, Traits>> l,
     basic_short_string<CharT, N, Traits, Alloc> const& r) UTL_THROWS {
     basic_short_string<CharT, N, Traits, Alloc> output;
     output.reserve(l.size() + r.size());
@@ -1620,60 +1662,60 @@ UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<Cha
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
-    basic_short_string<CharT, N, Traits, Alloc>&& l,
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) __UTL_STRING_INLINE constexpr basic_short_string<CharT, N, Traits, Alloc>
+operator+(basic_short_string<CharT, N, Traits, Alloc>&& l,
     basic_short_string<CharT, N, Traits, Alloc>&& r) UTL_THROWS {
     return __UTL move(l.append(r));
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
-    basic_short_string<CharT, N, Traits, Alloc>&& l,
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) __UTL_STRING_INLINE constexpr basic_short_string<CharT, N, Traits, Alloc>
+operator+(basic_short_string<CharT, N, Traits, Alloc>&& l,
     basic_short_string<CharT, N, Traits, Alloc> const& r) UTL_THROWS {
     return __UTL move(l.append(r));
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
-    basic_short_string<CharT, N, Traits, Alloc>&& l, CharT const* r) UTL_THROWS {
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) __UTL_STRING_INLINE constexpr basic_short_string<CharT, N, Traits, Alloc>
+operator+(basic_short_string<CharT, N, Traits, Alloc>&& l, CharT const* r) UTL_THROWS {
     return __UTL move(l.append(r));
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
-    basic_short_string<CharT, N, Traits, Alloc>&& l, CharT r) UTL_THROWS {
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) __UTL_STRING_INLINE constexpr basic_short_string<CharT, N, Traits, Alloc>
+operator+(basic_short_string<CharT, N, Traits, Alloc>&& l, CharT r) UTL_THROWS {
     return __UTL move(l.append(r));
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
-    basic_short_string<CharT, N, Traits, Alloc>&& l,
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) __UTL_STRING_INLINE constexpr basic_short_string<CharT, N, Traits, Alloc>
+operator+(basic_short_string<CharT, N, Traits, Alloc>&& l,
     type_identity_t<basic_string_view<CharT, Traits>> r) UTL_THROWS {
     return __UTL move(l.append(r));
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
-    basic_short_string<CharT, N, Traits, Alloc> const& l,
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) __UTL_STRING_INLINE constexpr basic_short_string<CharT, N, Traits, Alloc>
+operator+(basic_short_string<CharT, N, Traits, Alloc> const& l,
     basic_short_string<CharT, N, Traits, Alloc>&& r) UTL_THROWS {
     return __UTL move(r.insert(0, l));
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
-    CharT const* l, basic_short_string<CharT, N, Traits, Alloc>&& r) UTL_THROWS {
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) __UTL_STRING_INLINE constexpr basic_short_string<CharT, N, Traits, Alloc>
+operator+(CharT const* l, basic_short_string<CharT, N, Traits, Alloc>&& r) UTL_THROWS {
     return __UTL move(r.insert(0, l));
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
-    CharT l, basic_short_string<CharT, N, Traits, Alloc>&& r) UTL_THROWS {
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) __UTL_STRING_INLINE constexpr basic_short_string<CharT, N, Traits, Alloc>
+operator+(CharT l, basic_short_string<CharT, N, Traits, Alloc>&& r) UTL_THROWS {
     return __UTL move(r.insert(0, l));
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
-    type_identity_t<basic_string_view<CharT, Traits>> l,
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) __UTL_STRING_INLINE constexpr basic_short_string<CharT, N, Traits, Alloc>
+operator+(type_identity_t<basic_string_view<CharT, Traits>> l,
     basic_short_string<CharT, N, Traits, Alloc>&& r) UTL_THROWS {
     return __UTL move(r.insert(0, l));
 }
@@ -1687,7 +1729,7 @@ UTL_NAMESPACE_END
 UTL_NAMESPACE_BEGIN
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) inline constexpr typename Traits::comparison_category operator<=>(
+UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr typename Traits::comparison_category operator<=>(
     basic_short_string<CharT, N, Traits, Alloc> const& lhs,
     basic_short_string<CharT, N, Traits, Alloc> const& rhs) noexcept {
     using result_type = typename Traits::comparison_category;
@@ -1695,7 +1737,7 @@ UTL_ATTRIBUTE(STRING_PURE) inline constexpr typename Traits::comparison_category
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) inline constexpr typename Traits::comparison_category operator<=>(
+UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr typename Traits::comparison_category operator<=>(
     basic_short_string<CharT, N, Traits, Alloc> const& lhs, CharT const* rhs) noexcept {
     using result_type = typename Traits::comparison_category;
     return static_cast<result_type>(lhs.compare(rhs) <=> 0);
@@ -1708,96 +1750,96 @@ UTL_NAMESPACE_END
 UTL_NAMESPACE_BEGIN
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator<(
+UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool operator<(
     basic_short_string<CharT, N, Traits, Alloc> const& lhs,
     basic_short_string<CharT, N, Traits, Alloc> const& rhs) noexcept {
     return lhs.compare(rhs) < 0;
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator<(
+UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool operator<(
     basic_short_string<CharT, N, Traits, Alloc> const& lhs, CharT const* rhs) noexcept {
     return lhs.compare(rhs) < 0;
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator<(
+UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool operator<(
     CharT const* lhs, basic_short_string<CharT, N, Traits, Alloc> const& rhs) noexcept {
     return rhs.compare(lhs) > 0;
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator>(
+UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool operator>(
     basic_short_string<CharT, N, Traits, Alloc> const& lhs,
     basic_short_string<CharT, N, Traits, Alloc> const& rhs) noexcept {
     return rhs < lhs;
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator>(
+UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool operator>(
     basic_short_string<CharT, N, Traits, Alloc> const& lhs, CharT const* rhs) noexcept {
     return rhs < lhs;
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator>(
+UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool operator>(
     CharT const* lhs, basic_short_string<CharT, N, Traits, Alloc> const& rhs) noexcept {
     return rhs < lhs;
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator>=(
+UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool operator>=(
     basic_short_string<CharT, N, Traits, Alloc> const& lhs,
     basic_short_string<CharT, N, Traits, Alloc> const& rhs) noexcept {
     return !(lhs < rhs);
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator>=(
+UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool operator>=(
     basic_short_string<CharT, N, Traits, Alloc> const& lhs, CharT const* rhs) noexcept {
     return !(lhs < rhs);
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator>=(
+UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool operator>=(
     CharT const* lhs, basic_short_string<CharT, N, Traits, Alloc> const& rhs) noexcept {
     return !(lhs < rhs);
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator<=(
+UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool operator<=(
     basic_short_string<CharT, N, Traits, Alloc> const& lhs,
     basic_short_string<CharT, N, Traits, Alloc> const& rhs) noexcept {
     return !(rhs < lhs);
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator<=(
+UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool operator<=(
     basic_short_string<CharT, N, Traits, Alloc> const& lhs, CharT const* rhs) noexcept {
     return !(rhs < lhs);
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator<=(
+UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool operator<=(
     CharT const* lhs, basic_short_string<CharT, N, Traits, Alloc> const& rhs) noexcept {
     return !(rhs < lhs);
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator!=(
+UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool operator!=(
     basic_short_string<CharT, N, Traits, Alloc> const& lhs,
     basic_short_string<CharT, N, Traits, Alloc> const& rhs) noexcept {
     return !(lhs == rhs);
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator!=(
+UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool operator!=(
     basic_short_string<CharT, N, Traits, Alloc> const& lhs, CharT const* rhs) noexcept {
     return !(lhs == rhs);
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator!=(
+UTL_ATTRIBUTE(STRING_PURE) __UTL_STRING_INLINE constexpr bool operator!=(
     CharT const* lhs, basic_short_string<CharT, N, Traits, Alloc> const& rhs) noexcept {
     return !(lhs == rhs);
 }

--- a/src/utl/public/utl/string/utl_basic_short_string.h
+++ b/src/utl/public/utl/string/utl_basic_short_string.h
@@ -89,21 +89,22 @@ private:
          */
         size_type capacity_;
 
-        __UTL_HIDE_FROM_ABI constexpr heap_type() noexcept = default;
-        __UTL_HIDE_FROM_ABI constexpr heap_type(heap_type const&) noexcept = default;
-        __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 heap_type& operator=(heap_type const&) noexcept = default;
+        __UTL_HIDE_FROM_ABI inline constexpr heap_type() noexcept = default;
+        __UTL_HIDE_FROM_ABI inline constexpr heap_type(heap_type const&) noexcept = default;
+        __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 heap_type& operator=(
+            heap_type const&) noexcept = default;
 
-        __UTL_HIDE_FROM_ABI constexpr heap_type(pointer data, size_type capacity) noexcept
+        __UTL_HIDE_FROM_ABI inline constexpr heap_type(pointer data, size_type capacity) noexcept
             : data_(data)
             , capacity_(capacity) {}
 
-        __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 heap_type& operator=(
+        __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 heap_type& operator=(
             allocation_result<pointer, size_type>&& other) noexcept {
             data_ = __UTL move(other.ptr);
             capacity_ = other.size;
             return *this;
         }
-        __UTL_HIDE_FROM_ABI constexpr
+        __UTL_HIDE_FROM_ABI inline constexpr
         operator allocation_result<pointer, size_type>() const noexcept {
             return {data_, capacity_};
         }
@@ -127,19 +128,22 @@ public:
         using typename base_type::reference;
         using typename base_type::value_type;
 
-        __UTL_HIDE_FROM_ABI constexpr iterator() noexcept = default;
-        __UTL_HIDE_FROM_ABI constexpr iterator(iterator const& other) noexcept = default;
-        __UTL_HIDE_FROM_ABI constexpr iterator(iterator&& other) noexcept = default;
-        __UTL_HIDE_FROM_ABI constexpr iterator& operator=(iterator const& other) noexcept = default;
-        __UTL_HIDE_FROM_ABI constexpr iterator& operator=(iterator&& other) noexcept = default;
+        __UTL_HIDE_FROM_ABI inline constexpr iterator() noexcept = default;
+        __UTL_HIDE_FROM_ABI inline constexpr iterator(iterator const& other) noexcept = default;
+        __UTL_HIDE_FROM_ABI inline constexpr iterator(iterator&& other) noexcept = default;
+        __UTL_HIDE_FROM_ABI inline constexpr iterator& operator=(
+            iterator const& other) noexcept = default;
+        __UTL_HIDE_FROM_ABI inline constexpr iterator& operator=(
+            iterator&& other) noexcept = default;
         using base_type::operator*;
         using base_type::operator->;
 
     private:
         friend basic_short_string;
-        __UTL_HIDE_FROM_ABI constexpr iterator(char_pointer data) noexcept : base_type(data) {}
+        __UTL_HIDE_FROM_ABI inline constexpr iterator(char_pointer data) noexcept
+            : base_type(data) {}
         template <typename It>
-        __UTL_HIDE_FROM_ABI constexpr iterator(It other) noexcept
+        __UTL_HIDE_FROM_ABI inline constexpr iterator(It other) noexcept
             : iterator(const_cast<pointer>(__UTL to_address(other))) {}
     };
 
@@ -154,22 +158,23 @@ public:
         using typename base_type::reference;
         using typename base_type::value_type;
 
-        __UTL_HIDE_FROM_ABI constexpr const_iterator() noexcept = default;
-        __UTL_HIDE_FROM_ABI constexpr const_iterator(
+        __UTL_HIDE_FROM_ABI inline constexpr const_iterator() noexcept = default;
+        __UTL_HIDE_FROM_ABI inline constexpr const_iterator(
             const_iterator const& other) noexcept = default;
-        __UTL_HIDE_FROM_ABI constexpr const_iterator(const_iterator&& other) noexcept = default;
-        __UTL_HIDE_FROM_ABI constexpr const_iterator& operator=(
+        __UTL_HIDE_FROM_ABI inline constexpr const_iterator(
+            const_iterator&& other) noexcept = default;
+        __UTL_HIDE_FROM_ABI inline constexpr const_iterator& operator=(
             const_iterator const& other) noexcept = default;
-        __UTL_HIDE_FROM_ABI constexpr const_iterator& operator=(
+        __UTL_HIDE_FROM_ABI inline constexpr const_iterator& operator=(
             const_iterator&& other) noexcept = default;
         using base_type::operator*;
         using base_type::operator->;
 
     private:
         friend basic_short_string;
-        __UTL_HIDE_FROM_ABI constexpr const_iterator(char_pointer data) noexcept
+        __UTL_HIDE_FROM_ABI inline constexpr const_iterator(char_pointer data) noexcept
             : base_type(data) {}
-        __UTL_HIDE_FROM_ABI constexpr const_iterator(iterator other) noexcept
+        __UTL_HIDE_FROM_ABI inline constexpr const_iterator(iterator other) noexcept
             : base_type(__UTL to_address(other)) {}
     };
 
@@ -177,15 +182,16 @@ public:
     using const_reverse_iterator = __UTL reverse_iterator<const_iterator>;
 
     basic_short_string(decltype(nullptr)) = delete;
-    __UTL_HIDE_FROM_ABI constexpr basic_short_string() noexcept(noexcept(allocator_type()))
+    __UTL_HIDE_FROM_ABI inline constexpr basic_short_string() noexcept(noexcept(allocator_type()))
         : basic_short_string(allocator_type()) {}
 
-    __UTL_HIDE_FROM_ABI explicit constexpr basic_short_string(allocator_type const& a) noexcept
+    __UTL_HIDE_FROM_ABI explicit inline constexpr basic_short_string(
+        allocator_type const& a) noexcept
         : storage_(details::compressed_pair::default_initialize, a)
         , size_()
         , is_heap_() {}
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string(
         const_char_pointer str, size_type len, allocator_type const& a = allocator_type())
         UTL_THROWS
         : basic_short_string(a) {
@@ -194,21 +200,22 @@ public:
 
     template <UTL_CONCEPT_CXX20(__UTL legacy_input_iterator) It UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_legacy_input_iterator(It))>
-    __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string(
         It first, It last, allocator_type const& a = allocator_type()) UTL_THROWS
         : basic_short_string(a) {
         assign(first, last);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string(
         const_char_pointer str, allocator_type const& a = allocator_type()) UTL_THROWS
         : basic_short_string(str, traits_type::length(str), a) {}
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string(::std::initializer_list<value_type> ilist,
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string(
+        ::std::initializer_list<value_type> ilist,
         allocator_type const& a = allocator_type()) UTL_THROWS
         : basic_short_string(ilist.begin(), ilist.size(), a) {}
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string(
         size_type count, value_type ch, allocator_type const& a = allocator_type()) UTL_THROWS
         : basic_short_string(a) {
         resize(count, ch);
@@ -216,7 +223,7 @@ public:
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_ABI_PRIVATE explicit UTL_CONSTEXPR_CXX14 basic_short_string(View const& view,
+    __UTL_HIDE_FROM_ABI explicit inline UTL_CONSTEXPR_CXX14 basic_short_string(View const& view,
         allocator_type const& a = allocator_type()) noexcept(!utl::with_exceptions &&
         is_nothrow_convertible<View, view_type>::value)
         : basic_short_string(a) {
@@ -225,14 +232,15 @@ public:
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string(View const& view, size_type pos, size_type n,
-        allocator_type const& a = allocator_type()) noexcept(!utl::with_exceptions &&
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string(View const& view, size_type pos,
+        size_type n, allocator_type const& a = allocator_type()) noexcept(!utl::with_exceptions &&
         is_nothrow_convertible<View, view_type>::value)
         : basic_short_string(a) {
         assign(view, pos, n);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string(basic_short_string const& other) UTL_THROWS
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string(
+        basic_short_string const& other) UTL_THROWS
         : storage_(other.storage_.first(),
               alloc_traits::select_on_container_copy_construction(other.allocator_ref()))
         , size_(other.size_)
@@ -242,8 +250,8 @@ public:
         }
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string(basic_short_string const& other, size_type pos,
-        size_type count, allocator_type const& alloc = allocator_type()) UTL_THROWS
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string(basic_short_string const& other,
+        size_type pos, size_type count, allocator_type const& alloc = allocator_type()) UTL_THROWS
         : storage_(other.storage_.first(), alloc)
         , size_(other.size_)
         , is_heap_(other.is_heap_) {
@@ -259,11 +267,11 @@ public:
         inline_substring(pos, count);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string(basic_short_string const& other, size_type pos,
-        allocator_type const& alloc = allocator_type()) UTL_THROWS
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string(basic_short_string const& other,
+        size_type pos, allocator_type const& alloc = allocator_type()) UTL_THROWS
         : basic_short_string(other, pos, other.size(), alloc) {}
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& operator=(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& operator=(
         basic_short_string const& other) UTL_THROWS {
         if (this != __UTL addressof(other)) {
             destroy();
@@ -280,15 +288,15 @@ public:
         return *this;
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string(basic_short_string&& other) noexcept
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string(basic_short_string&& other) noexcept
         : storage_(other.storage_)
         , size_(other.size_)
         , is_heap_(other.is_heap_) {
         __UTL move(other).reset_to_short();
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string(basic_short_string&& other, size_type pos,
-        size_type count, allocator_type const& alloc = allocator_type()) UTL_THROWS
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string(basic_short_string&& other,
+        size_type pos, size_type count, allocator_type const& alloc = allocator_type()) UTL_THROWS
         : storage_(other.storage_.first(), alloc)
         , size_(other.size_)
         , is_heap_(other.is_heap_) {
@@ -301,21 +309,21 @@ public:
         on_move_construct_with_alloc(other, pos, count, alloc_traits::is_always_equal);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string(basic_short_string&& other, size_type pos,
-        allocator_type const& alloc = allocator_type()) UTL_THROWS
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string(basic_short_string&& other,
+        size_type pos, allocator_type const& alloc = allocator_type()) UTL_THROWS
         : basic_short_string(__UTL move(other), pos, other.size(), alloc) {}
 
     // TODO: container-compatible-ranges ctor
 
-    __UTL_HIDE_FROM_ABI constexpr operator view_type() const noexcept UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI inline constexpr operator view_type() const noexcept UTL_LIFETIMEBOUND {
         return view_type{data(), size()};
     }
-    __UTL_HIDE_FROM_ABI explicit constexpr
+    __UTL_HIDE_FROM_ABI explicit inline constexpr
     operator basic_zstring_view<value_type, traits_type>() const noexcept UTL_LIFETIMEBOUND {
         return basic_zstring_view<value_type, traits_type>{data(), size()};
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string&
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string&
     operator=(basic_short_string&& other) noexcept(
         (alloc_traits::propagate_on_container_move_assignment::value &&
             alloc_traits::is_always_equal::value) ||
@@ -328,40 +336,39 @@ public:
         return *this;
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX20 ~basic_short_string() noexcept { destroy(); }
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX20 ~basic_short_string() noexcept { destroy(); }
 
-    UTL_ATTRIBUTE(STRING_PURE)
-    UTL_CONSTEXPR_CXX14 char_pointer data() noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 char_pointer data() noexcept UTL_LIFETIMEBOUND {
         return !is_heap_ ? get_short().data_ : __UTL to_address(get_heap().data_);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr const_char_pointer data() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_char_pointer data() const noexcept UTL_LIFETIMEBOUND {
         return !is_heap_ ? get_short().data_ : __UTL to_address(get_heap().data_);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr const_pointer c_str() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_pointer c_str() const noexcept UTL_LIFETIMEBOUND {
         return data();
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr bool empty() const noexcept { return !size_; }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type size() const noexcept { return size_; }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type length() const noexcept { return size_; }
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool empty() const noexcept { return !size_; }
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type size() const noexcept { return size_; }
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type length() const noexcept { return size_; }
 
-    UTL_ATTRIBUTE(STRING_CONST) constexpr size_type max_size() const noexcept {
+    UTL_ATTRIBUTE(STRING_CONST) inline constexpr size_type max_size() const noexcept {
         return numeric::maximum<size_type>::value >> 1;
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type capacity() const noexcept {
-        constexpr size_type short_capacity = sizeof(short_type::data_) / sizeof(value_type);
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type capacity() const noexcept {
+        size_type const short_capacity = sizeof(short_type::data_) / sizeof(value_type);
         size_type const buffer_capacity = !is_heap_ ? short_capacity : get_heap().capacity_;
         return buffer_capacity - 1;
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr allocator_type get_allocator() const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr allocator_type get_allocator() const noexcept {
         return allocator_ref();
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 void reserve(size_type new_capacity) UTL_THROWS {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void reserve(size_type new_capacity) UTL_THROWS {
         if (new_capacity <= this->capacity()) {
             return;
         }
@@ -374,11 +381,11 @@ public:
         reserve_impl(new_capacity);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 void resize(size_type new_size) UTL_THROWS {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void resize(size_type new_size) UTL_THROWS {
         resize(new_size, value_type());
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 void resize(size_type new_size, value_type ch)
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void resize(size_type new_size, value_type ch)
         UTL_THROWS {
         reserve(new_size);
         traits_type::assign(data() + size(), __UTL numeric::max(new_size, size()) - size(), ch);
@@ -391,7 +398,7 @@ public:
     UTL_CONSTRAINT_CXX20(requires(Op op, char_pointer p, size_type s) {
         { op(p, s) } -> integral;
     })
-    __UTL_ABI_PRIVATE UTL_CONSTEXPR_WITH_TRY void resize_and_overwrite(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_WITH_TRY void resize_and_overwrite(
         size_type new_size, Op operation) UTL_THROWS {
         reserve(new_size);
         UTL_TRY {
@@ -404,82 +411,75 @@ public:
         }
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 void shrink_to_fit() UTL_THROWS {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void shrink_to_fit() UTL_THROWS {
         if (is_heap_ && size() < capacity()) {
             get_heap() = alloc_traits::reallocate(allocator_ref(), get_heap(), size() + 1);
         }
     }
 
-    UTL_ATTRIBUTES(REINITIALIZES, _HIDE_FROM_ABI)
-    UTL_CONSTEXPR_CXX14 void clear() noexcept {
+    UTL_ATTRIBUTES(REINITIALIZES, _HIDE_FROM_ABI) inline UTL_CONSTEXPR_CXX14 void clear() noexcept {
         *data() = 0;
         size_ = 0;
     }
 
-    UTL_ATTRIBUTE(STRING_PURE)
-    UTL_CONSTEXPR_CXX14 iterator begin() noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 iterator begin() noexcept UTL_LIFETIMEBOUND {
         return iterator(data());
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr const_iterator cbegin() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_iterator cbegin() const noexcept UTL_LIFETIMEBOUND {
         return const_iterator(data());
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr const_iterator begin() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_iterator begin() const noexcept UTL_LIFETIMEBOUND {
         return const_iterator(data());
     }
-    UTL_ATTRIBUTE(STRING_PURE)
-    UTL_CONSTEXPR_CXX14 iterator end() noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 iterator end() noexcept UTL_LIFETIMEBOUND {
         return iterator(data() + size());
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr const_iterator cend() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_iterator cend() const noexcept UTL_LIFETIMEBOUND {
         return const_iterator(data() + size());
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr const_iterator end() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_iterator end() const noexcept UTL_LIFETIMEBOUND {
         return const_iterator(data() + size());
     }
-    UTL_ATTRIBUTE(STRING_PURE)
-    UTL_CONSTEXPR_CXX14 iterator rbegin() noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 iterator rbegin() noexcept UTL_LIFETIMEBOUND {
         return reverse_iterator(end());
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr const_iterator crbegin() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_iterator crbegin() const noexcept UTL_LIFETIMEBOUND {
         return const_reverse_iterator(end());
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr const_iterator rbegin() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_iterator rbegin() const noexcept UTL_LIFETIMEBOUND {
         return const_reverse_iterator(end());
     }
-    UTL_ATTRIBUTE(STRING_PURE)
-    UTL_CONSTEXPR_CXX14 iterator rend() noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 iterator rend() noexcept UTL_LIFETIMEBOUND {
         return reverse_iterator(begin());
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr const_iterator crend() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_iterator crend() const noexcept UTL_LIFETIMEBOUND {
         return const_reverse_iterator(begin());
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr const_iterator rend() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_iterator rend() const noexcept UTL_LIFETIMEBOUND {
         return const_reverse_iterator(begin());
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr const_reference front() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_reference front() const noexcept UTL_LIFETIMEBOUND {
         return *data();
     }
-    UTL_ATTRIBUTE(STRING_PURE)
-    UTL_CONSTEXPR_CXX14 reference front() noexcept UTL_LIFETIMEBOUND { return *data(); }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr const_reference back() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 reference front() noexcept UTL_LIFETIMEBOUND {
+        return *data();
+    }
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_reference back() const noexcept UTL_LIFETIMEBOUND {
         return data()[size() - 1];
     }
-    UTL_ATTRIBUTE(STRING_PURE)
-    UTL_CONSTEXPR_CXX14 reference back() noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 reference back() noexcept UTL_LIFETIMEBOUND {
         return data()[size() - 1];
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr const_reference operator[](size_type idx) const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_reference operator[](size_type idx) const noexcept UTL_LIFETIMEBOUND {
         return data()[idx];
     }
-    UTL_ATTRIBUTE(STRING_PURE)
-    UTL_CONSTEXPR_CXX14 reference operator[](size_type idx) noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 reference operator[](size_type idx) noexcept UTL_LIFETIMEBOUND {
         return data()[idx];
     }
-    UTL_ATTRIBUTE(STRING_PURE)
-    UTL_CONSTEXPR_CXX14 reference at(size_type idx) UTL_THROWS UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 reference at(size_type idx) UTL_THROWS UTL_LIFETIMEBOUND {
         return const_cast<reference>(as_const(*this).data()[idx]);
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr const_reference at(size_type idx) const UTL_THROWS UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_reference at(size_type idx) const UTL_THROWS UTL_LIFETIMEBOUND {
         UTL_THROW_IF(idx >= size(),
             out_of_range(UTL_MESSAGE_FORMAT("[UTL] basic_short_string::at operation failed, "
                                             "Reason=[index out of range], idx=[%zu], size=[%zu]"),
@@ -487,17 +487,19 @@ public:
         return data()[idx];
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 void push_back(value_type ch) UTL_THROWS {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void push_back(value_type ch) UTL_THROWS {
         reserve(size() + 1);
         data()[size_++] = ch;
         data()[size_] = value_type();
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 void pop_back() noexcept { data()[--size_] = value_type(); }
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void pop_back() noexcept {
+        data()[--size_] = value_type();
+    }
 
     basic_short_string& assign(decltype(nullptr)) = delete;
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_WITH_TRY basic_short_string& assign(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_WITH_TRY basic_short_string& assign(
         size_type count, value_type ch) UTL_THROWS UTL_LIFETIMEBOUND {
         UTL_ATTRIBUTE(MAYBE_UNUSED) size_type const old_size = exchange(size_, 0);
         UTL_TRY {
@@ -510,12 +512,12 @@ public:
         }
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& assign(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& assign(
         basic_short_string const& other) UTL_THROWS UTL_LIFETIMEBOUND {
         return *this = other;
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& assign(basic_short_string const& other,
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& assign(basic_short_string const& other,
         size_type pos, size_type count = npos) UTL_THROWS UTL_LIFETIMEBOUND {
         if (this == addressof(other)) {
             return *this;
@@ -533,12 +535,12 @@ public:
         return *this;
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& assign(basic_short_string&& other)
-        UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& assign(
+        basic_short_string&& other) UTL_THROWS UTL_LIFETIMEBOUND {
         return *this = move(other);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& assign(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& assign(
         const_char_pointer str, size_type count) UTL_THROWS UTL_LIFETIMEBOUND {
         UTL_ASSERT(str != nullptr);
         reserve(count);
@@ -547,15 +549,15 @@ public:
         return *this;
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& assign(const_char_pointer str)
-        UTL_THROWS {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& assign(
+        const_char_pointer str) UTL_THROWS {
         UTL_ASSERT(str != nullptr);
         assign(str, traits_type::length(str));
     }
 
     template <UTL_CONCEPT_CXX20(__UTL legacy_input_iterator) It UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_legacy_input_iterator(It) && !UTL_TRAIT_is_legacy_forward_iterator(It))>
-    __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& assign(It begin, It end)
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& assign(It begin, It end)
         UTL_THROWS UTL_LIFETIMEBOUND {
         size_ = 0;
         while (begin != end) {
@@ -566,7 +568,7 @@ public:
 
     template <UTL_CONCEPT_CXX20(__UTL legacy_forward_iterator) It UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_legacy_forward_iterator(It))>
-    __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX17 basic_short_string& assign(It begin, It end)
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX17 basic_short_string& assign(It begin, It end)
         UTL_THROWS UTL_LIFETIMEBOUND {
         auto const diff = __UTL distance(begin, end);
         if (diff < 0) UTL_ATTRIBUTE(UNLIKELY) {
@@ -583,14 +585,14 @@ public:
         size_ = diff;
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& assign(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& assign(
         ::std::initializer_list<value_type> list) UTL_THROWS UTL_LIFETIMEBOUND {
         assign(list.begin(), list.end());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& assign(View const& view)
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& assign(View const& view)
         UTL_THROWS UTL_LIFETIMEBOUND {
         view_type const v(view);
         return assign(v.data(), v.size());
@@ -598,8 +600,8 @@ public:
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& assign(View const& view, size_type subidx,
-        size_type subcount = npos) UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& assign(View const& view,
+        size_type subidx, size_type subcount = npos) UTL_THROWS UTL_LIFETIMEBOUND {
         view_type const v(view);
         UTL_THROW_IF(subidx > v.size(),
             out_of_range(
@@ -610,7 +612,7 @@ public:
         return assign(v.substr(subidx, subcount));
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& insert(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& insert(
         size_type pos, size_type count, value_type ch) UTL_THROWS UTL_LIFETIMEBOUND {
         UTL_THROW_IF(pos > size(),
             out_of_range(UTL_MESSAGE_FORMAT("[UTL] `basic_short_string::insert` operation failed, "
@@ -625,7 +627,7 @@ public:
         return begin() + pos;
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& insert(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& insert(
         size_type pos, const_char_pointer str, size_type length) UTL_THROWS UTL_LIFETIMEBOUND {
         UTL_THROW_IF(pos > size(),
             out_of_range(UTL_MESSAGE_FORMAT("[UTL] `basic_short_string::insert` operation failed, "
@@ -640,17 +642,17 @@ public:
         return *this;
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& insert(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& insert(
         size_type pos, const_char_pointer str) UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(pos, str, traits_type::length(str));
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& insert(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& insert(
         size_type pos, basic_short_string const& str) UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(pos, str.data(), str.size());
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& insert(size_type pos,
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& insert(size_type pos,
         basic_short_string const& str, size_type idx, size_type count = npos)
         UTL_THROWS UTL_LIFETIMEBOUND {
         UTL_THROW_IF(idx > str.size(),
@@ -663,20 +665,20 @@ public:
         return insert(pos, str.data() + idx, copy_size);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 iterator insert(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 iterator insert(
         const_iterator pos, size_type count, value_type ch) UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(pos - cbegin(), count, ch);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 iterator insert(const_iterator pos, value_type ch)
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 iterator insert(const_iterator pos, value_type ch)
         UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(pos, 1, ch);
     }
 
     template <UTL_CONCEPT_CXX20(__UTL legacy_input_iterator) It UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_legacy_input_iterator(It) && !UTL_TRAIT_is_legacy_forward_iterator(It))>
-    __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 iterator insert(const_iterator pos, It first, It last)
-        UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 iterator insert(
+        const_iterator pos, It first, It last) UTL_THROWS UTL_LIFETIMEBOUND {
         auto const idx = pos - begin();
         while (first != last) {
             insert(pos, *first);
@@ -688,8 +690,8 @@ public:
 
     template <UTL_CONCEPT_CXX20(__UTL legacy_forward_iterator) It UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_legacy_forward_iterator(It))>
-    __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 iterator insert(const_iterator pos, It first, It last)
-        UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 iterator insert(
+        const_iterator pos, It first, It last) UTL_THROWS UTL_LIFETIMEBOUND {
         auto const length = __UTL distance(first, last);
         if (length < 0) UTL_ATTRIBUTE(UNLIKELY) {
             return *this;
@@ -710,22 +712,22 @@ public:
         return iterator(data() + idx);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 iterator insert(const_iterator pos,
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 iterator insert(const_iterator pos,
         ::std::initializer_list<value_type> list) UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(pos, list.begin(), list.size());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& insert(size_type pos, View const& view)
-        UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& insert(
+        size_type pos, View const& view) UTL_THROWS UTL_LIFETIMEBOUND {
         view_type const v(view);
         return insert(pos, v.data(), v.size());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& insert(size_type pos, View const& view,
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& insert(size_type pos, View const& view,
         size_type subidx, size_type subcount = npos) UTL_THROWS UTL_LIFETIMEBOUND {
         view_type const v(view);
         UTL_THROW_IF(subidx > v.size(),
@@ -737,26 +739,27 @@ public:
         return insert(pos, v.substr(subidx, subcount));
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& erase(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& erase(
         size_type idx = 0, size_type count = npos) UTL_THROWS UTL_LIFETIMEBOUND {
         auto const length = __UTL numeric::min(size() - idx, count);
         auto const first = begin() + idx;
         return erase(first, first + length), *this;
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 iterator erase(iterator pos) noexcept UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 iterator erase(iterator pos) noexcept UTL_LIFETIMEBOUND {
         return erase(pos, pos + 1);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 iterator erase(const_iterator pos) noexcept UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 iterator erase(const_iterator pos) noexcept UTL_LIFETIMEBOUND {
         return erase(pos, pos + 1);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 iterator erase(const_iterator first, const_iterator last) noexcept UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 iterator erase(
+        const_iterator first, const_iterator last) noexcept UTL_LIFETIMEBOUND {
         return erase(iterator(first), iterator(last));
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 iterator erase(iterator first, iterator last) noexcept UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 iterator erase(iterator first, iterator last) noexcept UTL_LIFETIMEBOUND {
         auto const length = last - first;
         auto const src = last.operator->();
         auto const dst = first.operator->();
@@ -766,54 +769,54 @@ public:
         return iterator(dst + length);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& append(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& append(
         size_type count, value_type ch) UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(size(), count, ch);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& append(basic_short_string const& str)
-        UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& append(
+        basic_short_string const& str) UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(size(), str);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& append(basic_short_string const& str,
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& append(basic_short_string const& str,
         size_type idx, size_type count = npos) UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(size(), str, idx, count);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& append(const_char_pointer str)
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& append(const_char_pointer str)
         UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(size(), str);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& append(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& append(
         const_char_pointer str, size_type count) UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(size(), str, count);
     }
 
     template <UTL_CONCEPT_CXX20(__UTL legacy_input_iterator) It UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_legacy_input_iterator(It))>
-    __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& append(It first, It last)
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& append(It first, It last)
         UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(end(), first, last), *this;
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& append(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& append(
         ::std::initializer_list<value_type> list) UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(size(), list.begin(), list.size());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& append(View const& view)
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& append(View const& view)
         UTL_THROWS UTL_LIFETIMEBOUND {
         return insert(size(), view);
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& append(View const& view, size_type subidx,
-        size_type subcount = npos) UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& append(View const& view,
+        size_type subidx, size_type subcount = npos) UTL_THROWS UTL_LIFETIMEBOUND {
         view_type const v(view);
         UTL_THROW_IF(subidx > v.size(),
             out_of_range(
@@ -824,44 +827,44 @@ public:
         return insert(size(), v.substr(subidx, subcount));
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& operator+=(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& operator+=(
         basic_short_string const& str) UTL_THROWS UTL_LIFETIMEBOUND {
         return append(str);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& operator+=(value_type ch)
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& operator+=(value_type ch)
         UTL_THROWS UTL_LIFETIMEBOUND {
         return append(1, ch);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& operator+=(const_char_pointer str)
-        UTL_THROWS UTL_LIFETIMEBOUND {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& operator+=(
+        const_char_pointer str) UTL_THROWS UTL_LIFETIMEBOUND {
         return append(str);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& operator+=(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& operator+=(
         ::std::initializer_list<value_type> list) UTL_THROWS UTL_LIFETIMEBOUND {
         return append(list);
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& operator+=(View const& view)
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& operator+=(View const& view)
         UTL_THROWS UTL_LIFETIMEBOUND {
         return append(view);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& replace(size_type pos, size_type count,
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(size_type pos, size_type count,
         basic_short_string const& str) UTL_THROWS UTL_LIFETIMEBOUND {
         return replace(pos, count, str.data(), str.size());
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
         const_iterator last, basic_short_string const& str) UTL_THROWS UTL_LIFETIMEBOUND {
         return replace(first, last, str.data(), str.size());
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& replace(size_type pos, size_type count,
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(size_type pos, size_type count,
         basic_short_string const& str, size_type subidx, size_type subcount = npos)
         UTL_THROWS UTL_LIFETIMEBOUND {
         UTL_THROW_IF(subidx > str.size(),
@@ -874,7 +877,7 @@ public:
         return replace(pos, count, view.data(), view.size());
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& replace(size_type pos, size_type count,
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(size_type pos, size_type count,
         const_char_pointer str, size_type length) UTL_THROWS UTL_LIFETIMEBOUND {
         UTL_THROW_IF(pos > size(),
             out_of_range(UTL_MESSAGE_FORMAT("[UTL] `basic_short_string::replace` operation failed, "
@@ -884,7 +887,7 @@ public:
         return replace(first, first + count, str, length);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
         const_iterator last, const_char_pointer str, size_type length)
         UTL_THROWS UTL_LIFETIMEBOUND {
         auto const replaced_count = last - first;
@@ -902,19 +905,19 @@ public:
         return *this;
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& replace(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(
         size_type pos, size_type count, const_char_pointer str) UTL_THROWS {
         UTL_ASSERT(str != nullptr);
         return replace(pos, count, str, traits_type::length(str));
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
         const_iterator last, const_char_pointer str) UTL_THROWS UTL_LIFETIMEBOUND {
         UTL_ASSERT(str != nullptr);
         return replace(first, last, str, traits_type::length(str));
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& replace(size_type pos, size_type count,
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(size_type pos, size_type count,
         size_type char_count, value_type ch) UTL_THROWS UTL_LIFETIMEBOUND {
         UTL_THROW_IF(pos > size(),
             out_of_range(UTL_MESSAGE_FORMAT("[UTL] `basic_short_string::replace` operation failed, "
@@ -924,7 +927,7 @@ public:
         return replace(first, first + count, char_count, ch);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
         const_iterator last, size_type char_count, value_type ch) UTL_THROWS UTL_LIFETIMEBOUND {
         auto const replaced_count = last - first;
         auto const assign_ch = [p = const_cast<pointer>(first.operator->()), ch](
@@ -943,7 +946,7 @@ public:
 
     template <UTL_CONCEPT_CXX20(__UTL legacy_input_iterator) It UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_legacy_input_iterator(It))>
-    __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
         const_iterator last, It in_first, It in_last) UTL_THROWS UTL_LIFETIMEBOUND {
         while (first != last && in_first != in_last) {
             const_cast<reference>(*first) = *in_first;
@@ -956,7 +959,7 @@ public:
         return *this;
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
         const_iterator last, ::std::initializer_list<value_type> list)
         UTL_THROWS UTL_LIFETIMEBOUND {
         return replace(first, last, list.begin(), list.size());
@@ -964,7 +967,7 @@ public:
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
         const_iterator last, View const& view) UTL_THROWS UTL_LIFETIMEBOUND {
         view_type const v(view);
         return replace(first, last, v.data(), v.size());
@@ -972,7 +975,7 @@ public:
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(const_iterator first,
         const_iterator last, View const& view, size_type subidx, size_type subcount = npos)
         UTL_THROWS UTL_LIFETIMEBOUND {
         view_type const v(view);
@@ -987,7 +990,7 @@ public:
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& replace(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(
         size_type idx, size_type count, View const& view) UTL_THROWS UTL_LIFETIMEBOUND {
         auto const first = cbegin() + idx;
         return replace(first, first + count, view);
@@ -995,7 +998,7 @@ public:
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    __UTL_ABI_PRIVATE UTL_CONSTEXPR_CXX14 basic_short_string& replace(size_type idx, size_type count,
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_short_string& replace(size_type idx, size_type count,
         View const& view, size_type subidx, size_type subcount = npos)
         UTL_THROWS UTL_LIFETIMEBOUND {
         view_type const v(view);
@@ -1008,7 +1011,7 @@ public:
         return replace(idx, count, v.substr(subidx, subcount));
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 size_type copy(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 size_type copy(
         pointer dst, size_type count, size_type pos = 0) const UTL_THROWS {
         UTL_THROW_IF(pos > size(),
             out_of_range(UTL_MESSAGE_FORMAT("[UTL] `basic_short_string::replace` operation failed, "
@@ -1020,247 +1023,249 @@ public:
         return copied;
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 void swap(basic_short_string& other) noexcept(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void swap(basic_short_string& other) noexcept(
         alloc_traits::propagate_on_container_swap::value || alloc_traits::is_always_equal::value) {
         using swap_alloc_t = bool_constant<alloc_traits::propagate_on_container_swap::value ||
             !alloc_traits::is_always_equal::value>;
         swap(other, swap_alloc_t{});
     }
 
-    __UTL_HIDE_FROM_ABI friend UTL_CONSTEXPR_CXX14 void swap(
+    __UTL_HIDE_FROM_ABI friend inline UTL_CONSTEXPR_CXX14 void swap(
         basic_short_string& l, basic_short_string& r) noexcept(noexcept(l.swap(r))) {
         l.swap(r);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find(
         basic_short_string const& str, size_type pos = 0) const noexcept {
         return find(str.data(), pos, str.size());
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find(
         const_char_pointer str, size_type pos, size_type str_len) const noexcept {
         // CONSTEXPR_ASSERT(str != nullptr);
         return details::string::find<traits_type>(data(), size(), str, str_len, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find(
         const_char_pointer str, size_type pos = 0) const noexcept {
         // CONSTEXPR_ASSERT(str != nullptr);
         return find(str, pos, traits_type::length(str));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find(value_type ch, size_type pos = 0) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find(
+        value_type ch, size_type pos = 0) const noexcept {
         return details::string::find<traits_type>(data(), size(), ch, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find(view_type view, size_type pos = 0) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find(
+        view_type view, size_type pos = 0) const noexcept {
         return find(view.data(), pos, view.size());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) constexpr size_type find(View const& view, size_type pos = 0) const
-        noexcept(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
+    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) inline constexpr size_type find(View const& view,
+        size_type pos = 0) const noexcept(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
         return find(view_type(view), pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type rfind(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type rfind(
         basic_short_string const& str, size_type pos = npos) const noexcept {
         return rfind(str.data(), pos, str.size());
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type rfind(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type rfind(
         const_char_pointer str, size_type pos, size_type str_len) const noexcept {
         // CONSTEXPR_ASSERT(str != nullptr);
         return details::string::rfind<traits_type>(data(), size(), str, str_len, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type rfind(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type rfind(
         const_char_pointer str, size_type pos = npos) const noexcept {
         // CONSTEXPR_ASSERT(str != nullptr);
         return rfind(str, pos, traits_type::length(str));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type rfind(value_type ch, size_type pos = npos) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type rfind(
+        value_type ch, size_type pos = npos) const noexcept {
         return details::string::rfind<traits_type>(data(), size(), ch, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type rfind(view_type view, size_type pos = npos) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type rfind(
+        view_type view, size_type pos = npos) const noexcept {
         return rfind(view.data(), pos, view.size());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) constexpr size_type rfind(View const& view,
+    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) inline constexpr size_type rfind(View const& view,
         size_type pos = npos) const noexcept(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
         return rfind(view_type(view), pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_first_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_of(
         basic_short_string const& chars, size_type pos = 0) const noexcept {
         return find_first_of(chars.data(), pos, chars.size());
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_first_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_of(
         const_char_pointer chars, size_type pos, size_type chars_count) const noexcept {
         // CONSTEXPR_ASSERT(chars != nullptr);
         return details::string::find_first_of<traits_type>(data(), size(), chars, chars_count, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_first_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_of(
         const_char_pointer chars, size_type pos = 0) const noexcept {
         // CONSTEXPR_ASSERT(chars != nullptr);
         return find_first_of(chars, pos, traits_type::length(chars));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_first_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_of(
         value_type ch, size_type pos = 0) const noexcept {
         return details::string::find_first_of<traits_type>(data(), size(), ch, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_first_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_of(
         view_type view, size_type pos = 0) const noexcept {
         return find_first_of(view.data(), pos, view.size());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) constexpr size_type find_first_of(View const& view,
+    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) inline constexpr size_type find_first_of(View const& view,
         size_type pos = 0) const noexcept(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
         return find_first_of(view_type(view), pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_first_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_not_of(
         basic_short_string const& chars, size_type pos = 0) const noexcept {
         return find_first_not_of(chars.data(), pos, chars.size());
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_first_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_not_of(
         const_char_pointer chars, size_type pos, size_type chars_count) const noexcept {
         // CONSTEXPR_ASSERT(chars != nullptr);
         return details::string::find_first_not_of<traits_type>(
             data(), size(), chars, chars_count, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_first_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_not_of(
         const_char_pointer chars, size_type pos = 0) const noexcept {
         // CONSTEXPR_ASSERT(chars != nullptr);
         return find_first_not_of(chars, pos, traits_type::length(chars));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_first_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_not_of(
         value_type ch, size_type pos = 0) const noexcept {
         return find_first_not_of(&ch, pos, 1);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_first_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_not_of(
         view_type view, size_type pos = 0) const noexcept {
         return find_first_not_of(view.data(), pos, view.size());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) constexpr size_type find_first_not_of(View const& view,
+    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) inline constexpr size_type find_first_not_of(View const& view,
         size_type pos = 0) const noexcept(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
         return find_first_not_of(view_type(view), pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_last_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_of(
         basic_short_string const& chars, size_type pos = npos) const noexcept {
         return find_last_of(chars.data(), pos, chars.size());
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_last_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_of(
         const_char_pointer chars, size_type pos, size_type chars_count) const noexcept {
         // CONSTEXPR_ASSERT(chars != nullptr);
         return details::string::find_last_of<traits_type>(data(), size(), chars, chars_count, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_last_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_of(
         const_char_pointer chars, size_type pos = npos) const noexcept {
         // CONSTEXPR_ASSERT(chars != nullptr);
         return find_last_of(chars, pos, traits_type::length(chars));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_last_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_of(
         value_type ch, size_type pos = npos) const noexcept {
         return find_last_of(&ch, pos, 1);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_last_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_of(
         view_type view, size_type pos = npos) const noexcept {
         return find_last_of(view.data(), pos, view.size());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) constexpr size_type find_last_of(View const& view,
+    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) inline constexpr size_type find_last_of(View const& view,
         size_type pos = npos) const noexcept(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
         return find_last_of(view_type(view), pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_last_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_not_of(
         basic_short_string const& chars, size_type pos = npos) const noexcept {
         return find_last_not_of(chars.data(), pos, chars.size());
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_last_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_not_of(
         const_char_pointer chars, size_type pos, size_type count) const UTL_THROWS {
         // CONSTEXPR_ASSERT(chars != nullptr);
         return details::string::find_last_not_of<traits_type>(data(), size(), chars, count, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_last_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_not_of(
         const_char_pointer chars, size_type pos = npos) const UTL_THROWS {
         // CONSTEXPR_ASSERT(chars != nullptr);
         return find_last_not_of(chars, pos, traits_type::length(chars));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_last_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_not_of(
         value_type ch, size_type pos = npos) const UTL_THROWS {
         return find_last_not_of(&ch, pos, 1);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_last_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_not_of(
         view_type view, size_type pos = npos) const UTL_THROWS {
         return find_last_not_of(view.data(), pos, view.size());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) constexpr size_type find_last_not_of(View const& view,
+    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) inline constexpr size_type find_last_not_of(View const& view,
         size_type pos = npos) const UTL_NOEXCEPT(UTL_TRAIT_is_nothrow_convertible(View,
         view_type)) {
         return find_last_not_of(view_type(view), pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr int compare(basic_short_string const& other) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr int compare(basic_short_string const& other) const noexcept {
         return details::string::compare<traits_type>(data(), size(), other.data(), other.size());
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr int compare(const_char_pointer str) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr int compare(const_char_pointer str) const noexcept {
         // CONSTEXPR_ASSERT(str != nullptr);
         return details::string::compare<traits_type>(data(), size(), str, traits_type::length(str));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr int compare(view_type view) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr int compare(view_type view) const noexcept {
         return details::string::compare<traits_type>(data(), size(), view.data(), view.size());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(is_convertible<View, view_type>::value)>
-    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) UTL_CONSTEXPR_CXX14 int compare(View const& view) const
+    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) inline UTL_CONSTEXPR_CXX14 int compare(View const& view) const
         noexcept(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
         return compare(view_type(view));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE)
-    UTL_CONSTEXPR_CXX14 int compare(
+    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 int compare(
         size_type pos, size_type count, basic_short_string const& other) const UTL_THROWS {
         return compare(pos, count, other.data(), other.size());
     }
 
-    UTL_ATTRIBUTE(STRING_PURE)
-    UTL_CONSTEXPR_CXX14 int compare(
+    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 int compare(
         size_type pos, size_type count, const_char_pointer str, size_type str_len) const UTL_THROWS {
         UTL_ASSERT(str != nullptr);
         UTL_THROW_IF(pos > size(),
@@ -1271,28 +1276,24 @@ public:
             data() + pos, __UTL numeric::min(count, size() - pos), str, str_len);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE)
-    UTL_CONSTEXPR_CXX14 int compare(
+    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 int compare(
         size_type pos, size_type count, const_char_pointer str) const UTL_THROWS {
         return compare(pos, count, str, traits_type::length(str));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE)
-    UTL_CONSTEXPR_CXX14 int compare(
+    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 int compare(
         size_type pos, size_type count, view_type view) const UTL_THROWS {
         return compare(pos, count, view.data(), view.size());
     }
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE)
-    UTL_CONSTEXPR_CXX14 int compare(size_type pos, size_type count,
+    UTL_ATTRIBUTES(NODISCARD, _ABI_PRIVATE) inline UTL_CONSTEXPR_CXX14 int compare(size_type pos, size_type count,
         View const& view) const UTL_NOEXCEPT(UTL_TRAIT_is_nothrow_convertible(View, view_type)) {
         return compare(pos, count, view_type(view));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE)
-    UTL_CONSTEXPR_CXX14 int compare(size_type pos, size_type count,
+    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 int compare(size_type pos, size_type count,
         basic_short_string const& other, size_type pos2, size_type count2 = npos) const UTL_THROWS {
         UTL_THROW_IF(pos2 > other.size(),
             out_of_range(
@@ -1302,8 +1303,7 @@ public:
         return compare(pos, count, view_type(other).substr(pos2, count2));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE)
-    UTL_CONSTEXPR_CXX14 int compare(size_type pos, size_type count, view_type view,
+    UTL_ATTRIBUTE(STRING_PURE) inline UTL_CONSTEXPR_CXX14 int compare(size_type pos, size_type count, view_type view,
         size_type pos2, size_type count2 = npos) const UTL_THROWS {
         UTL_THROW_IF(pos2 > view.size(),
             out_of_range(
@@ -1315,66 +1315,65 @@ public:
 
     template <UTL_CONCEPT_CXX20(convertible_to<view_type>) View UTL_CONSTRAINT_CXX11(
         is_convertible<View, view_type>::value)>
-    UTL_ATTRIBUTES(NODISCARD, PURE, _ABI_PRIVATE)
-    UTL_CONSTEXPR_CXX14 int compare(size_type pos, size_type count,
+    UTL_ATTRIBUTES(NODISCARD, PURE, _ABI_PRIVATE) inline UTL_CONSTEXPR_CXX14 int compare(size_type pos, size_type count,
         View const& view, size_type pos2, size_type count2 = npos) const UTL_NOEXCEPT(UTL_TRAIT_is_nothrow_convertible(View,
         view_type)) {
         return compare(pos, count, view_type(view), pos2, count2);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr bool starts_with(view_type view) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool starts_with(view_type view) const noexcept {
         return size() >= view.size() && traits_type::compare(data(), view.data(), view.size()) == 0;
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr bool starts_with(value_type ch) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool starts_with(value_type ch) const noexcept {
         return !empty() && front() == ch;
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr bool starts_with(const_char_pointer str) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool starts_with(const_char_pointer str) const noexcept {
         // CONSTEXPR_ASSERT(str != nullptr);
         return starts_with(view_type(str));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr bool ends_with(view_type view) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool ends_with(view_type view) const noexcept {
         return size() >= view.size() &&
             traits_type::compare(view_type(*this).substr(size() - view.size()).data(), view.data(),
                 view.size()) == 0;
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr bool ends_with(value_type ch) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool ends_with(value_type ch) const noexcept {
         return !empty() && back() == ch;
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr bool ends_with(const_char_pointer str) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool ends_with(const_char_pointer str) const noexcept {
         // CONSTEXPR_ASSERT(str != nullptr);
         return ends_with(view_type(str));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr bool contains(view_type view) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool contains(view_type view) const noexcept {
         return find(view) != npos;
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr bool contains(value_type ch) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool contains(value_type ch) const noexcept {
         return traits_type::find(data(), size(), ch) != nullptr;
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr bool contains(const_char_pointer str) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool contains(const_char_pointer str) const noexcept {
         // CONSTEXPR_ASSERT(str != nullptr);
         return contains(view_type(str));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr basic_short_string substr(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr basic_short_string substr(
         size_type pos = 0, size_type count = npos) const& {
         return basic_short_string(*this, pos, count);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr basic_short_string substr(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr basic_short_string substr(
         size_type pos = 0, size_type count = npos) const&& {
         return basic_short_string(__UTL move(*this), pos, count);
     }
 
 private:
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 void swap(basic_short_string& other, false_type) noexcept {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void swap(basic_short_string& other, false_type) noexcept {
         ranges::swap(storage_.first(), other.storage_.first());
         auto size_tmp = size_;
         auto heap_tmp = is_heap_;
@@ -1384,12 +1383,12 @@ private:
         other.is_heap_ = heap_tmp;
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 void swap(basic_short_string& other, true_type) noexcept {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void swap(basic_short_string& other, true_type) noexcept {
         swap(other, false_type{});
         ranges::swap(allocator_ref(), other.allocator_ref());
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CONSTRUCTS_AT void transfer_to_heap(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CONSTRUCTS_AT void transfer_to_heap(
         size_type new_capacity) UTL_THROWS {
         UTL_ASSERT(!is_heap_);
         auto const result = alloc_traits::allocate_at_least(allocator_ref(), new_capacity + 1);
@@ -1399,13 +1398,15 @@ private:
         is_heap_ = true;
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX20 void grow_heap(size_type new_capacity) UTL_THROWS {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX20 void grow_heap(size_type new_capacity)
+        UTL_THROWS {
         UTL_ASSERT(is_heap_);
         get_heap() =
             alloc_traits::reallocate_at_least(allocator_ref(), get_heap(), new_capacity + 1);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX20 void reserve_impl(size_type new_capacity) UTL_THROWS {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX20 void reserve_impl(size_type new_capacity)
+        UTL_THROWS {
         UTL_ASSERT(new_capacity > this->capacity());
         UTL_TRY {
             if (!is_heap_) {
@@ -1421,13 +1422,13 @@ private:
         }
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 void destroy() noexcept {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void destroy() noexcept {
         if (is_heap_) {
             alloc_traits::deallocate(allocator_ref(), get_heap().data_, get_heap().capacity_);
         }
     }
 
-    __UTL_HIDE_FROM_ABI static UTL_CONSTEXPR_CXX20 heap_type clone_heap(
+    __UTL_HIDE_FROM_ABI static inline UTL_CONSTEXPR_CXX20 heap_type clone_heap(
         allocator_type& alloc, basic_short_string const& src) UTL_THROWS {
         UTL_ASSERT(src.is_heap_);
         UTL_TRY {
@@ -1442,9 +1443,10 @@ private:
         }
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 void reset_to_short() && noexcept {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void reset_to_short() && noexcept {
         // The && qualifier is not needed but added to prevent accidental use
-        // constexpr only if `is_heap_` is `false` because constexpr placement new is not portable
+        // inline constexpr only if `is_heap_` is `false` because inline constexpr placement new is
+        // not portable
         if (is_heap_) {
             size_ = 0;
             is_heap_ = false;
@@ -1452,12 +1454,13 @@ private:
         }
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 void move_assign(basic_short_string& other, false_type)
-        UTL_THROWS {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void move_assign(
+        basic_short_string& other, false_type) UTL_THROWS {
         *this = other;
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 void move_assign(basic_short_string& other, true_type) noexcept {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void move_assign(
+        basic_short_string& other, true_type) noexcept {
         destroy();
         storage_.first() = other.storage_.first();
         alloc_traits::assign(allocator_ref(), __UTL move(other.allocator_ref()));
@@ -1467,13 +1470,14 @@ private:
         __UTL move(other).reset_to_short();
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 void inline_substring(size_type pos, size_type count) noexcept {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void inline_substring(
+        size_type pos, size_type count) noexcept {
         auto const new_size = __UTL numeric::min(this->size() - pos, count);
         traits_type::move(this->data(), this->data() + pos, new_size);
         this->resize(new_size);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 void on_move_construct_with_alloc(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void on_move_construct_with_alloc(
         basic_short_string& other, size_type pos, size_type count, true_type) UTL_THROWS {
         if (!alloc_traits::equals(allocator_ref(), other.allocator_ref()) && other.is_heap_) {
             storage_.get_heap() = clone_heap(allocator_ref(), other);
@@ -1484,25 +1488,28 @@ private:
         }
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 void on_move_construct_with_alloc(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void on_move_construct_with_alloc(
         basic_short_string& other, size_type pos, size_type count, false_type) noexcept {
         inline_substring(pos, count);
         __UTL move(other).reset_to_short();
     }
 
-    UTL_ATTRIBUTE(STRING_CONST)
-    UTL_CONSTEXPR_CXX14 short_type& get_short() noexcept { return storage_.first().short_; }
-    UTL_ATTRIBUTE(STRING_CONST)
-    UTL_CONSTEXPR_CXX14 heap_type& get_heap() noexcept { return storage_.first().heap_; }
-    UTL_ATTRIBUTE(STRING_CONST)
-    UTL_CONSTEXPR_CXX14 allocator_type& allocator_ref() noexcept { return storage_.second(); }
-    UTL_ATTRIBUTE(STRING_CONST) constexpr short_type const& get_short() const noexcept {
+    UTL_ATTRIBUTE(STRING_CONST) inline UTL_CONSTEXPR_CXX14 short_type& get_short() noexcept {
         return storage_.first().short_;
     }
-    UTL_ATTRIBUTE(STRING_CONST) constexpr heap_type const& get_heap() const noexcept {
+    UTL_ATTRIBUTE(STRING_CONST) inline UTL_CONSTEXPR_CXX14 heap_type& get_heap() noexcept {
         return storage_.first().heap_;
     }
-    UTL_ATTRIBUTE(STRING_CONST) constexpr allocator_type const& allocator_ref() const noexcept {
+    UTL_ATTRIBUTE(STRING_CONST) inline UTL_CONSTEXPR_CXX14 allocator_type& allocator_ref() noexcept {
+        return storage_.second();
+    }
+    UTL_ATTRIBUTE(STRING_CONST) inline constexpr short_type const& get_short() const noexcept {
+        return storage_.first().short_;
+    }
+    UTL_ATTRIBUTE(STRING_CONST) inline constexpr heap_type const& get_heap() const noexcept {
+        return storage_.first().heap_;
+    }
+    UTL_ATTRIBUTE(STRING_CONST) inline constexpr allocator_type const& allocator_ref() const noexcept {
         return storage_.second();
     }
 
@@ -1518,8 +1525,8 @@ private:
 };
 
 template <typename CharT, size_t N, typename Traits, typename Alloc, typename U>
-__UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 typename basic_short_string<CharT, N, Traits, Alloc>::size_type erase(
-    basic_short_string<CharT, N, Traits, Alloc>& c, U const& value) {
+__UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 typename basic_short_string<CharT, N, Traits, Alloc>::size_type
+erase(basic_short_string<CharT, N, Traits, Alloc>& c, U const& value) {
     auto const it = __UTL remove(c.begin(), c.end(), value);
     auto const result = c.end() - it;
     c.erase(it, c.end());
@@ -1527,8 +1534,7 @@ __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 typename basic_short_string<CharT, N, Tr
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc, typename Pred>
-__UTL_HIDE_FROM_ABI
-    UTL_CONSTEXPR_CXX14 typename basic_short_string<CharT, N, Traits, Alloc>::size_type
+__UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 typename basic_short_string<CharT, N, Traits, Alloc>::size_type
 erase_if(basic_short_string<CharT, N, Traits, Alloc>& c, Pred const& pred) {
     auto const it = __UTL remove_if(c.begin(), c.end(), pred);
     auto const result = c.end() - it;
@@ -1537,19 +1543,20 @@ erase_if(basic_short_string<CharT, N, Traits, Alloc>& c, Pred const& pred) {
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(STRING_PURE) constexpr bool operator==(basic_short_string<CharT, N, Traits, Alloc> const& lhs,
+UTL_ATTRIBUTES(STRING_PURE) inline constexpr bool operator==(
+    basic_short_string<CharT, N, Traits, Alloc> const& lhs,
     basic_short_string<CharT, N, Traits, Alloc> const& rhs) noexcept {
     return lhs.size() == rhs.size() && lhs.compare(rhs) == 0;
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(STRING_PURE) constexpr bool operator==(
+UTL_ATTRIBUTES(STRING_PURE) inline constexpr bool operator==(
     basic_short_string<CharT, N, Traits, Alloc> const& lhs, CharT const* rhs) noexcept {
     return lhs.compare(rhs) == 0;
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
     basic_short_string<CharT, N, Traits, Alloc> const& l,
     basic_short_string<CharT, N, Traits, Alloc> const& r) UTL_THROWS {
     basic_short_string<CharT, N, Traits, Alloc> output;
@@ -1560,13 +1567,13 @@ UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) constexpr basic_short_string<CharT, N, 
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
     basic_short_string<CharT, N, Traits, Alloc> const& l, CharT const* r) UTL_THROWS {
     return l + basic_string_view<CharT, Traits>(r);
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
     basic_short_string<CharT, N, Traits, Alloc> const& l, CharT r) UTL_THROWS {
     basic_short_string<CharT, N, Traits, Alloc> output;
     output.reserve(l.size() + 1);
@@ -1576,7 +1583,7 @@ UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) constexpr basic_short_string<CharT, N, 
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
     basic_short_string<CharT, N, Traits, Alloc> const& l,
     type_identity_t<basic_string_view<CharT, Traits>> r) UTL_THROWS {
     basic_short_string<CharT, N, Traits, Alloc> output;
@@ -1587,13 +1594,13 @@ UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) constexpr basic_short_string<CharT, N, 
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
     CharT const* l, basic_short_string<CharT, N, Traits, Alloc> const& r) UTL_THROWS {
     return basic_string_view<CharT, Traits>(l) + r;
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
     CharT l, basic_short_string<CharT, N, Traits, Alloc> const& r) UTL_THROWS {
     basic_short_string<CharT, N, Traits, Alloc> output;
     output.reserve(l.size() + 1);
@@ -1603,7 +1610,7 @@ UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) constexpr basic_short_string<CharT, N, 
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
     type_identity_t<basic_string_view<CharT, Traits>> l,
     basic_short_string<CharT, N, Traits, Alloc> const& r) UTL_THROWS {
     basic_short_string<CharT, N, Traits, Alloc> output;
@@ -1613,59 +1620,59 @@ UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) constexpr basic_short_string<CharT, N, 
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
     basic_short_string<CharT, N, Traits, Alloc>&& l,
     basic_short_string<CharT, N, Traits, Alloc>&& r) UTL_THROWS {
     return __UTL move(l.append(r));
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
     basic_short_string<CharT, N, Traits, Alloc>&& l,
     basic_short_string<CharT, N, Traits, Alloc> const& r) UTL_THROWS {
     return __UTL move(l.append(r));
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
     basic_short_string<CharT, N, Traits, Alloc>&& l, CharT const* r) UTL_THROWS {
     return __UTL move(l.append(r));
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
     basic_short_string<CharT, N, Traits, Alloc>&& l, CharT r) UTL_THROWS {
     return __UTL move(l.append(r));
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
     basic_short_string<CharT, N, Traits, Alloc>&& l,
     type_identity_t<basic_string_view<CharT, Traits>> r) UTL_THROWS {
     return __UTL move(l.append(r));
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
     basic_short_string<CharT, N, Traits, Alloc> const& l,
     basic_short_string<CharT, N, Traits, Alloc>&& r) UTL_THROWS {
     return __UTL move(r.insert(0, l));
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
     CharT const* l, basic_short_string<CharT, N, Traits, Alloc>&& r) UTL_THROWS {
     return __UTL move(r.insert(0, l));
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
     CharT l, basic_short_string<CharT, N, Traits, Alloc>&& r) UTL_THROWS {
     return __UTL move(r.insert(0, l));
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
+UTL_ATTRIBUTES(NODISCARD,_HIDE_FROM_ABI) inline constexpr basic_short_string<CharT, N, Traits, Alloc> operator+(
     type_identity_t<basic_string_view<CharT, Traits>> l,
     basic_short_string<CharT, N, Traits, Alloc>&& r) UTL_THROWS {
     return __UTL move(r.insert(0, l));
@@ -1680,7 +1687,7 @@ UTL_NAMESPACE_END
 UTL_NAMESPACE_BEGIN
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) constexpr typename Traits::comparison_category operator<=>(
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr typename Traits::comparison_category operator<=>(
     basic_short_string<CharT, N, Traits, Alloc> const& lhs,
     basic_short_string<CharT, N, Traits, Alloc> const& rhs) noexcept {
     using result_type = typename Traits::comparison_category;
@@ -1688,7 +1695,7 @@ UTL_ATTRIBUTE(STRING_PURE) constexpr typename Traits::comparison_category operat
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) constexpr typename Traits::comparison_category operator<=>(
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr typename Traits::comparison_category operator<=>(
     basic_short_string<CharT, N, Traits, Alloc> const& lhs, CharT const* rhs) noexcept {
     using result_type = typename Traits::comparison_category;
     return static_cast<result_type>(lhs.compare(rhs) <=> 0);
@@ -1701,91 +1708,96 @@ UTL_NAMESPACE_END
 UTL_NAMESPACE_BEGIN
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator<(basic_short_string<CharT, N, Traits, Alloc> const& lhs,
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator<(
+    basic_short_string<CharT, N, Traits, Alloc> const& lhs,
     basic_short_string<CharT, N, Traits, Alloc> const& rhs) noexcept {
     return lhs.compare(rhs) < 0;
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator<(
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator<(
     basic_short_string<CharT, N, Traits, Alloc> const& lhs, CharT const* rhs) noexcept {
     return lhs.compare(rhs) < 0;
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator<(
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator<(
     CharT const* lhs, basic_short_string<CharT, N, Traits, Alloc> const& rhs) noexcept {
     return rhs.compare(lhs) > 0;
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator>(basic_short_string<CharT, N, Traits, Alloc> const& lhs,
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator>(
+    basic_short_string<CharT, N, Traits, Alloc> const& lhs,
     basic_short_string<CharT, N, Traits, Alloc> const& rhs) noexcept {
     return rhs < lhs;
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator>(
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator>(
     basic_short_string<CharT, N, Traits, Alloc> const& lhs, CharT const* rhs) noexcept {
     return rhs < lhs;
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator>(
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator>(
     CharT const* lhs, basic_short_string<CharT, N, Traits, Alloc> const& rhs) noexcept {
     return rhs < lhs;
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator>=(basic_short_string<CharT, N, Traits, Alloc> const& lhs,
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator>=(
+    basic_short_string<CharT, N, Traits, Alloc> const& lhs,
     basic_short_string<CharT, N, Traits, Alloc> const& rhs) noexcept {
     return !(lhs < rhs);
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator>=(
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator>=(
     basic_short_string<CharT, N, Traits, Alloc> const& lhs, CharT const* rhs) noexcept {
     return !(lhs < rhs);
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator>=(
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator>=(
     CharT const* lhs, basic_short_string<CharT, N, Traits, Alloc> const& rhs) noexcept {
     return !(lhs < rhs);
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator<=(basic_short_string<CharT, N, Traits, Alloc> const& lhs,
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator<=(
+    basic_short_string<CharT, N, Traits, Alloc> const& lhs,
     basic_short_string<CharT, N, Traits, Alloc> const& rhs) noexcept {
     return !(rhs < lhs);
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator<=(
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator<=(
     basic_short_string<CharT, N, Traits, Alloc> const& lhs, CharT const* rhs) noexcept {
     return !(rhs < lhs);
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator<=(
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator<=(
     CharT const* lhs, basic_short_string<CharT, N, Traits, Alloc> const& rhs) noexcept {
     return !(rhs < lhs);
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator!=(basic_short_string<CharT, N, Traits, Alloc> const& lhs,
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator!=(
+    basic_short_string<CharT, N, Traits, Alloc> const& lhs,
     basic_short_string<CharT, N, Traits, Alloc> const& rhs) noexcept {
     return !(lhs == rhs);
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator!=(
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator!=(
     basic_short_string<CharT, N, Traits, Alloc> const& lhs, CharT const* rhs) noexcept {
     return !(lhs == rhs);
 }
 
 template <typename CharT, size_t N, typename Traits, typename Alloc>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator!=(
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator!=(
     CharT const* lhs, basic_short_string<CharT, N, Traits, Alloc> const& rhs) noexcept {
     return !(lhs == rhs);
 }

--- a/src/utl/public/utl/string/utl_basic_string_view.h
+++ b/src/utl/public/utl/string/utl_basic_string_view.h
@@ -38,7 +38,7 @@ public:
     using const_pointer = CharType const*;
     using reference = CharType&;
     using const_reference = CharType const&;
-    static inline constexpr size_type npos = details::string::npos;
+    __UTL_PUBLIC_TEMPLATE_DATA static inline constexpr size_type npos = details::string::npos;
     class const_iterator;
     using iterator = const_iterator;
     using const_reverse_iterator = __UTL reverse_iterator<const_iterator>;
@@ -401,26 +401,11 @@ UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator==(
     return lhs.size() == rhs.size() && lhs.compare(rhs) == 0;
 }
 
-UTL_NAMESPACE_END
-
-#if UTL_CXX20
-
-#  include "utl/compare/utl_compare_fwd.h"
-
-UTL_NAMESPACE_BEGIN
-
 template <typename CharType, typename Traits>
-UTL_ATTRIBUTE(STRING_PURE) inline constexpr typename Traits::comparison_category operator<=>(
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator!=(
     basic_string_view<CharType, Traits> lhs, basic_string_view<CharType, Traits> rhs) noexcept {
-    using result_type = typename Traits::comparison_category;
-    return static_cast<result_type>(lhs.compare(rhs) <=> 0);
+    return !(lhs == rhs);
 }
-
-UTL_NAMESPACE_END
-
-#else
-
-UTL_NAMESPACE_BEGIN
 
 template <typename CharType, typename Traits>
 UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator<(
@@ -446,11 +431,32 @@ UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator<=(
     return !(rhs < lhs);
 }
 
+UTL_NAMESPACE_END
+
+#if UTL_CXX20
+
+#  include "utl/compare/utl_compare_fwd.h"
+
+UTL_NAMESPACE_BEGIN
+
 template <typename CharType, typename Traits>
-UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator!=(
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr typename Traits::comparison_category operator<=>(
     basic_string_view<CharType, Traits> lhs, basic_string_view<CharType, Traits> rhs) noexcept {
-    return !(lhs == rhs);
+    using result_type = typename Traits::comparison_category;
+    return static_cast<result_type>(lhs.compare(rhs) <=> 0);
 }
+
+UTL_NAMESPACE_END
+
+#endif
+
+#if !UTL_CXX17
+
+UTL_NAMESPACE_BEGIN
+
+template <typename CharT, typename Traits>
+__UTL_ABI_PUBLIC constexpr typename basic_string_view<CharT, N, Traits, Alloc>::size_type
+    basic_string_view<CharT, Traits>::npos;
 
 UTL_NAMESPACE_END
 

--- a/src/utl/public/utl/string/utl_basic_string_view.h
+++ b/src/utl/public/utl/string/utl_basic_string_view.h
@@ -38,7 +38,7 @@ public:
     using const_pointer = CharType const*;
     using reference = CharType&;
     using const_reference = CharType const&;
-    static constexpr size_type npos = details::string::npos;
+    static inline constexpr size_type npos = details::string::npos;
     class const_iterator;
     using iterator = const_iterator;
     using const_reverse_iterator = __UTL reverse_iterator<const_iterator>;
@@ -55,29 +55,33 @@ public:
         using typename base_type::reference;
         using typename base_type::value_type;
 
-        __UTL_HIDE_FROM_ABI constexpr const_iterator() noexcept = default;
-        __UTL_HIDE_FROM_ABI constexpr const_iterator(
+        __UTL_HIDE_FROM_ABI inline constexpr const_iterator() noexcept = default;
+        __UTL_HIDE_FROM_ABI inline constexpr const_iterator(
             const_iterator const& other) noexcept = default;
-        __UTL_HIDE_FROM_ABI constexpr const_iterator(const_iterator&& other) noexcept = default;
-        __UTL_HIDE_FROM_ABI constexpr const_iterator& operator=(
+        __UTL_HIDE_FROM_ABI inline constexpr const_iterator(
+            const_iterator&& other) noexcept = default;
+        __UTL_HIDE_FROM_ABI inline constexpr const_iterator& operator=(
             const_iterator const& other) noexcept = default;
-        __UTL_HIDE_FROM_ABI constexpr const_iterator& operator=(
+        __UTL_HIDE_FROM_ABI inline constexpr const_iterator& operator=(
             const_iterator&& other) noexcept = default;
         using base_type::operator*;
         using base_type::operator->;
 
     private:
         friend basic_string_view;
-        __UTL_HIDE_FROM_ABI constexpr const_iterator(pointer data) noexcept : base_type(data) {}
+        __UTL_HIDE_FROM_ABI inline constexpr const_iterator(pointer data) noexcept
+            : base_type(data) {}
     };
 
     basic_string_view(decltype(nullptr)) = delete;
-    __UTL_HIDE_FROM_ABI constexpr basic_string_view() noexcept : data_(), size_() {}
-    __UTL_HIDE_FROM_ABI constexpr basic_string_view(basic_string_view const&) noexcept = default;
-    __UTL_HIDE_FROM_ABI constexpr basic_string_view(const_pointer data, size_type size) noexcept
+    __UTL_HIDE_FROM_ABI inline constexpr basic_string_view() noexcept : data_(), size_() {}
+    __UTL_HIDE_FROM_ABI inline constexpr basic_string_view(
+        basic_string_view const&) noexcept = default;
+    __UTL_HIDE_FROM_ABI inline constexpr basic_string_view(
+        const_pointer data, size_type size) noexcept
         : data_(data)
         , size_(size) {}
-    __UTL_HIDE_FROM_ABI constexpr basic_string_view(const_pointer data) noexcept(
+    __UTL_HIDE_FROM_ABI inline constexpr basic_string_view(const_pointer data) noexcept(
         noexcept(traits_type::length(data)))
         : data_(data)
         , size_(traits_type::length(data)) {}
@@ -85,62 +89,62 @@ public:
     template <UTL_CONCEPT_CXX20(contiguous_iterator) It,
         UTL_CONCEPT_CXX20(sized_sentinel_for<It>) E UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_contiguous_iterator(It) && UTL_TRAIT_is_sized_sentinel_for(E, It))>
-    __UTL_HIDE_FROM_ABI constexpr basic_string_view(It begin, E end) noexcept(
+    __UTL_HIDE_FROM_ABI inline constexpr basic_string_view(It begin, E end) noexcept(
         UTL_TRAIT_is_nothrow_dereferenceable(It) && noexcept(end - begin))
         : data_(__UTL to_address(begin))
         , size_(end - begin) {}
 
     // TODO: ranges ctor
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_string_view& operator=(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_string_view& operator=(
         basic_string_view const&) noexcept = default;
 
-    UTL_ATTRIBUTE(STRING_INLINE_PURE) constexpr const_pointer data() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_INLINE_PURE) inline constexpr const_pointer data() const noexcept UTL_LIFETIMEBOUND {
         return data_;
     }
-    UTL_ATTRIBUTE(STRING_INLINE_PURE) constexpr bool empty() const noexcept { return !size(); }
-    UTL_ATTRIBUTE(STRING_INLINE_PURE) constexpr size_type size() const noexcept { return size_; }
-    UTL_ATTRIBUTE(STRING_INLINE_PURE) constexpr size_type length() const noexcept { return size_; }
+    UTL_ATTRIBUTE(STRING_INLINE_PURE) inline constexpr bool empty() const noexcept { return !size(); }
+    UTL_ATTRIBUTE(STRING_INLINE_PURE) inline constexpr size_type size() const noexcept { return size_; }
+    UTL_ATTRIBUTE(STRING_INLINE_PURE) inline constexpr size_type length() const noexcept { return size_; }
 
-    UTL_ATTRIBUTES(CONST, NODISCARD, _HIDE_FROM_ABI) constexpr size_type max_size() const noexcept {
+    UTL_ATTRIBUTES(CONST, NODISCARD, _HIDE_FROM_ABI) inline constexpr size_type max_size() const noexcept {
         return npos;
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr const_iterator cbegin() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_iterator cbegin() const noexcept UTL_LIFETIMEBOUND {
         return const_iterator(data());
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr const_iterator begin() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_iterator begin() const noexcept UTL_LIFETIMEBOUND {
         return const_iterator(data());
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr const_iterator cend() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_iterator cend() const noexcept UTL_LIFETIMEBOUND {
         return const_iterator(data() + size());
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr const_iterator end() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_iterator end() const noexcept UTL_LIFETIMEBOUND {
         return const_iterator(data() + size());
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr const_iterator crbegin() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_iterator crbegin() const noexcept UTL_LIFETIMEBOUND {
         return const_reverse_iterator(end());
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr const_iterator rbegin() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_iterator rbegin() const noexcept UTL_LIFETIMEBOUND {
         return const_reverse_iterator(end());
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr const_iterator crend() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_iterator crend() const noexcept UTL_LIFETIMEBOUND {
         return const_reverse_iterator(begin());
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr const_iterator rend() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_iterator rend() const noexcept UTL_LIFETIMEBOUND {
         return const_reverse_iterator(begin());
     }
-    UTL_ATTRIBUTE(STRING_INLINE_PURE) constexpr const_reference front() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_INLINE_PURE) inline constexpr const_reference front() const noexcept UTL_LIFETIMEBOUND {
         return *data_;
     }
-    UTL_ATTRIBUTE(STRING_INLINE_PURE) constexpr const_reference back() const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_INLINE_PURE) inline constexpr const_reference back() const noexcept UTL_LIFETIMEBOUND {
         return data_[size_ - 1];
     }
-    UTL_ATTRIBUTE(STRING_INLINE_PURE) constexpr const_reference operator[](size_type idx) const noexcept UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_INLINE_PURE) inline constexpr const_reference operator[](size_type idx) const noexcept UTL_LIFETIMEBOUND {
         return data_[idx];
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr const_reference at(size_type idx) const UTL_THROWS UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_reference at(size_type idx) const UTL_THROWS UTL_LIFETIMEBOUND {
         UTL_THROW_IF(idx > size(),
             out_of_range(UTL_MESSAGE_FORMAT("[UTL] `basic_string_view::at` operation failed, "
                                             "Reason=[index out of range], pos=[%zu], size=[%zu]"),
@@ -148,27 +152,27 @@ public:
         return *this[idx];
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 void remove_prefix(size_type n) noexcept {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void remove_prefix(size_type n) noexcept {
         n = __UTL numeric::min(n, size());
         data_ += n;
         size_ -= n;
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 void remove_suffix(size_type n) noexcept {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void remove_suffix(size_type n) noexcept {
         n = __UTL numeric::min(n, size());
         size_ -= n;
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 void swap(basic_string_view& other) noexcept {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void swap(basic_string_view& other) noexcept {
         other = __UTL exchange(*this, other);
     }
 
-    __UTL_HIDE_FROM_ABI friend UTL_CONSTEXPR_CXX14 void swap(
+    __UTL_HIDE_FROM_ABI friend inline UTL_CONSTEXPR_CXX14 void swap(
         basic_string_view& l, basic_string_view& r) noexcept {
         l.swap(r);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 size_t copy(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 size_t copy(
         pointer dest, size_type count, size_type pos = 0) const UTL_THROWS {
         UTL_ASSERT(dest != nullptr);
         UTL_THROW_IF(pos > size(),
@@ -180,197 +184,200 @@ public:
         return copied;
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr basic_string_view substr(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr basic_string_view substr(
         size_type pos = 0, size_type count = npos) const UTL_THROWS {
         return pos >= size()
             ? substr_throw(UTL_SOURCE_LOCATION(), pos, size())
             : basic_string_view(data() + pos, __UTL numeric::min(count, size() - pos));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr int compare(basic_string_view other) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr int compare(basic_string_view other) const noexcept {
         return details::string::compare<traits_type>(data(), size(), other.data(), other.size());
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr int compare(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr int compare(
         size_type pos, size_type count, basic_string_view other) const UTL_THROWS {
         return substr(pos, count).compare(other);
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr int compare(size_type pos, size_type count, basic_string_view other,
-        size_type other_pos, size_type other_count) const UTL_THROWS {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr int compare(size_type pos, size_type count,
+        basic_string_view other, size_type other_pos, size_type other_count) const UTL_THROWS {
         return substr(pos, count).compare(other.substr(other_pos, other_count));
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr int compare(const_pointer other) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr int compare(const_pointer other) const noexcept {
         return compare(basic_string_view(other));
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr int compare(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr int compare(
         size_type pos, size_type count, const_pointer other) const UTL_THROWS {
         return substr(pos, count).compare(basic_string_view(other));
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr int compare(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr int compare(
         size_type pos, size_type count, const_pointer other, size_type other_count) const UTL_THROWS {
         return substr(pos, count).compare(basic_string_view(other, other_count));
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr bool starts_with(basic_string_view other) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool starts_with(basic_string_view other) const noexcept {
         return size() >= other.size() &&
             traits_type::compare(data(), other.data(), other.size()) == 0;
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr bool starts_with(value_type ch) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool starts_with(value_type ch) const noexcept {
         return !empty() && front() == ch;
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr bool starts_with(const_pointer other) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool starts_with(const_pointer other) const noexcept {
         // CONSTEXPR_ASSERT(other != nullptr);
         return starts_with(basic_string_view(other));
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr bool ends_with(basic_string_view other) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool ends_with(basic_string_view other) const noexcept {
         return size() >= other.size() &&
             traits_type::compare(data() + size() - other.size(), other.data(), other.size()) == 0;
     }
-    UTL_ATTRIBUTE(STRING_PURE) constexpr bool ends_with(value_type ch) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool ends_with(value_type ch) const noexcept {
         return !empty() && back() == ch;
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr bool ends_with(const_pointer other) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool ends_with(const_pointer other) const noexcept {
         // CONSTEXPR_ASSERT(other != nullptr);
         return ends_with(basic_string_view(other));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr bool contains(basic_string_view other) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool contains(basic_string_view other) const noexcept {
         return find(other) != npos;
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr bool contains(value_type ch) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool contains(value_type ch) const noexcept {
         return find(ch) != npos;
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr bool contains(const_pointer other) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool contains(const_pointer other) const noexcept {
         return find(other) != npos;
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find(
         basic_string_view other, size_type pos = 0) const noexcept {
         return find(other.data(), pos, other.size());
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find(value_type ch, size_type pos = 0) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find(
+        value_type ch, size_type pos = 0) const noexcept {
         return details::string::find<traits_type>(data(), size(), ch, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find(
         const_pointer str, size_type pos, size_type str_len) const noexcept {
         // CONSTEXPR_ASSERT(str != nullptr);
         return details::string::find<traits_type>(data(), size(), str, str_len, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find(const_pointer str, size_type pos = 0) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find(
+        const_pointer str, size_type pos = 0) const noexcept {
         // CONSTEXPR_ASSERT(str != nullptr);
         return find(str, pos, traits_type::length(str));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type rfind(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type rfind(
         basic_string_view other, size_type pos = npos) const noexcept {
         return rfind(other.data(), pos, other.size());
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type rfind(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type rfind(
         const_pointer str, size_type pos, size_type str_len) const noexcept {
         // CONSTEXPR_ASSERT(str != nullptr);
         return details::string::rfind<traits_type>(data(), size(), str, str_len, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type rfind(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type rfind(
         const_pointer str, size_type pos = npos) const noexcept {
         // CONSTEXPR_ASSERT(str != nullptr);
         return rfind(str, pos, traits_type::length(str));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type rfind(value_type ch, size_type pos = npos) const noexcept {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type rfind(
+        value_type ch, size_type pos = npos) const noexcept {
         return details::string::rfind<traits_type>(data(), size(), ch, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_first_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_of(
         basic_string_view other, size_type pos = 0) const noexcept {
         return find_first_of(other.data(), pos, other.size());
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_first_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_of(
         const_pointer chars, size_type pos, size_type chars_count) const noexcept {
         // CONSTEXPR_ASSERT(chars != nullptr);
         return details::string::find_first_of<traits_type>(data(), size(), chars, chars_count, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_first_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_of(
         const_pointer chars, size_type pos = 0) const noexcept {
         // CONSTEXPR_ASSERT(chars != nullptr);
         return find_first_of(chars, pos, traits_type::length(chars));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_first_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_of(
         value_type ch, size_type pos = 0) const noexcept {
         return details::string::find_first_of<traits_type>(data(), size(), ch, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_first_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_not_of(
         basic_string_view other, size_type pos = 0) const noexcept {
         return find_first_not_of(other.data(), pos, other.size());
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_first_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_not_of(
         const_pointer chars, size_type pos, size_type chars_count) const noexcept {
         // CONSTEXPR_ASSERT(chars != nullptr);
         return details::string::find_first_not_of<traits_type>(
             data(), size(), chars, chars_count, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_first_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_not_of(
         const_pointer chars, size_type pos = 0) const noexcept {
         // CONSTEXPR_ASSERT(chars != nullptr);
         return find_first_not_of(chars, pos, traits_type::length(chars));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_first_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_first_not_of(
         value_type ch, size_type pos = 0) const noexcept {
         return find_first_not_of(&ch, pos, 1);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_last_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_of(
         basic_string_view other, size_type pos = npos) const noexcept {
         return find_last_of(other.data(), pos, other.size());
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_last_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_of(
         const_pointer chars, size_type pos, size_type chars_count) const noexcept {
         // CONSTEXPR_ASSERT(chars != nullptr);
         return details::string::find_last_of<traits_type>(data(), size(), chars, chars_count, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_last_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_of(
         const_pointer chars, size_type pos = npos) const noexcept {
         // CONSTEXPR_ASSERT(chars != nullptr);
         return find_last_of(chars, pos, traits_type::length(chars));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_last_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_of(
         value_type ch, size_type pos = npos) const noexcept {
         return find_last_of(&ch, pos, 1);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_last_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_not_of(
         basic_string_view other, size_type pos = npos) const noexcept {
         return find_last_not_of(other.data(), pos, other.size());
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_last_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_not_of(
         const_pointer chars, size_type pos, size_type count) const noexcept {
         // CONSTEXPR_ASSERT(chars != nullptr);
         return details::string::find_last_not_of<traits_type>(data(), size(), chars, count, pos);
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_last_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_not_of(
         const_pointer chars, size_type pos = npos) const noexcept {
         // CONSTEXPR_ASSERT(chars != nullptr);
         return find_last_not_of(chars, pos, traits_type::length(chars));
     }
 
-    UTL_ATTRIBUTE(STRING_PURE) constexpr size_type find_last_not_of(
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr size_type find_last_not_of(
         value_type ch, size_type pos = npos) const noexcept {
         return find_last_not_of(&ch, pos, 1);
     }
@@ -389,9 +396,9 @@ private:
 };
 
 template <typename CharType, typename Traits>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator==(
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator==(
     basic_string_view<CharType, Traits> lhs, basic_string_view<CharType, Traits> rhs) noexcept {
-    return lhs.size() == rhs.size() && (lhs.data() == rhs.data() || lhs.compare(rhs) == 0);
+    return lhs.size() == rhs.size() && lhs.compare(rhs) == 0;
 }
 
 UTL_NAMESPACE_END
@@ -403,7 +410,7 @@ UTL_NAMESPACE_END
 UTL_NAMESPACE_BEGIN
 
 template <typename CharType, typename Traits>
-UTL_ATTRIBUTE(STRING_PURE) constexpr typename Traits::comparison_category operator<=>(
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr typename Traits::comparison_category operator<=>(
     basic_string_view<CharType, Traits> lhs, basic_string_view<CharType, Traits> rhs) noexcept {
     using result_type = typename Traits::comparison_category;
     return static_cast<result_type>(lhs.compare(rhs) <=> 0);
@@ -416,31 +423,31 @@ UTL_NAMESPACE_END
 UTL_NAMESPACE_BEGIN
 
 template <typename CharType, typename Traits>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator<(
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator<(
     basic_string_view<CharType, Traits> lhs, basic_string_view<CharType, Traits> rhs) noexcept {
     return lhs.compare(rhs) < 0;
 }
 
 template <typename CharType, typename Traits>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator>(
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator>(
     basic_string_view<CharType, Traits> lhs, basic_string_view<CharType, Traits> rhs) noexcept {
     return rhs < lhs;
 }
 
 template <typename CharType, typename Traits>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator>=(
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator>=(
     basic_string_view<CharType, Traits> lhs, basic_string_view<CharType, Traits> rhs) noexcept {
     return !(lhs < rhs);
 }
 
 template <typename CharType, typename Traits>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator<=(
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator<=(
     basic_string_view<CharType, Traits> lhs, basic_string_view<CharType, Traits> rhs) noexcept {
     return !(rhs < lhs);
 }
 
 template <typename CharType, typename Traits>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator!=(
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator!=(
     basic_string_view<CharType, Traits> lhs, basic_string_view<CharType, Traits> rhs) noexcept {
     return !(lhs == rhs);
 }

--- a/src/utl/public/utl/string/utl_basic_zstring_view.h
+++ b/src/utl/public/utl/string/utl_basic_zstring_view.h
@@ -43,33 +43,35 @@ public:
     using typename base_type::value_type;
 
     basic_zstring_view(decltype(nullptr)) = delete;
-    __UTL_HIDE_FROM_ABI constexpr basic_zstring_view() noexcept = default;
-    __UTL_HIDE_FROM_ABI constexpr basic_zstring_view(basic_zstring_view const&) noexcept = default;
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_zstring_view(const_pointer data, size_type size) UTL_THROWS
+    __UTL_HIDE_FROM_ABI inline constexpr basic_zstring_view() noexcept = default;
+    __UTL_HIDE_FROM_ABI inline constexpr basic_zstring_view(
+        basic_zstring_view const&) noexcept = default;
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_zstring_view(
+        const_pointer data, size_type size) UTL_THROWS
         : base_type(data, size) {
         UTL_THROW_IF(data()[size] != 0,
             invalid_argument(UTL_MESSAGE_FORMAT(
                 "zstring_view construction failed, Reason=[argument string not null-terminated]")));
     }
-    __UTL_HIDE_FROM_ABI constexpr basic_zstring_view(const_pointer data)
+    __UTL_HIDE_FROM_ABI inline constexpr basic_zstring_view(const_pointer data)
         UTL_NOEXCEPT(noexcept(traits_type::length(data)))
         : base_type(data, traits_type::length(data)) {}
 
     template <UTL_CONCEPT_CXX20(contiguous_iterator) It,
         UTL_CONCEPT_CXX20(sized_sentinel_for<It>) E UTL_CONSTRAINT_CXX11(
         UTL_TRAIT_is_contiguous_iterator(It) && UTL_TRAIT_is_sized_sentinel_for(E, It))>
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_zstring_view(It begin, E end)
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_zstring_view(It begin, E end)
         UTL_NOEXCEPT(UTL_TRAIT_is_nothrow_dereferenceable(It)&& noexcept(end - begin))
         : basic_zstring_view(__UTL to_address(begin), end - begin) {}
 
     __UTL_HIDE_FROM_ABI explicit UTL_CONSTEXPR_CXX14 basic_zstring_view(base_type other) UTL_THROWS
         : basic_zstring_view(other.data(), other.size()) {}
 
-    __UTL_HIDE_FROM_ABI constexpr operator base_type() const { return *this; }
+    __UTL_HIDE_FROM_ABI inline constexpr operator base_type() const { return *this; }
 
     // TODO: ranges ctor
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 basic_zstring_view& operator=(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 basic_zstring_view& operator=(
         basic_zstring_view const&) noexcept = default;
 
     using base_type::back;
@@ -90,7 +92,7 @@ public:
     using base_type::operator[];
     using base_type::remove_prefix;
 
-    UTL_ATTRIBUTE(STRING_PURE)constexpr const_reference at(size_type idx) const UTL_THROWS UTL_LIFETIMEBOUND {
+    UTL_ATTRIBUTE(STRING_PURE) inline constexpr const_reference at(size_type idx) const UTL_THROWS UTL_LIFETIMEBOUND {
         UTL_THROW_IF(idx > size(),
             out_of_range(UTL_MESSAGE_FORMAT("[UTL] `basic_zstring_view::at` operation failed, "
                                             "Reason=[index out of range], pos=[%zu], size=[%zu]"),
@@ -98,16 +100,16 @@ public:
         return *this[idx];
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 void swap(basic_zstring_view& other) noexcept {
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 void swap(basic_zstring_view& other) noexcept {
         base_type::swap(other);
     }
 
-    __UTL_HIDE_FROM_ABI friend UTL_CONSTEXPR_CXX14 void swap(
+    __UTL_HIDE_FROM_ABI friend inline UTL_CONSTEXPR_CXX14 void swap(
         basic_zstring_view& l, basic_zstring_view& r) noexcept {
         l.swap(r);
     }
 
-    __UTL_HIDE_FROM_ABI UTL_CONSTEXPR_CXX14 size_type copy(
+    __UTL_HIDE_FROM_ABI inline UTL_CONSTEXPR_CXX14 size_type copy(
         pointer dest, size_type count, size_type pos = 0) const UTL_THROWS {
         UTL_THROW_IF(pos > size(),
             out_of_range(UTL_MESSAGE_FORMAT("[UTL] `basic_zstring_view::copy` operation failed, "
@@ -118,7 +120,7 @@ public:
         return copied;
     }
 
-    __UTL_HIDE_FROM_ABI constexpr base_type substr(
+    __UTL_HIDE_FROM_ABI inline constexpr base_type substr(
         size_type pos = 0, size_type count = npos) const UTL_THROWS {
         return pos >= size() ? substr_throw(UTL_SOURCE_LOCATION(), pos, size())
                              : base_type(data() + pos, __UTL numeric::min(count, size() - pos));
@@ -136,7 +138,7 @@ public:
     using base_type::starts_with;
 
 private:
-    UTL_ATTRIBUTES(NORETURN, NOINLINE, _HIDE_FROM_ABI) static basic_zstring_view substr_throw(
+    UTL_ATTRIBUTES(NORETURN, NOINLINE) static basic_zstring_view substr_throw(
         __UTL source_location src, size_t pos, size_t size) UTL_THROWS {
         exceptions::message_vformat format = {
             "[UTL] `basic_zstring_view::substr` operation failed, "
@@ -147,9 +149,39 @@ private:
 };
 
 template <typename CharType, typename Traits>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator==(
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator==(
     basic_zstring_view<CharType, Traits> lhs, basic_zstring_view<CharType, Traits> rhs) noexcept {
     return lhs.size() == rhs.size() && (lhs.data() == rhs.data() || lhs.compare(rhs) == 0);
+}
+
+template <typename CharType, typename Traits>
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator!=(
+    basic_zstring_view<CharType, Traits> lhs, basic_zstring_view<CharType, Traits> rhs) noexcept {
+    return !(lhs == rhs);
+}
+
+template <typename CharType, typename Traits>
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator<(
+    basic_zstring_view<CharType, Traits> lhs, basic_zstring_view<CharType, Traits> rhs) noexcept {
+    return lhs.compare(rhs) < 0;
+}
+
+template <typename CharType, typename Traits>
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator>(
+    basic_zstring_view<CharType, Traits> lhs, basic_zstring_view<CharType, Traits> rhs) noexcept {
+    return rhs < lhs;
+}
+
+template <typename CharType, typename Traits>
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator>=(
+    basic_zstring_view<CharType, Traits> lhs, basic_zstring_view<CharType, Traits> rhs) noexcept {
+    return !(lhs < rhs);
+}
+
+template <typename CharType, typename Traits>
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr bool operator<=(
+    basic_zstring_view<CharType, Traits> lhs, basic_zstring_view<CharType, Traits> rhs) noexcept {
+    return !(rhs < lhs);
 }
 
 UTL_NAMESPACE_END
@@ -161,46 +193,10 @@ UTL_NAMESPACE_END
 UTL_NAMESPACE_BEGIN
 
 template <typename CharType, typename Traits>
-UTL_ATTRIBUTE(STRING_PURE) constexpr typename Traits::comparison_category operator<=>(
+UTL_ATTRIBUTE(STRING_PURE) inline constexpr typename Traits::comparison_category operator<=>(
     basic_zstring_view<CharType, Traits> lhs, basic_zstring_view<CharType, Traits> rhs) noexcept {
     using result_type = typename Traits::comparison_category;
     return static_cast<result_type>(lhs.compare(rhs) <=> 0);
-}
-
-UTL_NAMESPACE_END
-
-#else
-
-UTL_NAMESPACE_BEGIN
-
-template <typename CharType, typename Traits>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator<(
-    basic_zstring_view<CharType, Traits> lhs, basic_zstring_view<CharType, Traits> rhs) noexcept {
-    return lhs.compare(rhs) < 0;
-}
-
-template <typename CharType, typename Traits>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator>(
-    basic_zstring_view<CharType, Traits> lhs, basic_zstring_view<CharType, Traits> rhs) noexcept {
-    return rhs < lhs;
-}
-
-template <typename CharType, typename Traits>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator>=(
-    basic_zstring_view<CharType, Traits> lhs, basic_zstring_view<CharType, Traits> rhs) noexcept {
-    return !(lhs < rhs);
-}
-
-template <typename CharType, typename Traits>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator<=(
-    basic_zstring_view<CharType, Traits> lhs, basic_zstring_view<CharType, Traits> rhs) noexcept {
-    return !(rhs < lhs);
-}
-
-template <typename CharType, typename Traits>
-UTL_ATTRIBUTE(STRING_PURE) constexpr bool operator!=(
-    basic_zstring_view<CharType, Traits> lhs, basic_zstring_view<CharType, Traits> rhs) noexcept {
-    return !(lhs == rhs);
 }
 
 UTL_NAMESPACE_END

--- a/src/utl/public/utl/string/utl_libc.h
+++ b/src/utl/public/utl/string/utl_libc.h
@@ -16,99 +16,116 @@ namespace libc {
 
 namespace unsafe {
 template <typename T>
-__UTL_HIDE_FROM_ABI constexpr T* memcpy(
+__UTL_HIDE_FROM_ABI inline constexpr T* memcpy(
     T* UTL_RESTRICT dst, T const* UTL_RESTRICT src, element_count_t count) noexcept {
-    return UTL_CONSTANT_P(src + count != dst) ? compile_time::memcpy(dst, src, count)
-                                              : runtime::memcpy(dst, src, count);
+    return UTL_CONSTANT_P(compile_time::memcpy(dst, src, count))
+        ? compile_time::memcpy(dst, src, count)
+        : runtime::memcpy(dst, src, count);
 }
 
 template <typename T>
-__UTL_HIDE_FROM_ABI constexpr T* memmove(T* dst, T const* src, element_count_t count) noexcept {
-    return UTL_CONSTANT_P(src + count != dst) ? compile_time::memmove(dst, src, count)
-                                              : runtime::memmove(dst, src, count);
+__UTL_HIDE_FROM_ABI inline constexpr T* memmove(
+    T* dst, T const* src, element_count_t count) noexcept {
+    return UTL_CONSTANT_P(compile_time::memmove(dst, src, count))
+        ? compile_time::memmove(dst, src, count)
+        : runtime::memmove(dst, src, count);
 }
 
 template <typename T, typename U>
-UTL_ATTRIBUTE(LIBC_PURE) constexpr int memcmp(T const* lhs, U const* rhs, element_count_t count) noexcept {
-    return UTL_CONSTANT_P(src + count != dst) ? compile_time::memcmp(lhs, rhs, count)
-                                              : runtime::memcmp(lhs, rhs, count);
+UTL_ATTRIBUTE(LIBC_PURE) inline constexpr int memcmp(
+    T const* lhs, U const* rhs, element_count_t count) noexcept {
+    return UTL_CONSTANT_P(compile_time::memcmp(lhs, rhs, count))
+        ? compile_time::memcmp(lhs, rhs, count)
+        : runtime::memcmp(lhs, rhs, count);
 }
 
 template <typename T>
-__UTL_HIDE_FROM_ABI constexpr T* memset(T* dst, T const src, element_count_t count) noexcept {
-    return UTL_CONSTANT_P(src != *(dst + count - 1)) ? compile_time::memset(dst, src, count)
-                                                     : runtime::memset(dst, src, count);
+__UTL_HIDE_FROM_ABI inline constexpr T* memset(
+    T* dst, T const src, element_count_t count) noexcept {
+    return UTL_CONSTANT_P(compile_time::memset(dst, src, count))
+        ? compile_time::memset(dst, src, count)
+        : runtime::memset(dst, src, count);
 }
 } // namespace unsafe
 
 template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_CONSTRAINT_CXX11(
     is_trivially_copyable<T>::value)>
-__UTL_HIDE_FROM_ABI constexpr T* memcpy(
+__UTL_HIDE_FROM_ABI inline constexpr T* memcpy(
     T* UTL_RESTRICT dst, T const* UTL_RESTRICT src, element_count_t count) noexcept {
     return unsafe::memcpy(dst, src, count);
 }
 
 template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_CONSTRAINT_CXX11(
     is_trivially_copyable<T>::value)>
-__UTL_HIDE_FROM_ABI constexpr T* memmove(T* dst, T const* src, element_count_t count) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr T* memmove(
+    T* dst, T const* src, element_count_t count) noexcept {
     return unsafe::memmove(dst, src, count);
 }
 
 template <UTL_CONCEPT_CXX20(exact_size<1>) T, UTL_CONCEPT_CXX20(exact_size<1>) U UTL_CONSTRAINT_CXX11(
     exact_size<T, 1>::value && exact_size<U, 1>::value)>
-UTL_ATTRIBUTE(LIBC_PURE) constexpr T* memchr(T const* str, U value, size_t bytes) noexcept {
-    return UTL_CONSTANT_P((value, str + bytes)) ? compile_time::memchr(str, value, bytes)
-                                                : runtime::memchr(str, value, bytes);
+UTL_ATTRIBUTE(LIBC_PURE) inline constexpr T* memchr(T const* str, U value, size_t bytes) noexcept {
+    return UTL_CONSTANT_P(compile_time::memchr(str, value, bytes))
+        ? compile_time::memchr(str, value, bytes)
+        : runtime::memchr(str, value, bytes);
 }
 
 template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_CONSTRAINT_CXX11(
     is_trivially_copyable<T>::value && exact_size<T, 1>::value)>
 UTL_CONSTRAINT_CXX20(exact_size<T, 1>)
-__UTL_HIDE_FROM_ABI constexpr T* memset(T* dst, T const src, element_count_t count) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr T* memset(
+    T* dst, T const src, element_count_t count) noexcept {
     return unsafe::memset(dst, src, count);
 }
 
 template <typename T, typename U>
-UTL_ATTRIBUTE(LIBC_PURE) constexpr int memcmp(T const* lhs, U const* rhs, element_count_t count) noexcept {
+UTL_ATTRIBUTE(LIBC_PURE) inline constexpr int memcmp(
+    T const* lhs, U const* rhs, element_count_t count) noexcept {
     static_assert(is_trivially_lexicographically_comparable<T, U>::value,
         "Types must be lexicographically comparable");
     return unsafe::memcmp(lhs, rhs, count);
 }
 
 template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
-UTL_ATTRIBUTE(LIBC_PURE) constexpr size_t strlen(T const* str) noexcept {
-    return UTL_CONSTANT_P(str) ? compile_time::strlen(str) : runtime::strlen(str);
+UTL_ATTRIBUTE(LIBC_PURE) inline constexpr size_t strlen(T const* str) noexcept {
+    return UTL_CONSTANT_P(compile_time::strlen(str)) ? compile_time::strlen(str)
+                                                     : runtime::strlen(str);
 }
 
 template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
-UTL_ATTRIBUTE(LIBC_PURE) constexpr T* strchr(T const* str, T const ch) noexcept {
-    return UTL_CONSTANT_P((ch, str)) ? compile_time::strchr(str, ch) : runtime::strchr(str, ch);
+UTL_ATTRIBUTE(LIBC_PURE) inline constexpr T* strchr(T const* str, T const ch) noexcept {
+    return UTL_CONSTANT_P(compile_time::strchr(str, ch)) ? compile_time::strchr(str, ch)
+                                                         : runtime::strchr(str, ch);
 }
 
 template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
-UTL_ATTRIBUTE(LIBC_PURE) constexpr int strcmp(T const* left, T const* right) noexcept {
-    return UTL_CONSTANT_P(left != right) ? compile_time::strcmp(left, right)
-                                         : runtime::strcmp(left, right);
+UTL_ATTRIBUTE(LIBC_PURE) inline constexpr int strcmp(T const* left, T const* right) noexcept {
+    return UTL_CONSTANT_P(compile_time::strcmp(left, right)) ? compile_time::strcmp(left, right)
+                                                             : runtime::strcmp(left, right);
 }
 
 template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
-UTL_ATTRIBUTE(LIBC_PURE) constexpr int strncmp(
+UTL_ATTRIBUTE(LIBC_PURE) inline constexpr int strncmp(
     T const* left, T const* right, element_count_t max_len) noexcept {
-    return UTL_CONSTANT_P(left + max_len != right + max_len)
+    return UTL_CONSTANT_P(compile_time::strncmp(left, right, max_len))
         ? compile_time::strncmp(left, right, max_len)
         : runtime::strncmp(left, right, max_len);
 }
 
 template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
-__UTL_HIDE_FROM_ABI constexpr T* strnset(T* dst, T const val, element_count_t max_len) noexcept {
-    return UTL_CONSTANT_P((dst + max_len, val)) ? compile_time::strnset(dst, val, max_len)
-                                                : runtime::strnset(dst, val, max_len);
+__UTL_HIDE_FROM_ABI inline constexpr T* strnset(
+    T* dst, T const val, element_count_t max_len) noexcept {
+    return UTL_CONSTANT_P(compile_time::strnset(dst, val, max_len))
+        ? compile_time::strnset(dst, val, max_len)
+        : runtime::strnset(dst, val, max_len);
 }
 
 template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
-UTL_ATTRIBUTE(LIBC_PURE) constexpr T* strnchr(T const* str, T const ch, element_count_t max_len) noexcept {
-    return UTL_CONSTANT_P((str + max_len, ch)) ? compile_time::strnchr(str, ch, max_len)
-                                               : runtime::strnchr(str, ch, max_len);
+UTL_ATTRIBUTE(LIBC_PURE) inline constexpr T* strnchr(
+    T const* str, T const ch, element_count_t max_len) noexcept {
+    return UTL_CONSTANT_P(compile_time::strnchr(str, ch, max_len))
+        ? compile_time::strnchr(str, ch, max_len)
+        : runtime::strnchr(str, ch, max_len);
 }
 } // namespace libc
 

--- a/src/utl/public/utl/string/utl_libc_compile_time.h
+++ b/src/utl/public/utl/string/utl_libc_compile_time.h
@@ -13,32 +13,33 @@ namespace compile_time {
 namespace recursive {
 
 template <typename T>
-__UTL_HIDE_FROM_ABI constexpr T* memcpy(
+__UTL_HIDE_FROM_ABI inline constexpr T* memcpy(
     T* dst, T const* src, element_count_t count, T* org) noexcept {
     return count == 0 ? org : ((*dst = *src), memcpy(dst + 1, src + 1, count - 1, org));
 }
 
 template <typename T>
-__UTL_HIDE_FROM_ABI constexpr T* reverse_memcpy(
+__UTL_HIDE_FROM_ABI inline constexpr T* reverse_memcpy(
     T* dst, T const* src, element_count_t count, T* org) noexcept {
     return count == 0 ? org : ((*--dst = *--src), memcpy(dst, src, count - 1, org));
 }
 
 template <typename T>
-__UTL_HIDE_FROM_ABI constexpr T* memset(
+__UTL_HIDE_FROM_ABI inline constexpr T* memset(
     T* dst, T const src, element_count_t count, T* org) noexcept {
     return count == 0 ? org : ((*dst = src), memset(dst + 1, src, count - 1, org));
 }
 
 template <typename T>
-__UTL_HIDE_FROM_ABI constexpr T* memmove(T* dst, T const* src, element_count_t count) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr T* memmove(
+    T* dst, T const* src, element_count_t count) noexcept {
     return is_pointer_in_range(src, src + count, dst)
         ? reverse_memcpy(dst + count, src + count, count, dst)
         : memcpy(dst, src, count, dst);
 }
 
 template <typename T, typename U>
-__UTL_HIDE_FROM_ABI constexpr int memcmp(
+__UTL_HIDE_FROM_ABI inline constexpr int memcmp(
     T const* left, U const* right, element_count_t count) noexcept {
     static_assert(is_trivially_lexicographically_comparable<T, U>::value,
         "Types must be lexicographically comparable");
@@ -51,26 +52,26 @@ __UTL_HIDE_FROM_ABI constexpr int memcmp(
 
 template <UTL_CONCEPT_CXX20(exact_size<1>) T, UTL_CONCEPT_CXX20(
     exact_size<1>) U UTL_CONSTRAINT_CXX11(exact_size<T, 1>::value && exact_size<U, 1>::value)>
-__UTL_HIDE_FROM_ABI constexpr T* memchr(T const* str, U value, size_t bytes) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr T* memchr(T const* str, U value, size_t bytes) noexcept {
     return bytes == 0   ? nullptr
         : *str == value ? const_cast<T*>(str)
                         : __UTL libc::compile_time::recursive::memchr(str + 1, value, bytes - 1);
 }
 
 template <typename T>
-__UTL_HIDE_FROM_ABI constexpr size_t strlen(T const* str, size_t r = 0) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr size_t strlen(T const* str, size_t r = 0) noexcept {
     return !*str ? r : strlen(str, r + 1);
 }
 
 template <typename T>
-__UTL_HIDE_FROM_ABI constexpr T* strchr(T const* str, T const ch) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr T* strchr(T const* str, T const ch) noexcept {
     return *str == ch ? const_cast<T*>(str)
         : !*str       ? nullptr
                       : __UTL libc::compile_time::recursive::strchr(str + 1, ch);
 }
 
 template <typename T>
-__UTL_HIDE_FROM_ABI constexpr int strcmp(T const* left, T const* right) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr int strcmp(T const* left, T const* right) noexcept {
     return !*left && !*right ? 0
         : (*left < *right)   ? -1
         : (*right < *left)   ? 1
@@ -78,7 +79,7 @@ __UTL_HIDE_FROM_ABI constexpr int strcmp(T const* left, T const* right) noexcept
 }
 
 template <typename T>
-__UTL_HIDE_FROM_ABI constexpr int strncmp(
+__UTL_HIDE_FROM_ABI inline constexpr int strncmp(
     T const* left, T const* right, element_count_t len) noexcept {
     return len == 0 || (!*left && !*right) ? 0
         : (*left < *right)                 ? -1
@@ -88,7 +89,8 @@ __UTL_HIDE_FROM_ABI constexpr int strncmp(
 }
 
 template <typename T>
-__UTL_HIDE_FROM_ABI constexpr T* strnchr(T const* str, T const ch, element_count_t len) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr T* strnchr(
+    T const* str, T const ch, element_count_t len) noexcept {
     return len == 0    ? nullptr
         : (*str == ch) ? const_cast<T*>(str)
         : (!*str)      ? nullptr
@@ -96,7 +98,7 @@ __UTL_HIDE_FROM_ABI constexpr T* strnchr(T const* str, T const ch, element_count
 }
 
 template <typename T>
-__UTL_HIDE_FROM_ABI constexpr T* strnset(
+__UTL_HIDE_FROM_ABI inline constexpr T* strnset(
     T* dst, T const val, element_count_t count, T* org) noexcept {
     return count == 0
         ? org
@@ -108,7 +110,8 @@ __UTL_HIDE_FROM_ABI constexpr T* strnset(
 
 template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_CONSTRAINT_CXX11(
     is_trivially_copyable<T>::value)>
-__UTL_HIDE_FROM_ABI constexpr T* memcpy(T* dst, T const* src, element_count_t count) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr T* memcpy(
+    T* dst, T const* src, element_count_t count) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_memcpy)
     return __builtin_memcpy(dst, src, byte_count<T>(count)), dst;
 #else
@@ -119,7 +122,8 @@ __UTL_HIDE_FROM_ABI constexpr T* memcpy(T* dst, T const* src, element_count_t co
 template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_CONSTRAINT_CXX11(
     is_trivially_copyable<T>::value && exact_size<T, 1>::value)>
 UTL_CONSTRAINT_CXX20(exact_size<T, 1>)
-__UTL_HIDE_FROM_ABI constexpr T* memset(T* dst, T const src, element_count_t count) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr T* memset(
+    T* dst, T const src, element_count_t count) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_memset)
     return __builtin_memset(dst, as_byte(src), byte_count<T>(count)), dst;
 #else
@@ -129,7 +133,8 @@ __UTL_HIDE_FROM_ABI constexpr T* memset(T* dst, T const src, element_count_t cou
 
 template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_CONSTRAINT_CXX11(
     is_trivially_copyable<T>::value)>
-__UTL_HIDE_FROM_ABI constexpr T* memmove(T* dst, T const* src, element_count_t count) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr T* memmove(
+    T* dst, T const* src, element_count_t count) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_memmove)
     return __builtin_memmove(dst, src, byte_count<T>(count)), dst;
 #else
@@ -138,7 +143,7 @@ __UTL_HIDE_FROM_ABI constexpr T* memmove(T* dst, T const* src, element_count_t c
 }
 
 template <typename T, typename U>
-__UTL_HIDE_FROM_ABI constexpr int memcmp(
+__UTL_HIDE_FROM_ABI inline constexpr int memcmp(
     T const* left, U const* right, element_count_t count) noexcept {
     static_assert(is_trivially_lexicographically_comparable<T, U>::value,
         "Types must be lexicographically comparable");
@@ -149,7 +154,8 @@ __UTL_HIDE_FROM_ABI constexpr int memcmp(
 #endif
 }
 
-__UTL_HIDE_FROM_ABI constexpr char* memchr(char const* str, char value, size_t bytes) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr char* memchr(
+    char const* str, char value, size_t bytes) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_char_memchr)
     return __builtin_char_memchr(str, (int)value, bytes);
 #else
@@ -159,11 +165,11 @@ __UTL_HIDE_FROM_ABI constexpr char* memchr(char const* str, char value, size_t b
 
 template <UTL_CONCEPT_CXX20(exact_size<1>) T, UTL_CONCEPT_CXX20(
     exact_size<1>) U UTL_CONSTRAINT_CXX11(exact_size<T, 1>::value && exact_size<U, 1>::value)>
-__UTL_HIDE_FROM_ABI constexpr T* memchr(T const* str, U value, size_t bytes) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr T* memchr(T const* str, U value, size_t bytes) noexcept {
     return recursive::memchr(str, as_byte(value), bytes);
 }
 
-__UTL_HIDE_FROM_ABI constexpr size_t strlen(char const* str) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr size_t strlen(char const* str) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_strlen)
     return __builtin_strlen(str);
 #else
@@ -171,7 +177,7 @@ __UTL_HIDE_FROM_ABI constexpr size_t strlen(char const* str) noexcept {
 #endif
 }
 
-__UTL_HIDE_FROM_ABI constexpr size_t strlen(wchar_t const* str) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr size_t strlen(wchar_t const* str) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_wcslen)
     return __builtin_wcslen(str);
 #else
@@ -180,11 +186,11 @@ __UTL_HIDE_FROM_ABI constexpr size_t strlen(wchar_t const* str) noexcept {
 }
 
 template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
-__UTL_HIDE_FROM_ABI constexpr size_t strlen(T const* str) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr size_t strlen(T const* str) noexcept {
     return recursive::strlen(str);
 }
 
-__UTL_HIDE_FROM_ABI constexpr char* strchr(char const* str, char const ch) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr char* strchr(char const* str, char const ch) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_strchr)
     return __builtin_strchr(str, (int)ch);
 #else
@@ -192,7 +198,8 @@ __UTL_HIDE_FROM_ABI constexpr char* strchr(char const* str, char const ch) noexc
 #endif
 }
 
-__UTL_HIDE_FROM_ABI constexpr wchar_t* strchr(wchar_t const* str, wchar_t const ch) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr wchar_t* strchr(
+    wchar_t const* str, wchar_t const ch) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_wcschr)
     return __builtin_wcschr(str, ch);
 #else
@@ -201,11 +208,11 @@ __UTL_HIDE_FROM_ABI constexpr wchar_t* strchr(wchar_t const* str, wchar_t const 
 }
 
 template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
-__UTL_HIDE_FROM_ABI constexpr T* strchr(T const* str, T const ch) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr T* strchr(T const* str, T const ch) noexcept {
     return recursive::strchr(str, ch);
 }
 
-__UTL_HIDE_FROM_ABI constexpr int strcmp(char const* left, char const* right) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr int strcmp(char const* left, char const* right) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_strcmp)
     return __builtin_strcmp(left, right);
 #else
@@ -213,7 +220,8 @@ __UTL_HIDE_FROM_ABI constexpr int strcmp(char const* left, char const* right) no
 #endif
 }
 
-__UTL_HIDE_FROM_ABI constexpr int strcmp(wchar_t const* left, wchar_t const* right) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr int strcmp(
+    wchar_t const* left, wchar_t const* right) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_wcscmp)
     return __builtin_wcscmp(left, right);
 #else
@@ -222,11 +230,11 @@ __UTL_HIDE_FROM_ABI constexpr int strcmp(wchar_t const* left, wchar_t const* rig
 }
 
 template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
-__UTL_HIDE_FROM_ABI constexpr int strcmp(T const* left, T const* right) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr int strcmp(T const* left, T const* right) noexcept {
     return recursive::strcmp(left, right);
 }
 
-__UTL_HIDE_FROM_ABI constexpr int strncmp(
+__UTL_HIDE_FROM_ABI inline constexpr int strncmp(
     char const* left, char const* right, element_count_t len) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_strncmp)
     return __builtin_strncmp(left, right, (size_t)len);
@@ -235,7 +243,7 @@ __UTL_HIDE_FROM_ABI constexpr int strncmp(
 #endif
 }
 
-__UTL_HIDE_FROM_ABI constexpr int strncmp(
+__UTL_HIDE_FROM_ABI inline constexpr int strncmp(
     wchar_t const* left, wchar_t const* right, element_count_t len) noexcept {
 #if UTL_HAS_BUILTIN(__builtin_wcsncmp)
     return __builtin_wcsncmp(left, right, (size_t)len);
@@ -245,18 +253,19 @@ __UTL_HIDE_FROM_ABI constexpr int strncmp(
 }
 
 template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
-__UTL_HIDE_FROM_ABI constexpr int strncmp(
+__UTL_HIDE_FROM_ABI inline constexpr int strncmp(
     T const* left, T const* right, element_count_t len) noexcept {
     return recursive::strncmp(left, right, len);
 }
 
 template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
-__UTL_HIDE_FROM_ABI constexpr T* strnset(T* dst, T const val, element_count_t max_len) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr T* strnset(
+    T* dst, T const val, element_count_t max_len) noexcept {
     return recursive::strnset(dst, val, max_len, dst);
 }
 
 template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
-__UTL_HIDE_FROM_ABI constexpr T* strnchr(
+__UTL_HIDE_FROM_ABI inline constexpr T* strnchr(
     T const* str, T const val, element_count_t max_len) noexcept {
     return recursive::strnchr(str, val, max_len);
 }

--- a/src/utl/public/utl/string/utl_libc_compile_time.h
+++ b/src/utl/public/utl/string/utl_libc_compile_time.h
@@ -12,6 +12,11 @@ namespace libc {
 namespace compile_time {
 namespace recursive {
 
+/**
+ * Non-pure, multi statement functions are _not_ constexpr in C++11,
+ * the recursive implementation is only used to suppress warnings
+ * about C++14 extensions
+ */
 template <typename T>
 __UTL_HIDE_FROM_ABI inline constexpr T* memcpy(
     T* dst, T const* src, element_count_t count, T* org) noexcept {

--- a/src/utl/public/utl/string/utl_libc_runtime.h
+++ b/src/utl/public/utl/string/utl_libc_runtime.h
@@ -18,18 +18,11 @@ UTL_NAMESPACE_BEGIN
 namespace libc {
 namespace runtime {
 namespace standard {
-#if UTL_COMPILER_MSVC
-#  pragma intrinsic(memcpy)
-#endif
 
 template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_CONSTRAINT_CXX11(is_trivially_copyable<T>::value)>
 UTL_ATTRIBUTES(ALWAYS_INLINE,_HIDE_FROM_ABI) inline T* memcpy(
     T* UTL_RESTRICT dst, T const* UTL_RESTRICT src, element_count_t count) noexcept {
-#if UTL_HAS_BUILTIN(__builtin_memcpy)
-    return (T*)__builtin_memcpy(dst, src, byte_count<T>(count));
-#else
-    return (T*)::memcpy(dst, src, byte_count<T>(count));
-#endif
+    return (T*)__UTL_MEMCPY(dst, src, byte_count<T>(count));
 }
 
 template <UTL_CONCEPT_CXX20(trivially_copyable) T UTL_CONSTRAINT_CXX11(is_trivially_copyable<T>::value)>
@@ -68,19 +61,11 @@ UTL_ATTRIBUTES(LIBC_INLINE_PURE) inline T* memchr(T const* ptr, U value, size_t 
 #endif
 }
 
-#if UTL_COMPILER_MSVC
-#  pragma intrinsic(memcmp)
-#endif
-
 template <typename T, typename U>
 UTL_ATTRIBUTES(LIBC_INLINE_PURE) inline int memcmp(T const* lhs, U const* rhs, element_count_t count) noexcept {
     static_assert(is_trivially_lexicographically_comparable<T, U>::value,
         "Types must be lexicographically comparable");
-#if UTL_HAS_BUILTIN(__builtin_char_memchr)
-    return __builtin_memcmp(lhs, rhs, byte_count<T>(count));
-#else
-    return ::memcmp(lhs, rhs, byte_count<T>(count));
-#endif
+    return __UTL_MEMCMP(lhs, rhs, byte_count<T>(count));
 }
 
 #if UTL_COMPILER_MSVC

--- a/src/utl/public/utl/string/utl_string_details.h
+++ b/src/utl/public/utl/string/utl_string_details.h
@@ -30,40 +30,43 @@ namespace string {
 UTL_INLINE_CXX17 constexpr size_t npos = numeric::maximum<size_t>::value;
 
 template <UTL_CONCEPT_CXX20(string_char) T UTL_CONSTRAINT_CXX11(is_string_char<T>::value)>
-UTL_ATTRIBUTE(CONST_FUNCTION) constexpr size_t to_index(T const* base, T const* ptr) noexcept {
+UTL_ATTRIBUTE(CONST_FUNCTION) inline constexpr size_t to_index(T const* base, T const* ptr) noexcept {
     return ptr ? ptr - base : __UTL details::string::npos;
 }
 
-UTL_ATTRIBUTE(CONST_FUNCTION) constexpr int negative_if_true(bool b) noexcept {
+UTL_ATTRIBUTE(CONST_FUNCTION) inline constexpr int negative_if_true(bool b) noexcept {
     return -+b | 1;
 }
 
-UTL_ATTRIBUTE(CONST_FUNCTION) constexpr int other_if_zero(int x, int other) noexcept {
+UTL_ATTRIBUTE(CONST_FUNCTION) inline constexpr int other_if_zero(int x, int other) noexcept {
     return x ? x : other;
 }
 
-UTL_ATTRIBUTE(CONST_FUNCTION) constexpr int value_if_true(bool b, int value) noexcept {
+UTL_ATTRIBUTE(CONST_FUNCTION) inline constexpr int value_if_true(bool b, int value) noexcept {
     return b ? value : 0;
 }
 
-UTL_ATTRIBUTE(CONST_FUNCTION) constexpr int compare_size(int strcmp, size_t left, size_t right) noexcept {
-    return other_if_zero(strcmp, value_if_true(left != right, negative_if_true(left < right)));
+UTL_ATTRIBUTE(CONST_FUNCTION) inline constexpr int compare_size(
+    int result, size_t left, size_t right) noexcept {
+    return other_if_zero(result, value_if_true(left != right, negative_if_true(left < right)));
 }
 
 namespace compile_time {
 
 template <typename T>
-__UTL_HIDE_FROM_ABI constexpr T* rfind_char(T const* str, T const ch, T const* org) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr T const* rfind_char(
+    T const* str, T const ch, T const* org) noexcept {
     return *str == ch ? const_cast<T*>(str) : str == org ? nullptr : rfind_char(str - 1, ch, org);
 }
 
 template <typename T>
-__UTL_HIDE_FROM_ABI constexpr T* rfind_char(T const* str, T const ch, size_t len) noexcept {
+__UTL_HIDE_FROM_ABI inline constexpr T const* rfind_char(
+    T const* str, T const ch, size_t len) noexcept {
     return rfind_char(str + len - 1, ch, str);
 }
 
 template <typename Traits, typename T>
-__UTL_HIDE_FROM_ABI constexpr T* find_first_of(
+__UTL_HIDE_FROM_ABI inline constexpr T const* find_first_of(
     T const* str, size_t len, T const* chars, size_t chars_count) noexcept {
     return len == 0 ? nullptr
         : Traits::find(chars, chars_count, *str)
@@ -72,7 +75,7 @@ __UTL_HIDE_FROM_ABI constexpr T* find_first_of(
 }
 
 template <typename Traits, typename T>
-__UTL_HIDE_FROM_ABI constexpr T* find_first_not_of(
+__UTL_HIDE_FROM_ABI inline constexpr T const* find_first_not_of(
     T const* str, size_t len, T const* chars, size_t chars_count) noexcept {
     return len == 0 ? nullptr
         : !Traits::find(chars, chars_count, *str)
@@ -81,21 +84,21 @@ __UTL_HIDE_FROM_ABI constexpr T* find_first_not_of(
 }
 
 template <typename Traits, typename T>
-__UTL_HIDE_FROM_ABI constexpr T* find_last_of(
+__UTL_HIDE_FROM_ABI inline constexpr T const* find_last_of(
     T const* str, T const* current, T const* chars, size_t chars_count) noexcept {
     return current < str ? nullptr
         : Traits::find(chars, chars_count, *current)
         ? current
-        : find_first_of<Traits>(str, current - 1, chars, chars_count);
+        : find_last_of<Traits>(str, current - 1, chars, chars_count);
 }
 
 template <typename Traits, typename T>
-__UTL_HIDE_FROM_ABI constexpr T* find_last_not_of(
+__UTL_HIDE_FROM_ABI inline constexpr T const* find_last_not_of(
     T const* str, T const* current, T const* chars, size_t chars_count) noexcept {
     return current < str ? nullptr
         : !Traits::find(chars, chars_count, *current)
         ? current
-        : find_first_of<Traits>(str, current - 1, chars, chars_count);
+        : find_last_not_of<Traits>(str, current - 1, chars, chars_count);
 }
 
 template <typename CharType, typename Traits>
@@ -105,45 +108,46 @@ class substring_search {
     using value_type = CharType;
 
 public:
-    __UTL_HIDE_FROM_ABI constexpr substring_search(const_pointer substr, size_type len) noexcept
+    __UTL_HIDE_FROM_ABI inline constexpr substring_search(
+        const_pointer substr, size_type len) noexcept
         : substr_(substr)
         , len_(len) {}
 
-    __UTL_HIDE_FROM_ABI constexpr const_pointer find_for(
+    __UTL_HIDE_FROM_ABI inline constexpr const_pointer find_for(
         const_pointer str, size_type len) const noexcept {
         return len_ == 0 ? str : find_for_impl(str, len);
     }
 
 private:
-    __UTL_HIDE_FROM_ABI constexpr const_pointer find_for_impl(
+    __UTL_HIDE_FROM_ABI inline constexpr const_pointer find_for_impl(
         const_pointer str, size_type len) const noexcept {
         return find_for_impl_comparing(str, len, find_front(str, len));
     }
 
-    __UTL_HIDE_FROM_ABI constexpr const_pointer find_for_impl_comparing(
+    __UTL_HIDE_FROM_ABI inline constexpr const_pointer find_for_impl_comparing(
         const_pointer str, size_type len, const_pointer found) const noexcept {
         return found == nullptr   ? nullptr
             : compare_with(found) ? found
                                   : find_for_impl_tail(found + 1, len, str);
     }
 
-    __UTL_HIDE_FROM_ABI constexpr const_pointer find_for_impl_tail(
+    __UTL_HIDE_FROM_ABI inline constexpr const_pointer find_for_impl_tail(
         const_pointer found, size_type len, const_pointer str) const noexcept {
         return find_for_impl(found, len - (found - str));
     }
 
-    __UTL_HIDE_FROM_ABI constexpr const_pointer find_front(
+    __UTL_HIDE_FROM_ABI inline constexpr const_pointer find_front(
         const_pointer str, size_type len) const noexcept {
         return Traits::find(str, __UTL sub_sat(len + 1, size()), front());
     }
 
-    __UTL_HIDE_FROM_ABI constexpr bool compare_with(const_pointer found) const noexcept {
+    __UTL_HIDE_FROM_ABI inline constexpr bool compare_with(const_pointer found) const noexcept {
         return Traits::compare(found, data(), size()) == 0;
     }
 
-    __UTL_HIDE_FROM_ABI constexpr value_type front() const { return *substr_; }
-    __UTL_HIDE_FROM_ABI constexpr size_type size() const { return len_; }
-    __UTL_HIDE_FROM_ABI constexpr const_pointer data() const { return substr_; }
+    __UTL_HIDE_FROM_ABI inline constexpr value_type front() const { return *substr_; }
+    __UTL_HIDE_FROM_ABI inline constexpr size_type size() const { return len_; }
+    __UTL_HIDE_FROM_ABI inline constexpr const_pointer data() const { return substr_; }
 
     const_pointer substr_;
     size_type len_;
@@ -156,52 +160,55 @@ class substring_rsearch {
     using value_type = CharType;
 
 public:
-    __UTL_HIDE_FROM_ABI constexpr substring_rsearch(const_pointer substr, size_type len) noexcept
+    __UTL_HIDE_FROM_ABI inline constexpr substring_rsearch(
+        const_pointer substr, size_type len) noexcept
         : substr_(substr)
         , len_(len) {}
 
-    __UTL_HIDE_FROM_ABI constexpr const_pointer find_for(
+    __UTL_HIDE_FROM_ABI inline constexpr const_pointer find_for(
         const_pointer str, size_type len) const noexcept {
         return len_ == 0 ? str : find_for_impl(str, len);
     }
 
 private:
-    __UTL_HIDE_FROM_ABI constexpr const_pointer find_for_impl(
+    __UTL_HIDE_FROM_ABI inline constexpr const_pointer find_for_impl(
         const_pointer str, size_type len) const noexcept {
         return find_for_impl(str, len, min_len(len));
     }
 
-    __UTL_HIDE_FROM_ABI constexpr const_pointer find_for_impl(
+    __UTL_HIDE_FROM_ABI inline constexpr const_pointer find_for_impl(
         const_pointer str, size_type len, size_type min) const noexcept {
         return find_for_impl_tail(str, len, find_back(str, len, min), min);
     }
 
-    __UTL_HIDE_FROM_ABI constexpr const_pointer find_for_impl_tail(
+    __UTL_HIDE_FROM_ABI inline constexpr const_pointer find_for_impl_tail(
         const_pointer str, size_type len, const_pointer found, size_type min) const noexcept {
         return found == nullptr ? nullptr : find_for_impl_tail(str, len, found, found - min);
     }
 
-    __UTL_HIDE_FROM_ABI constexpr const_pointer find_for_impl_tail(
+    __UTL_HIDE_FROM_ABI inline constexpr const_pointer find_for_impl_tail(
         const_pointer str, size_type len, const_pointer found, const_pointer begin) const noexcept {
         return compare_with(begin) ? begin : find_for_impl(str, found - str);
     }
 
-    __UTL_HIDE_FROM_ABI constexpr const_pointer find_back(
+    __UTL_HIDE_FROM_ABI inline constexpr const_pointer find_back(
         const_pointer str, size_type len, size_type min) const noexcept {
         return rfind_char(str + min, back(), __UTL sub_sat(len, min));
     }
 
-    __UTL_HIDE_FROM_ABI constexpr bool compare_with(const_pointer begin) const {
+    __UTL_HIDE_FROM_ABI inline constexpr bool compare_with(const_pointer begin) const {
         return Traits::compare(begin, data(), size()) == 0;
     }
 
-    __UTL_HIDE_FROM_ABI constexpr size_type min_len(size_type len) const noexcept {
+    __UTL_HIDE_FROM_ABI inline constexpr size_type min_len(size_type len) const noexcept {
         return __UTL numeric::min(len_ - 1, len);
     }
 
-    __UTL_HIDE_FROM_ABI constexpr value_type back() const noexcept { return substr_[len_ - 1]; }
-    __UTL_HIDE_FROM_ABI constexpr size_type size() const noexcept { return len_; }
-    __UTL_HIDE_FROM_ABI constexpr const_pointer data() const noexcept { return substr_; }
+    __UTL_HIDE_FROM_ABI inline constexpr value_type back() const noexcept {
+        return substr_[len_ - 1];
+    }
+    __UTL_HIDE_FROM_ABI inline constexpr size_type size() const noexcept { return len_; }
+    __UTL_HIDE_FROM_ABI inline constexpr const_pointer data() const noexcept { return substr_; }
 
     const_pointer substr_;
     size_type len_;
@@ -223,7 +230,7 @@ UTL_ATTRIBUTES(NODISCARD, _HIDE_FROM_ABI) constexpr CharType const* rsearch_subs
 
 namespace runtime {
 template <typename T>
-UTL_ATTRIBUTE(INLINE_PURE_FUNCTION) inline T* rfind_char(T const* str, T const ch, size_t len) noexcept {
+UTL_ATTRIBUTE(INLINE_PURE_FUNCTION) inline T const* rfind_char(T const* str, T const ch, size_t len) noexcept {
     for (auto p = str + len - 1; p >= str; --p) {
         if (*p == ch) {
             return const_cast<T*>(str);
@@ -234,7 +241,7 @@ UTL_ATTRIBUTE(INLINE_PURE_FUNCTION) inline T* rfind_char(T const* str, T const c
 }
 
 template <typename Traits, typename T>
-UTL_ATTRIBUTE(INLINE_PURE_FUNCTION) inline T* find_first_of(
+UTL_ATTRIBUTE(INLINE_PURE_FUNCTION) inline T const* find_first_of(
     T const* str, size_t len, T const* chars, size_t chars_count) noexcept {
     while (len) {
         if (Traits::find(chars, chars_count, *str) != nullptr) {
@@ -249,7 +256,7 @@ UTL_ATTRIBUTE(INLINE_PURE_FUNCTION) inline T* find_first_of(
 }
 
 template <typename Traits, typename T>
-UTL_ATTRIBUTE(INLINE_PURE_FUNCTION) inline T* find_first_not_of(
+UTL_ATTRIBUTE(INLINE_PURE_FUNCTION) inline T const* find_first_not_of(
     T const* str, size_t len, T const* chars, size_t chars_count) noexcept {
     while (len) {
         if (Traits::find(chars, chars_count, *str) == nullptr) {
@@ -264,7 +271,7 @@ UTL_ATTRIBUTE(INLINE_PURE_FUNCTION) inline T* find_first_not_of(
 }
 
 template <typename Traits, typename T>
-UTL_ATTRIBUTE(INLINE_PURE_FUNCTION) inline T* find_last_of(
+UTL_ATTRIBUTE(INLINE_PURE_FUNCTION) inline T const* find_last_of(
     T const* str, T const* current, T const* chars, size_t chars_count) noexcept {
     while (current >= str) {
         if (Traits::find(chars, chars_count, *current) != nullptr) {
@@ -278,7 +285,7 @@ UTL_ATTRIBUTE(INLINE_PURE_FUNCTION) inline T* find_last_of(
 }
 
 template <typename Traits, typename T>
-UTL_ATTRIBUTE(INLINE_PURE_FUNCTION) inline T* find_last_not_of(
+UTL_ATTRIBUTE(INLINE_PURE_FUNCTION) inline T const* find_last_not_of(
     T const* str, T const* current, T const* chars, size_t chars_count) noexcept {
     while (current >= str) {
         if (Traits::find(chars, chars_count, *current) == nullptr) {
@@ -292,7 +299,7 @@ UTL_ATTRIBUTE(INLINE_PURE_FUNCTION) inline T* find_last_not_of(
 }
 
 template <typename Traits, typename CharType>
-UTL_ATTRIBUTE(PURE_FUNCTION) CharType const* search_substring(
+UTL_ATTRIBUTE(PURE_FUNCTION) inline CharType const* search_substring(
     CharType const* l, size_t l_count, CharType const* r, size_t r_count) noexcept {
     if (r_count == 0) {
         return l;
@@ -315,7 +322,7 @@ UTL_ATTRIBUTE(PURE_FUNCTION) CharType const* search_substring(
 }
 
 template <typename Traits, typename CharType>
-UTL_ATTRIBUTE(PURE_FUNCTION) CharType const* rsearch_substring(
+UTL_ATTRIBUTE(PURE_FUNCTION) inline CharType const* rsearch_substring(
     CharType const* l, size_t l_count, CharType const* r, size_t r_count) noexcept {
     if (r_count == 0) {
         return l;
@@ -339,7 +346,7 @@ UTL_ATTRIBUTE(PURE_FUNCTION) CharType const* rsearch_substring(
 } // namespace runtime
 
 template <typename Traits, typename CharType>
-UTL_ATTRIBUTE(PURE_FUNCTION) constexpr CharType const* search_substring(
+UTL_ATTRIBUTE(PURE_FUNCTION) inline constexpr CharType const* search_substring(
     CharType const* l, size_t l_count, CharType const* r, size_t r_count) noexcept {
     return UTL_CONSTANT_P(l == r && l_count == r_count)
         ? compile_time::search_substring<Traits>(l, l_count, r, r_count)
@@ -347,7 +354,7 @@ UTL_ATTRIBUTE(PURE_FUNCTION) constexpr CharType const* search_substring(
 }
 
 template <typename Traits, typename CharType>
-UTL_ATTRIBUTE(PURE_FUNCTION) constexpr CharType const* rsearch_substring(
+UTL_ATTRIBUTE(PURE_FUNCTION) inline constexpr CharType const* rsearch_substring(
     CharType const* l, size_t l_count, CharType const* r, size_t r_count) noexcept {
     return UTL_CONSTANT_P(l == r && l_count == r_count)
         ? compile_time::rsearch_substring<Traits>(l, l_count, r, r_count)
@@ -355,52 +362,52 @@ UTL_ATTRIBUTE(PURE_FUNCTION) constexpr CharType const* rsearch_substring(
 }
 
 template <typename Traits, typename CharType>
-UTL_ATTRIBUTE(PURE_FUNCTION) constexpr CharType const* rfind_char(
+UTL_ATTRIBUTE(PURE_FUNCTION) inline constexpr CharType const* rfind_char(
     CharType const* str, size_t length, CharType const ch) noexcept {
     return UTL_CONSTANT_P(*str == ch) ? compile_time::rfind_char<Traits>(str, ch, length)
                                       : runtime::rfind_char<Traits>(str, ch, length);
 }
 
 template <typename Traits, typename CharType>
-UTL_ATTRIBUTE(PURE_FUNCTION) constexpr size_t find(
+UTL_ATTRIBUTE(PURE_FUNCTION) inline constexpr size_t find(
     CharType const* l, size_t l_count, CharType const* r, size_t r_count) noexcept {
     return to_index(l, search_substring<Traits>(l, l_count, r, r_count));
 }
 
 template <typename Traits, typename CharType>
-UTL_ATTRIBUTE(PURE_FUNCTION) constexpr size_t find(
+UTL_ATTRIBUTE(PURE_FUNCTION) inline constexpr size_t find(
     CharType const* l, size_t l_count, CharType const* r, size_t r_count, size_t l_pos) noexcept {
     return find<Traits>(
         l + __UTL numeric::min(l_pos, l_count), __UTL sub_sat(l_count, l_pos), r, r_count);
 }
 
 template <typename Traits, typename CharType>
-UTL_ATTRIBUTE(PURE_FUNCTION) constexpr size_t find(
+UTL_ATTRIBUTE(PURE_FUNCTION) inline constexpr size_t find(
     CharType const* str, size_t length, CharType const ch, size_t pos) noexcept {
     return to_index(
         str, Traits::find(str + __UTL numeric::min(length, pos), __UTL sub_sat(length, pos), ch));
 }
 
 template <typename Traits, typename CharType>
-UTL_ATTRIBUTE(PURE_FUNCTION) constexpr size_t find(
+UTL_ATTRIBUTE(PURE_FUNCTION) inline constexpr size_t find(
     CharType const* str, size_t length, CharType const ch) noexcept {
     return to_index(str, Traits::find(str, length, ch));
 }
 
 template <typename CharType>
-UTL_ATTRIBUTE(PURE_FUNCTION) constexpr size_t rfind(
+UTL_ATTRIBUTE(PURE_FUNCTION) inline constexpr size_t rfind(
     CharType const* str, size_t length, CharType const ch) noexcept {
     return to_index(str, rfind_char(str, length, ch));
 }
 
 template <typename Traits, typename CharType>
-UTL_ATTRIBUTE(PURE_FUNCTION) constexpr size_t rfind(
+UTL_ATTRIBUTE(PURE_FUNCTION) inline constexpr size_t rfind(
     CharType const* str, size_t length, CharType const ch, size_t pos) noexcept {
     return rfind(str, __UTL numeric::min(length, __UTL add_sat<size_t>(pos, 1)), ch);
 }
 
 template <typename Traits, typename CharType>
-UTL_ATTRIBUTE(PURE_FUNCTION) constexpr size_t rfind(
+UTL_ATTRIBUTE(PURE_FUNCTION) inline constexpr size_t rfind(
     CharType const* l, size_t l_count, CharType const* r, size_t r_count, size_t l_pos) noexcept {
     return to_index(l,
         rsearch_substring<Traits>(
@@ -408,7 +415,7 @@ UTL_ATTRIBUTE(PURE_FUNCTION) constexpr size_t rfind(
 }
 
 template <typename Traits, typename T>
-UTL_ATTRIBUTE(PURE_FUNCTION) constexpr size_t find_first_of(
+UTL_ATTRIBUTE(PURE_FUNCTION) inline constexpr size_t find_first_of(
     T const* str, size_t len, T const* chars, size_t chars_count) noexcept {
     return to_index(str,
         UTL_CONSTANT_P((str != chars) + len + chars_count)
@@ -417,26 +424,27 @@ UTL_ATTRIBUTE(PURE_FUNCTION) constexpr size_t find_first_of(
 }
 
 template <typename Traits, typename T>
-UTL_ATTRIBUTE(PURE_FUNCTION) constexpr size_t find_first_of(
+UTL_ATTRIBUTE(PURE_FUNCTION) inline constexpr size_t find_first_of(
     T const* str, size_t len, T const* chars, size_t chars_count, size_t pos) noexcept {
     return find_first_of<Traits>(
         str + __UTL numeric::min(pos, len), __UTL sub_sat(len, pos), chars, chars_count);
 }
 
 template <typename Traits, typename T>
-UTL_ATTRIBUTE(PURE_FUNCTION) constexpr size_t find_first_of(
+UTL_ATTRIBUTE(PURE_FUNCTION) inline constexpr size_t find_first_of(
     T const* str, size_t len, T const ch, size_t pos) noexcept {
     return to_index(
         str, Traits::find(str + __UTL numeric::min(pos, len), __UTL sub_sat(len, pos), ch));
 }
 
 template <typename Traits, typename T>
-UTL_ATTRIBUTE(PURE_FUNCTION) constexpr size_t find_first_of(T const* str, size_t len, T const ch) noexcept {
+UTL_ATTRIBUTE(PURE_FUNCTION) inline constexpr size_t find_first_of(
+    T const* str, size_t len, T const ch) noexcept {
     return to_index(str, Traits::find(str, len, ch));
 }
 
 template <typename Traits, typename T>
-UTL_ATTRIBUTE(PURE_FUNCTION) constexpr size_t find_first_not_of(
+UTL_ATTRIBUTE(PURE_FUNCTION) inline constexpr size_t find_first_not_of(
     T const* str, size_t len, T const* chars, size_t chars_count) noexcept {
     return to_index(str,
         UTL_CONSTANT_P((str != chars) + len + chars_count)
@@ -445,14 +453,14 @@ UTL_ATTRIBUTE(PURE_FUNCTION) constexpr size_t find_first_not_of(
 }
 
 template <typename Traits, typename T>
-UTL_ATTRIBUTE(PURE_FUNCTION) constexpr size_t find_first_not_of(
+UTL_ATTRIBUTE(PURE_FUNCTION) inline constexpr size_t find_first_not_of(
     T const* str, size_t len, T const* chars, size_t chars_count, size_t pos) noexcept {
     return find_first_not_of<Traits>(
         str + __UTL numeric::min(pos, len), __UTL sub_sat(len, pos), chars, chars_count);
 }
 
 template <typename Traits, typename T>
-UTL_ATTRIBUTE(PURE_FUNCTION) constexpr size_t find_last_of(
+UTL_ATTRIBUTE(PURE_FUNCTION) inline constexpr size_t find_last_of(
     T const* str, size_t len, T const* chars, size_t chars_count) noexcept {
     return to_index(str,
         UTL_CONSTANT_P((str != chars) + len + chars_count)
@@ -461,13 +469,13 @@ UTL_ATTRIBUTE(PURE_FUNCTION) constexpr size_t find_last_of(
 }
 
 template <typename Traits, typename T>
-UTL_ATTRIBUTE(PURE_FUNCTION) constexpr size_t find_last_of(
+UTL_ATTRIBUTE(PURE_FUNCTION) inline constexpr size_t find_last_of(
     T const* str, size_t len, T const* chars, size_t chars_count, size_t pos) noexcept {
     return find_last_of<Traits>(str, __UTL numeric::min(len, pos), chars, chars_count);
 }
 
 template <typename Traits, typename T>
-UTL_ATTRIBUTE(PURE_FUNCTION) constexpr size_t find_last_not_of(
+UTL_ATTRIBUTE(PURE_FUNCTION) inline constexpr size_t find_last_not_of(
     T const* str, size_t len, T const* chars, size_t chars_count) noexcept {
     return to_index(str,
         UTL_CONSTANT_P((str != chars) + len + chars_count)
@@ -476,14 +484,14 @@ UTL_ATTRIBUTE(PURE_FUNCTION) constexpr size_t find_last_not_of(
 }
 
 template <typename Traits, typename T>
-UTL_ATTRIBUTE(PURE_FUNCTION) constexpr size_t find_last_not_of(
+UTL_ATTRIBUTE(PURE_FUNCTION) inline constexpr size_t find_last_not_of(
     T const* str, size_t len, T const* chars, size_t chars_count, size_t pos) noexcept {
     return find_last_not_of<Traits>(
         str, __UTL numeric::min(len, __UTL add_sat<size_t>(pos, 1)), chars, chars_count);
 }
 
 template <typename Traits, typename T>
-UTL_ATTRIBUTE(PURE_FUNCTION) constexpr int compare(
+UTL_ATTRIBUTE(PURE_FUNCTION) inline constexpr int compare(
     T const* left, size_t l_len, T const* right, size_t r_len) noexcept {
     return compare_size(
         Traits::compare(left, right, __UTL numeric::min(l_len, r_len)), l_len, r_len);

--- a/src/utl/public/utl/string/utl_string_utils.h
+++ b/src/utl/public/utl/string/utl_string_utils.h
@@ -263,7 +263,8 @@ __UTL_HIDE_FROM_ABI inline constexpr auto split(basic_string_view<CharType, Trai
     basic_string_view<CharType, Traits> str,
     F process) noexcept(UTL_TRAIT_is_nothrow_invocable(F, basic_string_view<CharType, Traits>))
     -> UTL_ENABLE_IF_CXX11(size_t, UTL_TRAIT_is_invocable(F, basic_string_view<CharType, Traits>)) {
-    return UTL_CONSTANT_P(str.data() != nullptr && delimiter.data() != nullptr)
+    return UTL_CONSTANT_P(
+               string_utils::compile_time::split_all(delimiter, str, __UTL move(process)))
         ? string_utils::compile_time::split_all(delimiter, str, __UTL move(process))
         : string_utils::runtime::split_all(delimiter, str, __UTL move(process));
 }
@@ -278,7 +279,8 @@ __UTL_HIDE_FROM_ABI inline constexpr auto split_while(basic_string_view<CharType
     F predicate) noexcept(UTL_TRAIT_is_nothrow_invocable(F, basic_string_view<CharType, Traits>) &&
     UTL_TRAIT_is_nothrow_boolean_testable(decltype(predicate(str))))
     -> UTL_ENABLE_IF_CXX11(size_t, UTL_TRAIT_is_boolean_testable(decltype(predicate(str)))) {
-    return UTL_CONSTANT_P(str.data() != nullptr && delimiter.data() != nullptr)
+    return UTL_CONSTANT_P(
+               string_utils::compile_time::split_while(delimiter, str, __UTL move(predicate)))
         ? string_utils::compile_time::split_while(delimiter, str, __UTL move(predicate))
         : string_utils::runtime::split_while(delimiter, str, __UTL move(predicate));
 }
@@ -289,7 +291,8 @@ __UTL_HIDE_FROM_ABI inline constexpr auto split(CharType delimiter,
     basic_string_view<CharType, Traits> str,
     F process) noexcept(UTL_TRAIT_is_nothrow_invocable(F, basic_string_view<CharType, Traits>))
     -> UTL_ENABLE_IF_CXX11(size_t, UTL_TRAIT_is_invocable(F, basic_string_view<CharType, Traits>)) {
-    return UTL_CONSTANT_P(str.data() != nullptr) && UTL_CONSTANT_P(delimiter)
+    return UTL_CONSTANT_P(
+               string_utils::compile_time::split_all(delimiter, str, __UTL move(process)))
         ? string_utils::compile_time::split_all(delimiter, str, __UTL move(process))
         : string_utils::runtime::split_all(delimiter, str, __UTL move(process));
 }
@@ -304,7 +307,8 @@ __UTL_HIDE_FROM_ABI inline constexpr auto split_while(CharType delimiter,
     F predicate) noexcept(UTL_TRAIT_is_nothrow_invocable(F, basic_string_view<CharType, Traits>) &&
     UTL_TRAIT_is_nothrow_boolean_testable(decltype(predicate(str))))
     -> UTL_ENABLE_IF_CXX11(size_t, UTL_TRAIT_is_boolean_testable(decltype(predicate(str)))) {
-    return UTL_CONSTANT_P(str.data() != nullptr) && UTL_CONSTANT_P(delimiter)
+    return UTL_CONSTANT_P(
+               string_utils::compile_time::split_while(delimiter, str, __UTL move(predicate)))
         ? string_utils::compile_time::split_while(delimiter, str, __UTL move(predicate))
         : string_utils::runtime::split_while(delimiter, str, __UTL move(predicate));
 }

--- a/src/utl/public/utl/string/utl_string_utils.h
+++ b/src/utl/public/utl/string/utl_string_utils.h
@@ -1,0 +1,347 @@
+// Copyright 2023-2024 Bryan Wong
+
+#pragma once
+
+#include "utl/utl_config.h"
+
+#include "utl/string/utl_string_fwd.h"
+
+#include "utl/numeric/utl_add_sat.h"
+#include "utl/numeric/utl_min.h"
+#include "utl/numeric/utl_sub_sat.h"
+#include "utl/type_traits/utl_invoke.h"
+#include "utl/type_traits/utl_is_boolean_testable.h"
+#include "utl/utility/utl_forward.h"
+#include "utl/utility/utl_move.h"
+
+#if UTL_CXX20
+#  include "utl/concepts/utl_boolean_testable.h"
+#  include "utl/concepts/utl_invocable.h"
+#else
+#  include "utl/type_traits/utl_enable_if.h"
+#endif
+
+UTL_NAMESPACE_BEGIN
+
+template <typename CharType, typename Traits = __UTL char_traits<CharType>>
+__UTL_HIDE_FROM_ABI inline constexpr basic_string_view<CharType, Traits> remove_prefix(
+    basic_string_view<CharType, Traits> str, size_t count) noexcept {
+    return str.substr(__UTL numeric::min(count, str.size()));
+}
+
+template <typename CharType, typename Traits = __UTL char_traits<CharType>>
+__UTL_HIDE_FROM_ABI inline constexpr basic_string_view<CharType, Traits> remove_suffix(
+    basic_string_view<CharType, Traits> str, size_t count) noexcept {
+    return str.substr(0, __UTL sub_sat(str.size(), count));
+}
+
+template <typename CharType, typename Traits = __UTL char_traits<CharType>>
+__UTL_HIDE_FROM_ABI inline constexpr basic_string_view<CharType, Traits> substring(
+    basic_string_view<CharType, Traits> str, size_t offset, size_t count) noexcept {
+    return offset = __UTL numeric::min(offset, str.size()),
+           count = __UTL numeric::min(str.size() - offset, count),
+           str.substr(offset, str.size() - offset - count);
+}
+
+namespace string_utils {
+namespace compile_time {
+template <typename CharType, typename Traits>
+struct split_all_impl {
+private:
+    using view_type = basic_string_view<CharType, Traits>;
+
+    template <typename F>
+    static inline constexpr size_t split2(
+        view_type delimiter, view_type str, F&& process, size_t count, size_t idx) noexcept {
+        return str.empty() ? count + 1
+                           : split(delimiter, str, __UTL forward<F>(process), count + 1);
+    }
+
+    template <typename F>
+    static inline constexpr size_t split1(
+        view_type delimiter, view_type str, F&& process, size_t count, size_t idx) noexcept {
+        return process(str.substr(0, idx)),
+               split2(delimiter, remove_prefix(str, __UTL add_sat(idx, delimiter.size())),
+                   __UTL forward<F>(process), count, idx);
+    }
+
+    template <typename F>
+    static inline constexpr size_t split(
+        view_type delimiter, view_type str, F&& process, size_t count = 0) noexcept {
+        return split1(delimiter, str, __UTL forward<F>(process), count, str.find(delimiter));
+    }
+
+    template <typename F>
+    static inline constexpr size_t split2(
+        CharType delimiter, view_type str, F&& process, size_t count, size_t idx) noexcept {
+        return str.empty() ? count + 1
+                           : split(delimiter, str, __UTL forward<F>(process), count + 1);
+    }
+
+    template <typename F>
+    static inline constexpr size_t split1(
+        CharType delimiter, view_type str, F&& process, size_t count, size_t idx) noexcept {
+        return process(str.substr(0, idx)),
+               split2(delimiter, remove_prefix(str, __UTL add_sat<size_t>(idx, 1)),
+                   __UTL forward<F>(process), count, idx);
+    }
+
+    template <typename F>
+    static inline constexpr size_t split(
+        CharType delimiter, view_type str, F&& process, size_t count = 0) noexcept {
+        return split1(delimiter, str, __UTL forward<F>(process), count, str.find(delimiter));
+    }
+
+public:
+    template <typename F>
+    __UTL_HIDE_FROM_ABI inline constexpr explicit split_all_impl(
+        view_type delimiter, view_type str, F&& process) noexcept
+        : count(split(delimiter, str, __UTL forward<F>(process))) {}
+
+    template <typename F>
+    __UTL_HIDE_FROM_ABI inline constexpr explicit split_all_impl(
+        CharType delimiter, view_type str, F&& process) noexcept
+        : count(split(delimiter, str, __UTL forward<F>(process))) {}
+
+    size_t count;
+};
+
+template <typename CharType, typename Traits, typename F>
+__UTL_HIDE_FROM_ABI inline constexpr size_t split_all(basic_string_view<CharType, Traits> delimiter,
+    basic_string_view<CharType, Traits> str, F&& process) {
+    return split_all_impl<CharType, Traits>(delimiter, str, __UTL forward<F>(process)).count;
+}
+
+template <typename CharType, typename Traits, typename F>
+__UTL_HIDE_FROM_ABI inline constexpr size_t split_all(
+    CharType delimiter, basic_string_view<CharType, Traits> str, F&& process) {
+    return split_all_impl<CharType, Traits>(delimiter, str, __UTL forward<F>(process)).count;
+}
+
+template <typename CharType, typename Traits>
+struct split_while_impl {
+private:
+    using view_type = basic_string_view<CharType, Traits>;
+
+    template <typename F>
+    static inline constexpr size_t split2(
+        view_type delimiter, view_type str, F&& predicate, size_t count, size_t idx) noexcept {
+        return str.empty() ? count + 1
+                           : split(delimiter, str, __UTL forward<F>(predicate), count + 1);
+    }
+
+    template <typename F>
+    static inline constexpr size_t split1(
+        view_type delimiter, view_type str, F&& predicate, size_t count, size_t idx) noexcept {
+        return !predicate(str.substr(0, idx))
+            ? count + 1
+            : split2(delimiter, remove_prefix(str, __UTL add_sat(idx, delimiter.size())),
+                  __UTL forward<F>(predicate), count, idx);
+    }
+
+    template <typename F>
+    static inline constexpr size_t split(
+        view_type delimiter, view_type str, F&& predicate, size_t count = 0) noexcept {
+        return split1(delimiter, str, __UTL forward<F>(predicate), count, str.find(delimiter));
+    }
+
+    template <typename F>
+    static inline constexpr size_t split2(
+        CharType delimiter, view_type str, F&& predicate, size_t count, size_t idx) noexcept {
+        return str.empty() ? count + 1
+                           : split(delimiter, str, __UTL forward<F>(predicate), count + 1);
+    }
+
+    template <typename F>
+    static inline constexpr size_t split1(
+        CharType delimiter, view_type str, F&& predicate, size_t count, size_t idx) noexcept {
+        return !predicate(str.substr(0, idx))
+            ? count + 1
+            : split2(delimiter, remove_prefix(str, __UTL add_sat<size_t>(idx, 1)),
+                  __UTL forward<F>(predicate), count, idx);
+    }
+
+    template <typename F>
+    static inline constexpr size_t split(
+        CharType delimiter, view_type str, F&& predicate, size_t count = 0) noexcept {
+        return split1(delimiter, str, __UTL forward<F>(predicate), count, str.find(delimiter));
+    }
+
+public:
+    template <typename F>
+    __UTL_HIDE_FROM_ABI inline constexpr explicit split_while_impl(
+        view_type delimiter, view_type str, F&& predicate) noexcept
+        : count(split(delimiter, str, __UTL forward<F>(predicate))) {}
+
+    size_t count;
+};
+
+template <typename CharType, typename Traits, typename F>
+__UTL_HIDE_FROM_ABI inline constexpr size_t split_while(
+    basic_string_view<CharType, Traits> delimiter, basic_string_view<CharType, Traits> str,
+    F&& predicate) {
+    return split_while_impl<CharType, Traits>(delimiter, str, __UTL forward<F>(predicate)).count;
+}
+
+template <typename CharType, typename Traits, typename F>
+__UTL_HIDE_FROM_ABI inline constexpr size_t split_while(CharType delimiter,
+    basic_string_view<CharType, Traits> str, F&& predicate, size_t count = 0, size_t idx = 0) {
+    return split_while_impl<CharType, Traits>(delimiter, str, __UTL forward<F>(predicate)).count;
+}
+
+} // namespace compile_time
+
+namespace runtime {
+template <typename CharType, typename Traits, typename F>
+__UTL_HIDE_FROM_ABI inline size_t split_all(basic_string_view<CharType, Traits> delimiter,
+    basic_string_view<CharType, Traits> str, F&& predicate) {
+    size_t count = 0;
+    do {
+        auto idx = str.find(delimiter);
+        predicate(str.substr(0, idx));
+        str = remove_prefix(str, __UTL add_sat(idx, delimiter.size()));
+        ++count;
+    } while (!str.empty());
+
+    return count;
+}
+
+template <typename CharType, typename Traits, typename F>
+__UTL_HIDE_FROM_ABI inline size_t split_while(basic_string_view<CharType, Traits> delimiter,
+    basic_string_view<CharType, Traits> str, F&& predicate) {
+    size_t count = 0;
+    do {
+        auto idx = str.find(delimiter);
+        if (!predicate(str.substr(0, idx))) {
+            return count + 1;
+        }
+
+        str = remove_prefix(str, __UTL add_sat(idx, delimiter.size()));
+        ++count;
+    } while (!str.empty());
+
+    return count;
+}
+
+template <typename CharType, typename Traits, typename F>
+__UTL_HIDE_FROM_ABI inline size_t split_all(
+    CharType delimiter, basic_string_view<CharType, Traits> str, F&& predicate) {
+    size_t count = 0;
+    do {
+        auto idx = str.find(delimiter);
+        predicate(str.substr(0, idx));
+        str = remove_prefix(str, __UTL add_sat(idx, 1));
+        ++count;
+    } while (!str.empty());
+
+    return count;
+}
+
+template <typename CharType, typename Traits, typename F>
+__UTL_HIDE_FROM_ABI inline size_t split_while(
+    CharType delimiter, basic_string_view<CharType, Traits> str, F&& predicate) {
+    size_t count = 0;
+    do {
+        auto idx = str.find(delimiter);
+        if (!predicate(str.substr(0, idx))) {
+            return count + 1;
+        }
+
+        str = remove_prefix(str, __UTL add_sat(idx, 1));
+        ++count;
+    } while (!str.empty());
+
+    return count;
+}
+
+} // namespace runtime
+} // namespace string_utils
+
+template <typename CharType, typename Traits = __UTL char_traits<CharType>,
+    UTL_CONCEPT_CXX20(__UTL invocable<basic_string_view<CharType, Traits>>) F>
+__UTL_HIDE_FROM_ABI inline constexpr auto split(basic_string_view<CharType, Traits> delimiter,
+    basic_string_view<CharType, Traits> str,
+    F process) noexcept(UTL_TRAIT_is_nothrow_invocable(F, basic_string_view<CharType, Traits>))
+    -> UTL_ENABLE_IF_CXX11(size_t, UTL_TRAIT_is_invocable(F, basic_string_view<CharType, Traits>)) {
+    return UTL_CONSTANT_P(str.data() != nullptr && delimiter.data() != nullptr)
+        ? string_utils::compile_time::split_all(delimiter, str, __UTL move(process))
+        : string_utils::runtime::split_all(delimiter, str, __UTL move(process));
+}
+
+template <typename CharType, typename Traits = __UTL char_traits<CharType>,
+    UTL_CONCEPT_CXX20(__UTL invocable<basic_string_view<CharType, Traits>>) F>
+UTL_CONSTRAINT_CXX20(requires(basic_string_view<CharType, Traits> str, F f) {
+    { f(str) } -> __UTL boolean_testable;
+})
+__UTL_HIDE_FROM_ABI inline constexpr auto split_while(basic_string_view<CharType, Traits> delimiter,
+    basic_string_view<CharType, Traits> str,
+    F predicate) noexcept(UTL_TRAIT_is_nothrow_invocable(F, basic_string_view<CharType, Traits>) &&
+    UTL_TRAIT_is_nothrow_boolean_testable(decltype(predicate(str))))
+    -> UTL_ENABLE_IF_CXX11(size_t, UTL_TRAIT_is_boolean_testable(decltype(predicate(str)))) {
+    return UTL_CONSTANT_P(str.data() != nullptr && delimiter.data() != nullptr)
+        ? string_utils::compile_time::split_while(delimiter, str, __UTL move(predicate))
+        : string_utils::runtime::split_while(delimiter, str, __UTL move(predicate));
+}
+
+template <typename CharType, typename Traits = __UTL char_traits<CharType>,
+    UTL_CONCEPT_CXX20(__UTL invocable<basic_string_view<CharType, Traits>>) F>
+__UTL_HIDE_FROM_ABI inline constexpr auto split(CharType delimiter,
+    basic_string_view<CharType, Traits> str,
+    F process) noexcept(UTL_TRAIT_is_nothrow_invocable(F, basic_string_view<CharType, Traits>))
+    -> UTL_ENABLE_IF_CXX11(size_t, UTL_TRAIT_is_invocable(F, basic_string_view<CharType, Traits>)) {
+    return UTL_CONSTANT_P(str.data() != nullptr) && UTL_CONSTANT_P(delimiter)
+        ? string_utils::compile_time::split_all(delimiter, str, __UTL move(process))
+        : string_utils::runtime::split_all(delimiter, str, __UTL move(process));
+}
+
+template <typename CharType, typename Traits = __UTL char_traits<CharType>,
+    UTL_CONCEPT_CXX20(__UTL invocable<basic_string_view<CharType, Traits>>) F>
+UTL_CONSTRAINT_CXX20(requires(basic_string_view<CharType, Traits> str, F f) {
+    { f(str) } -> __UTL boolean_testable;
+})
+__UTL_HIDE_FROM_ABI inline constexpr auto split_while(CharType delimiter,
+    basic_string_view<CharType, Traits> str,
+    F predicate) noexcept(UTL_TRAIT_is_nothrow_invocable(F, basic_string_view<CharType, Traits>) &&
+    UTL_TRAIT_is_nothrow_boolean_testable(decltype(predicate(str))))
+    -> UTL_ENABLE_IF_CXX11(size_t, UTL_TRAIT_is_boolean_testable(decltype(predicate(str)))) {
+    return UTL_CONSTANT_P(str.data() != nullptr) && UTL_CONSTANT_P(delimiter)
+        ? string_utils::compile_time::split_while(delimiter, str, __UTL move(predicate))
+        : string_utils::runtime::split_while(delimiter, str, __UTL move(predicate));
+}
+
+template <typename CharType, CharType... Vs>
+struct literal_sequence {
+    static constexpr CharType value[]{Vs..., (CharType)0};
+    static constexpr size_t size = sizeof...(Vs);
+};
+
+template <typename CharType, CharType... Vs>
+constexpr CharType literal_sequence<CharType, Vs...>::value[sizeof...(Vs)];
+
+template <typename CharType, typename Traits = __UTL char_traits<CharType>>
+__UTL_HIDE_FROM_ABI inline constexpr basic_string_view<CharType, Traits> rstrip(
+    basic_string_view<CharType, Traits> str) noexcept {
+    using whitespace = literal_sequence<CharType, (CharType)'\t', (CharType)'\n', (CharType)'\v',
+        (CharType)'\f', (CharType)'\r', (CharType)' '>;
+    using view_type = basic_string_view<CharType, Traits>;
+    return remove_suffix(
+        str, str.size() - str.find_last_not_of(view_type(whitespace::value, whitespace::size)) - 1);
+}
+
+template <typename CharType, typename Traits = __UTL char_traits<CharType>>
+__UTL_HIDE_FROM_ABI inline constexpr basic_string_view<CharType, Traits> lstrip(
+    basic_string_view<CharType, Traits> str) noexcept {
+    using whitespace = literal_sequence<CharType, (CharType)'\t', (CharType)'\n', (CharType)'\v',
+        (CharType)'\f', (CharType)'\r', (CharType)' '>;
+    using view_type = basic_string_view<CharType, Traits>;
+    return remove_prefix(
+        str, str.find_first_not_of(view_type(whitespace::value, whitespace::size)));
+}
+
+template <typename CharType, typename Traits = __UTL char_traits<CharType>>
+__UTL_HIDE_FROM_ABI inline constexpr basic_string_view<CharType, Traits> strip(
+    basic_string_view<CharType, Traits> str) noexcept {
+    return rstrip(lstrip(str));
+}
+
+UTL_NAMESPACE_END


### PR DESCRIPTION
* Adding a couple of useful pure string-processing utility functions, `strip` & `split` 
  * `split` works using the visitor pattern to process each token delimited by the delimiter argument
  * `split_while` is provided for early returning splits
  * `strip`, `rstrip`, `lstrip` provided 
  * There will probably be more but for now only these are defined
* Add `inline` keyword every where in the string library as members are no longer implicitly declared `inline` when compiling modules
* Simplify `UTL_CONTANT_P`
